### PR TITLE
Fix missing Compose imports in TagScreen

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -35,6 +37,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.foundation.background
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel


### PR DESCRIPTION
### Motivation
- Resolve unresolved reference errors for `width`, `size`, and `background` used in the `TagScreen` composable by adding the corresponding Compose layout imports. 

### Description
- Added `import androidx.compose.foundation.layout.size`, `import androidx.compose.foundation.layout.width`, and `import androidx.compose.foundation.background` to `app/src/main/java/com/example/quotepicker/ui/TagScreen.kt` to provide the missing modifiers. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696999607160832b8548322556c93dbf)