### PR TITLE
Fix FlowRow spacing parameters and opt-in ExperimentalFoundationApi

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -371,8 +371,8 @@ private fun TagSelectionSection(
             if (items.isNotEmpty()) {
                 Text(category.name, style = MaterialTheme.typography.labelMedium)
                 FlowRow(
-                    mainAxisSpacing = 8.dp,
-                    crossAxisSpacing = 8.dp
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     items.forEach { tag ->
                         val isSelected = selected.contains(tag.id)
@@ -400,8 +400,8 @@ private fun TagSelectionSection(
         if (uncategorized.isNotEmpty()) {
             Text("其他", style = MaterialTheme.typography.labelMedium)
             FlowRow(
-                mainAxisSpacing = 8.dp,
-                crossAxisSpacing = 8.dp
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
                 uncategorized.forEach { tag ->
                     val isSelected = selected.contains(tag.id)

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -600,8 +601,8 @@ private fun FilterCharacterDialog(
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 Text("角色")
                 FlowRow(
-                    mainAxisSpacing = 8.dp,
-                    crossAxisSpacing = 8.dp
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     FilterChip(
                         selected = current == null,
@@ -740,6 +741,7 @@ private fun ResourceEditDialog(
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ResourceGridItem(
     title: String,
@@ -786,8 +788,8 @@ private fun TagSelectionSection(
             if (items.isNotEmpty()) {
                 Text(category.name, style = MaterialTheme.typography.labelMedium)
                 FlowRow(
-                    mainAxisSpacing = 8.dp,
-                    crossAxisSpacing = 8.dp
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
                 ) {
                     items.forEach { tag ->
                         TagFilterChip(
@@ -801,10 +803,10 @@ private fun TagSelectionSection(
         }
         if (uncategorized.isNotEmpty()) {
             Text("其他", style = MaterialTheme.typography.labelMedium)
-            FlowRow(
-                mainAxisSpacing = 8.dp,
-                crossAxisSpacing = 8.dp
-            ) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
                 uncategorized.forEach { tag ->
                     TagFilterChip(
                         tag = tag,
@@ -854,8 +856,8 @@ private fun CharacterSelectionSection(
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(label)
         FlowRow(
-            mainAxisSpacing = 8.dp,
-            crossAxisSpacing = 8.dp
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
             characters.forEach { character ->
                 val isSelected = selected.contains(character.id)


### PR DESCRIPTION
### Motivation
- Update usages of `FlowRow` spacing to the current Compose API and remove deprecated parameters to fix layout/compile issues in tag and character selection UIs.\
- Ensure `combinedClickable` usage in the resource grid is annotated with the appropriate experimental opt-in to avoid compiler warnings.\

### Description
- Replaced `mainAxisSpacing`/`crossAxisSpacing` with `horizontalArrangement = Arrangement.spacedBy(...)` and `verticalArrangement = Arrangement.spacedBy(...)` in `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt`.\
- Applied the same `FlowRow` spacing changes in `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`.\
- Added `import androidx.compose.foundation.ExperimentalFoundationApi` and annotated the `ResourceGridItem` composable with `@OptIn(ExperimentalFoundationApi::class)` to cover `combinedClickable` usage.\

### Testing
- No automated tests were run for this change.\
- No runtime or compile verification was performed as part of this patch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969c215e934832bbeb931dcb75f1b91)