### PR TITLE
Separate draw and manage screens with image preview

### DIFF
--- a/app/src/main/java/com/example/quotepicker/vm/MainViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/MainViewModel.kt
@@ -33,14 +33,15 @@ class MainViewModel(app: Application): AndroidViewModel(app) {
     val uiState: StateFlow<UiState> = combine(
         repo.observeGroups(),
         _currentGroupId,
-        repo.observeQuotes(null)
-    ) { groups, gid, allQuotes ->
+        repo.observeQuotes(null),
+        _randomResult
+    ) { groups, gid, allQuotes, random ->
         val quotes = if (gid == null) allQuotes else allQuotes.filter { it.groupId == gid }
         UiState(
             groups = groups,
             currentGroupId = gid,
             quotes = quotes,
-            randomResult = _randomResult.value
+            randomResult = random
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, UiState())
 


### PR DESCRIPTION
## Summary
- split draw and data management into separate navigation tabs
- default image quotes to text with optional preview toggle

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68959783ef10832b97700e887b911bd5