### PR TITLE
Handle invalid base64 images gracefully

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
@@ -159,8 +159,10 @@ fun MainScreen(vm: MainViewModel = viewModel()) {
                         if (!q.text.isNullOrBlank()) {
                             Text(q.text)
                         }
-                        val bmp: Bitmap = vm.decodeBase64ToBitmap(q.imageBase64 ?: "")
-                        Image(bitmap = bmp.asImageBitmap(), contentDescription = null, modifier = Modifier.fillMaxWidth())
+                        val bmp = vm.decodeBase64ToBitmap(q.imageBase64 ?: "")
+                        bmp?.let {
+                            Image(bitmap = it.asImageBitmap(), contentDescription = null, modifier = Modifier.fillMaxWidth())
+                        }
                     }
                 }
             }
@@ -208,7 +210,7 @@ private fun GroupTabs(
 @Composable
 private fun QuoteList(
     quotes: List<QuoteEntity>,
-    decodeImage: (String)->android.graphics.Bitmap,
+    decodeImage: (String) -> Bitmap?,
     onDelete: (QuoteEntity)->Unit,
     onUpdate: (QuoteEntity)->Unit
 ) {
@@ -232,7 +234,9 @@ private fun QuoteList(
                             Text(q.text.orEmpty(), style = MaterialTheme.typography.titleMedium)
                             if (preview) {
                                 val bmp = remember(q.imageBase64) { decodeImage(q.imageBase64.orEmpty()) }
-                                Image(bitmap = bmp.asImageBitmap(), contentDescription = null, modifier = Modifier.fillMaxWidth())
+                                bmp?.let {
+                                    Image(bitmap = it.asImageBitmap(), contentDescription = null, modifier = Modifier.fillMaxWidth())
+                                }
                             }
                         }
                         Row(

--- a/app/src/main/java/com/example/quotepicker/vm/MainViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/MainViewModel.kt
@@ -96,8 +96,10 @@ class MainViewModel(app: Application): AndroidViewModel(app) {
         }
     }
 
-    fun decodeBase64ToBitmap(b64: String): Bitmap {
-        val bytes = Base64.decode(b64, Base64.DEFAULT)
-        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    fun decodeBase64ToBitmap(b64: String): Bitmap? {
+        return runCatching {
+            val bytes = Base64.decode(b64, Base64.DEFAULT)
+            BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+        }.getOrNull()
     }
 }


### PR DESCRIPTION
## Summary
- Safely decode base64 images, returning `null` on failure
- Guard image rendering against `null` bitmaps in QuoteList and result dialog

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6895a96ae780832ba50c028ae7007194