### PR TITLE
Opt in to Experimental Foundation API for combinedClickable usages

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -48,6 +48,7 @@ import com.example.quotepicker.ui.components.NameDialog
 import com.example.quotepicker.vm.TagViewModel
 import androidx.compose.runtime.collectAsState
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -222,6 +223,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun TagDialog(
     title: String,

--- a/app/src/main/java/com/example/quotepicker/ui/components/AvatarListItem.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/AvatarListItem.kt
@@ -1,5 +1,6 @@
 package com.example.quotepicker.ui.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
@@ -19,6 +20,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AvatarListItem(
     title: String,


### PR DESCRIPTION
### Motivation
- Allow usage of the experimental `combinedClickable` API without compiler opt-in errors by annotating the affected composables.

### Description
- Add `import androidx.compose.foundation.ExperimentalFoundationApi` and annotate `TagDialog` in `app/src/main/java/com/example/quotepicker/ui/TagScreen.kt` and annotate `AvatarListItem` in `app/src/main/java/com/example/quotepicker/ui/components/AvatarListItem.kt` with `@OptIn(ExperimentalFoundationApi::class)` so `combinedClickable` can be used safely.

### Testing
- No automated tests or build were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69699a1b6dcc832bb6a097a5c1054d4f)