### PR TITLE
Improve group selection UI and image captions

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -18,8 +18,16 @@ class Repository private constructor(context: Context) {
     suspend fun addTextQuote(groupId: Long, text: String, weight: Int) =
         quoteDao.insert(QuoteEntity(groupId = groupId, type = QuoteType.TEXT, text = text, weight = weight))
 
-    suspend fun addImageQuote(groupId: Long, base64: String, weight: Int) =
-        quoteDao.insert(QuoteEntity(groupId = groupId, type = QuoteType.IMAGE, imageBase64 = base64, weight = weight))
+    suspend fun addImageQuote(groupId: Long, base64: String, text: String, weight: Int) =
+        quoteDao.insert(
+            QuoteEntity(
+                groupId = groupId,
+                type = QuoteType.IMAGE,
+                imageBase64 = base64,
+                text = text,
+                weight = weight
+            )
+        )
 
     suspend fun updateQuote(q: QuoteEntity) = quoteDao.update(q)
     suspend fun deleteQuote(q: QuoteEntity) = quoteDao.delete(q)

--- a/app/src/main/java/com/example/quotepicker/ui/components/AddQuoteDialog.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/AddQuoteDialog.kt
@@ -19,7 +19,7 @@ fun AddQuoteDialog(
     groups: List<GroupEntity>,
     onDismiss: () -> Unit,
     onAddText: (groupId: Long, text: String, weight: Int) -> Unit,
-    onAddImage: (groupId: Long, base64: String, weight: Int) -> Unit,
+    onAddImage: (groupId: Long, base64: String, text: String, weight: Int) -> Unit,
     vm: MainViewModel
 ) {
     var isImage by remember { mutableStateOf(false) }
@@ -31,7 +31,7 @@ fun AddQuoteDialog(
         if (uri != null && groupId > 0) {
             val b64 = vm.encodeImageToBase64(uri)
             val w = weightStr.toIntOrNull() ?: 1
-            onAddImage(groupId, b64, w.coerceAtLeast(1))
+            onAddImage(groupId, b64, text.trim(), w.coerceAtLeast(1))
             onDismiss()
         }
     }
@@ -81,6 +81,13 @@ fun AddQuoteDialog(
                         label = { Text("文本内容") },
                         modifier = Modifier.fillMaxWidth()
                     )
+                } else {
+                    OutlinedTextField(
+                        value = text,
+                        onValueChange = { text = it },
+                        label = { Text("图片名称") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
                 }
             }
         },
@@ -95,7 +102,7 @@ fun AddQuoteDialog(
                     Text("确定")
                 }
             } else {
-                Button(onClick = { launcher.launch("image/*") }, enabled = groups.isNotEmpty()) {
+                Button(onClick = { launcher.launch("image/*") }, enabled = groups.isNotEmpty() && text.isNotBlank()) {
                     Text("导入图片")
                 }
             }

--- a/app/src/main/java/com/example/quotepicker/vm/MainViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/MainViewModel.kt
@@ -52,8 +52,8 @@ class MainViewModel(app: Application): AndroidViewModel(app) {
     fun addTextQuote(groupId: Long, text: String, weight: Int) = viewModelScope.launch {
         repo.addTextQuote(groupId, text, weight)
     }
-    fun addImageQuote(groupId: Long, base64: String, weight: Int) = viewModelScope.launch {
-        repo.addImageQuote(groupId, base64, weight)
+    fun addImageQuote(groupId: Long, base64: String, text: String, weight: Int) = viewModelScope.launch {
+        repo.addImageQuote(groupId, base64, text, weight)
     }
     fun deleteQuote(q: QuoteEntity) = viewModelScope.launch { repo.deleteQuote(q) }
     fun updateQuote(q: QuoteEntity) = viewModelScope.launch { repo.updateQuote(q) }


### PR DESCRIPTION
## Summary
- Replace horizontal tabs with wrapping group chips
- Allow naming image quotes and show captions when drawing or listing

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_6895a019f484832b927c4b8d9c7a39ac