### PR TITLE
Fix Compose state delegate imports

### DIFF
--- a/app/src/main/java/com/example/quotepicker/MainActivity.kt
+++ b/app/src/main/java/com/example/quotepicker/MainActivity.kt
@@ -6,6 +6,10 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import com.example.quotepicker.ui.GateScreen
 import com.example.quotepicker.ui.MainScreen
 
@@ -15,7 +19,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             Surface(color = MaterialTheme.colorScheme.background) {
-                var passed by androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }
+                var passed by remember { mutableStateOf(false) }
                 if (passed) {
                     MainScreen()
                 } else {


### PR DESCRIPTION
### Motivation
- Resolve the Compose state delegation error by importing the runtime delegate helpers so the `by` delegate can find `getValue`/`setValue`.

### Description
- Add `getValue`, `setValue`, `remember`, and `mutableStateOf` imports and simplify the state declaration from `androidx.compose.runtime.remember { androidx.compose.runtime.mutableStateOf(false) }` to `remember { mutableStateOf(false) }` in `MainActivity.kt`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969971ecb0c832b94afe4b536eb902b)