### PR TITLE
Revamp grids and gate visuals; rename app to 特效TEST

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -1,5 +1,6 @@
 package com.example.quotepicker.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,15 +13,14 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.ExpandLess
-import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -53,8 +53,8 @@ import com.example.quotepicker.data.CharacterWithTags
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
-import com.example.quotepicker.ui.components.AvatarListItem
 import com.example.quotepicker.ui.components.NameDialog
+import com.example.quotepicker.ui.components.SquareGridItem
 import com.example.quotepicker.vm.CharacterViewModel
 import com.example.quotepicker.vm.ResourceViewModel
 
@@ -73,11 +73,9 @@ fun CharacterScreen(
     var showTagPicker by remember { mutableStateOf(false) }
     var bottomSheetTarget by remember { mutableStateOf<CharacterWithTags?>(null) }
     var deleteTarget by remember { mutableStateOf<CharacterEntity?>(null) }
-    var showImages by remember { mutableStateOf(true) }
-    var showVideos by remember { mutableStateOf(true) }
-    var showAudios by remember { mutableStateOf(true) }
-    var showQuotes by remember { mutableStateOf(true) }
-    var showScenes by remember { mutableStateOf(true) }
+    var filterTagDialog by remember { mutableStateOf(false) }
+    var selectedTagIds by remember { mutableStateOf(setOf<Long>()) }
+    var selectedType by remember { mutableStateOf<ResourceType?>(null) }
 
     Scaffold(
         modifier = modifier,
@@ -108,12 +106,14 @@ fun CharacterScreen(
                         Text("暂无角色，点击右下角添加")
                     }
                 } else {
-                    LazyColumn(
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(96.dp),
                         contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         items(ui.characters, key = { it.character.id }) { character ->
-                            AvatarListItem(
+                            SquareGridItem(
                                 title = character.character.name,
                                 onClick = { selected = character },
                                 onLongClick = { bottomSheetTarget = character }
@@ -123,54 +123,48 @@ fun CharacterScreen(
                 }
             } else {
                 val char = selected!!.character
-                OutlinedTextField(
-                    value = char.description.orEmpty(),
-                    onValueChange = { vm.updateCharacter(char.copy(description = it)) },
-                    label = { Text("简介") },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(12.dp)
+                TagSummarySection(
+                    categories = ui.categories,
+                    tags = selected!!.tags,
+                    onEdit = { showTagPicker = true }
                 )
-                Row(Modifier.padding(horizontal = 12.dp), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    selected!!.tags.forEach { tag ->
-                        AssistChip(onClick = {}, label = { Text(tag.name) })
-                    }
-                    TextButton(onClick = { showTagPicker = true }) { Text("编辑标签") }
-                }
                 Spacer(Modifier.height(12.dp))
-                val grouped = resources.resources.filter {
+                CharacterResourceFilterBar(
+                    selectedType = selectedType,
+                    selectedTagIds = selectedTagIds,
+                    onTypeChange = { selectedType = it },
+                    onTagDialog = { filterTagDialog = true }
+                )
+                val filteredResources = resources.resources.filter {
                     it.characters.any { c -> c.id == char.id }
-                }.groupBy { it.resource.type }
-                ResourceGroup(
-                    title = "图片",
-                    items = grouped[ResourceType.IMAGE].orEmpty(),
-                    expanded = showImages,
-                    onToggle = { showImages = !showImages }
-                )
-                ResourceGroup(
-                    title = "视频",
-                    items = grouped[ResourceType.VIDEO].orEmpty(),
-                    expanded = showVideos,
-                    onToggle = { showVideos = !showVideos }
-                )
-                ResourceGroup(
-                    title = "声音",
-                    items = grouped[ResourceType.AUDIO].orEmpty(),
-                    expanded = showAudios,
-                    onToggle = { showAudios = !showAudios }
-                )
-                ResourceGroup(
-                    title = "语录",
-                    items = grouped[ResourceType.QUOTE].orEmpty(),
-                    expanded = showQuotes,
-                    onToggle = { showQuotes = !showQuotes }
-                )
-                ResourceGroup(
-                    title = "情景",
-                    items = grouped[ResourceType.SCENE].orEmpty(),
-                    expanded = showScenes,
-                    onToggle = { showScenes = !showScenes }
-                )
+                }.filter { res ->
+                    val typeMatch = selectedType?.let { it == res.resource.type } ?: true
+                    val tagMatch = if (selectedTagIds.isEmpty()) true else res.tags.any { selectedTagIds.contains(it.id) }
+                    typeMatch && tagMatch
+                }
+                if (filteredResources.isEmpty()) {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("暂无资源")
+                    }
+                } else {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(110.dp),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        items(filteredResources, key = { it.resource.id }) { resource ->
+                            val tagLabel = resource.tags.joinToString("、") { it.name }.ifBlank { "无标签" }
+                            val subtitle = "${typeLabel(resource.resource.type)}\n标签：$tagLabel"
+                            SquareGridItem(
+                                title = resource.resource.title,
+                                subtitle = subtitle,
+                                onClick = {},
+                                onLongClick = {}
+                            )
+                        }
+                    }
+                }
             }
         }
     }
@@ -202,6 +196,15 @@ fun CharacterScreen(
                 showTagPicker = false
             },
             onDismiss = { showTagPicker = false }
+        )
+    }
+    if (filterTagDialog) {
+        TagFilterDialog(
+            categories = ui.categories,
+            tags = ui.tags,
+            selectedIds = selectedTagIds,
+            onConfirm = { selectedTagIds = it },
+            onDismiss = { filterTagDialog = false }
         )
     }
 
@@ -250,51 +253,12 @@ fun CharacterScreen(
 }
 
 @Composable
-private fun ResourceGroup(
-    title: String,
-    items: List<com.example.quotepicker.data.ResourceWithTagsCharacters>,
-    expanded: Boolean,
-    onToggle: () -> Unit
-) {
-    Column(Modifier.padding(horizontal = 12.dp, vertical = 8.dp)) {
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(title, modifier = Modifier.weight(1f))
-            IconButton(onClick = onToggle) {
-                Icon(
-                    imageVector = if (expanded) Icons.Default.ExpandLess else Icons.Default.ExpandMore,
-                    contentDescription = null
-                )
-            }
-        }
-        if (expanded) {
-            if (items.isEmpty()) {
-                Text("暂无${title}资源")
-            } else {
-                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    items.forEach { resource ->
-                        AvatarListItem(
-                            title = resource.resource.title,
-                            onClick = {},
-                            onLongClick = {}
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
 private fun CharacterEditDialog(
     character: CharacterEntity,
     onConfirm: (CharacterEntity) -> Unit,
     onDismiss: () -> Unit
 ) {
     var name by remember { mutableStateOf(character.name) }
-    var description by remember { mutableStateOf(character.description.orEmpty()) }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("编辑角色") },
@@ -306,22 +270,138 @@ private fun CharacterEditDialog(
                     label = { Text("角色名") },
                     modifier = Modifier.fillMaxWidth()
                 )
-                OutlinedTextField(
-                    value = description,
-                    onValueChange = { description = it },
-                    label = { Text("简介") },
-                    modifier = Modifier.fillMaxWidth()
-                )
             }
         },
         confirmButton = {
             TextButton(onClick = {
-                if (name.isNotBlank()) onConfirm(character.copy(name = name.trim(), description = description))
+                if (name.isNotBlank()) onConfirm(character.copy(name = name.trim()))
                 onDismiss()
             }) { Text("确定") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun TagSummarySection(
+    categories: List<TagCategoryEntity>,
+    tags: List<TagEntity>,
+    onEdit: () -> Unit
+) {
+    val grouped = tags.groupBy { it.categoryId }
+    val categoryMap = categories.associateBy { it.id }
+    Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp)) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text("标签", style = MaterialTheme.typography.titleMedium)
+            TextButton(onClick = onEdit) { Text("编辑标签") }
+        }
+        categories.forEach { category ->
+            val items = grouped[category.id].orEmpty()
+            if (items.isNotEmpty()) {
+                Text(category.name, style = MaterialTheme.typography.labelMedium)
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items.forEach { tag ->
+                        TagBadge(tag = tag)
+                    }
+                }
+                Spacer(Modifier.height(8.dp))
+            }
+        }
+        val uncategorized = tags.filter { it.categoryId !in categoryMap.keys }
+        if (uncategorized.isNotEmpty()) {
+            Text("其他", style = MaterialTheme.typography.labelMedium)
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                uncategorized.forEach { tag ->
+                    TagBadge(tag = tag)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagBadge(tag: TagEntity) {
+    val bg = Color(tag.colorArgb)
+    val textColor = if (bg.luminance() < 0.5f) Color.White else Color.Black
+    Box(
+        modifier = Modifier
+            .background(bg, shape = MaterialTheme.shapes.small)
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Text(text = tag.name, color = textColor, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+@Composable
+private fun CharacterResourceFilterBar(
+    selectedType: ResourceType?,
+    selectedTagIds: Set<Long>,
+    onTypeChange: (ResourceType?) -> Unit,
+    onTagDialog: () -> Unit
+) {
+    Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp)) {
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            ResourceType.values().forEach { type ->
+                FilterChip(
+                    selected = selectedType == type,
+                    onClick = { onTypeChange(if (selectedType == type) null else type) },
+                    label = { Text(typeLabel(type)) }
+                )
+            }
+        }
+        Spacer(Modifier.height(8.dp))
+        AssistChip(onClick = onTagDialog, label = { Text("标签筛选(${selectedTagIds.size})") })
+    }
+}
+
+@Composable
+private fun TagFilterDialog(
+    categories: List<TagCategoryEntity>,
+    tags: List<TagEntity>,
+    selectedIds: Set<Long>,
+    onConfirm: (Set<Long>) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var selected by remember { mutableStateOf(selectedIds) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("筛选标签") },
+        text = {
+            TagSelectionSection(
+                label = "标签",
+                categories = categories,
+                tags = tags,
+                selected = selected,
+                onChange = { selected = it }
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onConfirm(selected)
+                onDismiss()
+            }) { Text("确定") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
+}
+
+private fun typeLabel(type: ResourceType): String = when (type) {
+    ResourceType.IMAGE -> "图片"
+    ResourceType.VIDEO -> "视频"
+    ResourceType.AUDIO -> "声音"
+    ResourceType.QUOTE -> "文本"
+    ResourceType.SCENE -> "情景"
 }
 
 @Composable

--- a/app/src/main/java/com/example/quotepicker/ui/GateScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/GateScreen.kt
@@ -20,6 +20,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.roundToInt
@@ -47,6 +52,19 @@ fun GateScreen(onPassed: () -> Unit) {
     var touchPosition by remember { mutableStateOf<Offset?>(null) }
     val opacity = remember { Animatable(0f) }
     val scope = rememberCoroutineScope()
+    val infiniteTransition = rememberInfiniteTransition(label = "magicCircle")
+    val rotation by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(6000),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "magicCircleRotation"
+    )
+    val density = LocalDensity.current
+    val circleSize = 156.dp
+    val circleSizePx = with(density) { circleSize.toPx() }
 
     // 解锁目标顺序：右上3次 → 左上1次 → 左下2次
     val targets = listOf(
@@ -124,10 +142,21 @@ fun GateScreen(onPassed: () -> Unit) {
             painter = painterResource(id = com.example.quotepicker.R.drawable.magic_circle),
             contentDescription = null,
             modifier = Modifier
-                .offset { IntOffset(pos.x.roundToInt() - 72, pos.y.roundToInt() - 96) }
-                .size(144.dp)
+                .offset {
+                    IntOffset(
+                        (pos.x - circleSizePx / 2f).roundToInt(),
+                        (pos.y - circleSizePx / 2f).roundToInt()
+                    )
+                }
+                .size(circleSize)
                 .background(Color.Transparent)
-                .graphicsLayer(alpha = opacity.value)
+                .graphicsLayer(
+                    alpha = opacity.value,
+                    rotationZ = rotation,
+                    shadowElevation = with(density) { 12.dp.toPx() },
+                    scaleX = 1.05f,
+                    scaleY = 1.05f
+                )
         )
     }
 }

--- a/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
@@ -1,11 +1,5 @@
 package com.example.quotepicker.ui
 
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Face
-import androidx.compose.material.icons.filled.LocalOffer
-import androidx.compose.material.icons.filled.Shuffle
-import androidx.compose.material.icons.filled.Storage
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
@@ -19,6 +13,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun MainScreen() {
@@ -30,25 +27,25 @@ fun MainScreen() {
                 NavigationBarItem(
                     selected = currentTab == 0,
                     onClick = { currentTab = 0 },
-                    icon = { Icon(Icons.Default.LocalOffer, contentDescription = null) },
+                    icon = { Spacer(Modifier.size(0.dp)) },
                     label = { Text("标签") }
                 )
                 NavigationBarItem(
                     selected = currentTab == 1,
                     onClick = { currentTab = 1 },
-                    icon = { Icon(Icons.Default.Face, contentDescription = null) },
+                    icon = { Spacer(Modifier.size(0.dp)) },
                     label = { Text("角色") }
                 )
                 NavigationBarItem(
                     selected = currentTab == 2,
                     onClick = { currentTab = 2 },
-                    icon = { Icon(Icons.Default.Storage, contentDescription = null) },
+                    icon = { Spacer(Modifier.size(0.dp)) },
                     label = { Text("资源") }
                 )
                 NavigationBarItem(
                     selected = currentTab == 3,
                     onClick = { currentTab = 3 },
-                    icon = { Icon(Icons.Default.Shuffle, contentDescription = null) },
+                    icon = { Spacer(Modifier.size(0.dp)) },
                     label = { Text("随机") }
                 )
             }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -38,7 +37,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -55,13 +53,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.luminance
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
+import com.example.quotepicker.ui.components.SquareGridItem
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -130,7 +128,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                 ) {
                     items(ui.resources, key = { it.resource.id }) { res ->
                         ResourceGridItem(
-                            title = res.resource.title,
+                            resource = res,
                             onClick = { previewTarget = res },
                             onLongClick = { bottomSheetTarget = res }
                         )
@@ -143,8 +141,8 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     if (showAddMenu) {
         ModalBottomSheet(onDismissRequest = { showAddMenu = false }) {
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                TextButton(onClick = { showTextDialog = true; showAddMenu = false }) { Text("创建文本语录") }
-                TextButton(onClick = { showImageQuoteDialog = true; showAddMenu = false }) { Text("创建图片语录") }
+                TextButton(onClick = { showTextDialog = true; showAddMenu = false }) { Text("创建文本") }
+                TextButton(onClick = { showImageQuoteDialog = true; showAddMenu = false }) { Text("创建图片文本") }
                 TextButton(onClick = { showSceneDialog = true; showAddMenu = false }) { Text("创建聊天情景") }
                 TextButton(onClick = {
                     pickedMediaType = ResourceType.IMAGE
@@ -167,7 +165,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
 
     if (showTextDialog) {
         QuoteDialog(
-            title = "创建文本语录",
+            title = "创建文本",
             onConfirm = { title, text, tagIds, characterIds ->
                 vm.addTextQuote(title, text, tagIds, characterIds)
                 showTextDialog = false
@@ -341,7 +339,7 @@ private fun typeLabel(type: ResourceType): String = when (type) {
     ResourceType.IMAGE -> "图片"
     ResourceType.VIDEO -> "视频"
     ResourceType.AUDIO -> "声音"
-    ResourceType.QUOTE -> "语录"
+    ResourceType.QUOTE -> "文本"
     ResourceType.SCENE -> "情景"
 }
 
@@ -424,7 +422,7 @@ private fun ImageQuoteDialog(
     }
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("创建图片语录") },
+        title = { Text("创建图片文本") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("标题") })
@@ -744,29 +742,18 @@ private fun ResourceEditDialog(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ResourceGridItem(
-    title: String,
+    resource: ResourceWithTagsCharacters,
     onClick: () -> Unit,
     onLongClick: () -> Unit
 ) {
-    OutlinedCard(
-        modifier = Modifier
-            .aspectRatio(1f)
-            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
-    ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(8.dp),
-            contentAlignment = Alignment.Center
-        ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodySmall,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis
-            )
-        }
-    }
+    val tagLabel = resource.tags.joinToString("、") { it.name }.ifBlank { "无标签" }
+    val subtitle = "${typeLabel(resource.resource.type)}\n标签：$tagLabel"
+    SquareGridItem(
+        title = resource.resource.title,
+        subtitle = subtitle,
+        onClick = onClick,
+        onLongClick = onLongClick
+    )
 }
 
 @OptIn(ExperimentalLayoutApi::class)

--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -11,8 +11,9 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
@@ -44,8 +45,8 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
-import com.example.quotepicker.ui.components.AvatarListItem
 import com.example.quotepicker.ui.components.NameDialog
+import com.example.quotepicker.ui.components.SquareGridItem
 import com.example.quotepicker.vm.TagViewModel
 import androidx.compose.runtime.collectAsState
 import androidx.compose.foundation.combinedClickable
@@ -62,8 +63,12 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     var bottomSheetTarget by remember { mutableStateOf<Any?>(null) }
     var deleteCategory by remember { mutableStateOf<TagCategoryEntity?>(null) }
     var deleteTag by remember { mutableStateOf<TagEntity?>(null) }
+    var sortByName by remember { mutableStateOf(true) }
 
     val isInCategory = ui.currentCategory != null
+    val categoryTagCounts = remember(ui.allTags) {
+        ui.allTags.groupingBy { it.categoryId }.eachCount()
+    }
 
     Scaffold(
         modifier = modifier,
@@ -75,6 +80,11 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                         IconButton(onClick = { vm.selectCategory(null) }) {
                             Icon(Icons.Default.ArrowBack, contentDescription = "返回")
                         }
+                    }
+                },
+                actions = {
+                    TextButton(onClick = { sortByName = !sortByName }) {
+                        Text(if (sortByName) "按名称排序✓" else "按名称排序")
                     }
                 }
             )
@@ -94,13 +104,22 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                         Text("暂无标签类别，点击右下角添加")
                     }
                 } else {
-                    LazyColumn(
+                    val categories = if (sortByName) {
+                        ui.categories.sortedBy { it.name.lowercase() }
+                    } else {
+                        ui.categories
+                    }
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(96.dp),
                         contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        items(ui.categories, key = { it.id }) { category ->
-                            AvatarListItem(
+                        items(categories, key = { it.id }) { category ->
+                            val count = categoryTagCounts[category.id] ?: 0
+                            SquareGridItem(
                                 title = category.name,
+                                subtitle = "标签 $count",
                                 onClick = { vm.selectCategory(category.id) },
                                 onLongClick = { bottomSheetTarget = category }
                             )
@@ -113,15 +132,24 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                         Text("暂无标签，点击右下角添加")
                     }
                 } else {
-                    LazyColumn(
+                    val tags = if (sortByName) {
+                        ui.tags.sortedBy { it.name.lowercase() }
+                    } else {
+                        ui.tags
+                    }
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(96.dp),
                         contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        items(ui.tags, key = { it.id }) { tag ->
-                            AvatarListItem(
+                        items(tags, key = { it.id }) { tag ->
+                            val bg = Color(tag.colorArgb)
+                            val textColor = if (bg.luminance() < 0.5f) Color.White else Color.Black
+                            SquareGridItem(
                                 title = tag.name,
-                                avatarColor = Color(tag.colorArgb),
-                                avatarTextColor = if (Color(tag.colorArgb).luminance() < 0.5f) Color.White else Color.Black,
+                                backgroundColor = bg,
+                                contentColor = textColor,
                                 onClick = {},
                                 onLongClick = { bottomSheetTarget = tag }
                             )

--- a/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
@@ -1,0 +1,69 @@
+package com.example.quotepicker.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun SquareGridItem(
+    title: String,
+    subtitle: String? = null,
+    modifier: Modifier = Modifier,
+    backgroundColor: Color = MaterialTheme.colorScheme.surface,
+    contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
+) {
+    OutlinedCard(
+        modifier = modifier
+            .aspectRatio(1f)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
+        ,
+        colors = CardDefaults.outlinedCardColors(containerColor = backgroundColor)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(10.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = contentColor,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                subtitle?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.labelSmall,
+                        color = contentColor.copy(alpha = 0.8f),
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/quotepicker/vm/TagViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/TagViewModel.kt
@@ -17,7 +17,8 @@ import kotlinx.coroutines.launch
 data class TagUiState(
     val categories: List<TagCategoryEntity> = emptyList(),
     val currentCategory: TagCategoryEntity? = null,
-    val tags: List<TagEntity> = emptyList()
+    val tags: List<TagEntity> = emptyList(),
+    val allTags: List<TagEntity> = emptyList()
 )
 
 class TagViewModel(app: Application) : AndroidViewModel(app) {
@@ -35,10 +36,11 @@ class TagViewModel(app: Application) : AndroidViewModel(app) {
     val uiState: StateFlow<TagUiState> = combine(
         repo.observeCategories(),
         selectedCategoryId,
-        tagsFlow
-    ) { categories, selectedId, tags ->
+        tagsFlow,
+        repo.observeAllTags()
+    ) { categories, selectedId, tags, allTags ->
         val current = categories.firstOrNull { it.id == selectedId }
-        TagUiState(categories = categories, currentCategory = current, tags = tags)
+        TagUiState(categories = categories, currentCategory = current, tags = tags, allTags = allTags)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, TagUiState())
 
     fun selectCategory(id: Long?) { selectedCategoryId.value = id }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,10 +1,10 @@
 <resources>
-    <string name="app_name">语录随机器</string>
+    <string name="app_name">特效TEST</string>
     <string name="add">添加</string>
     <string name="delete">删除</string>
     <string name="edit">编辑</string>
     <string name="group">分组</string>
-    <string name="quote">语录</string>
+    <string name="quote">文本</string>
     <string name="weight">权重</string>
     <string name="random">抽一句</string>
     <string name="text">文本</string>
@@ -15,7 +15,7 @@
     <string name="gate_hint">（白屏）按顺序点击：右上×3 → 左上×1 → 左下×2（10秒内）</string>
     <string name="import_image">导入图片</string>
     <string name="empty_group">暂无分组，点击右上角添加</string>
-    <string name="empty_quotes">该分组下暂无语录，点击下方 + 号添加</string>
+    <string name="empty_quotes">该分组下暂无文本，点击下方 + 号添加</string>
     <string name="add_group">添加分组</string>
     <string name="group_name">分组名</string>
     <string name="pick_one">抽一句</string>


### PR DESCRIPTION
### Motivation

- Improve the touch feedback for the gate by centering and polishing the magic circle and add visual motion.  
- Replace list rows with square tiles across tags, categories, characters and resources for denser multi-column layouts and easier name-sorting.  
- Surface tag counts, tag colors, and resource metadata (type + bound tags) in grids and unify "语录" terminology to `文本` in the app strings.  
- Simplify character detail UI by removing the description field and showing tag badges + resource grid with the same filtering used in resource management.

### Description

- Centered and animated the magic circle on touch in `GateScreen` by calculating the circle size in pixels, using `LocalDensity`, adding rotation and shadow, and fixing offset math to align the image with the touch point (`app/src/main/java/com/example/quotepicker/ui/GateScreen.kt`).  
- Added a reusable square tile component `SquareGridItem` for grid cells (`app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt`).  
- Switched `TagScreen` to use adaptive square grids for categories and tags, added a name-sort toggle, and show category tag counts; tags render as colored squares with appropriate text contrast (`app/src/main/java/com/example/quotepicker/ui/TagScreen.kt`).  
- Exposed `allTags` in `TagViewModel` to compute tag counts (`app/src/main/java/com/example/quotepicker/vm/TagViewModel.kt`).  
- Updated `ResourceScreen` to render resources as square tiles using `SquareGridItem` and display a subtitle containing the resource `type` and bound tags; adjusted dialog labels to use `文本` wording (`app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`).  
- Reworked `CharacterScreen` to grid the character list, removed the editable `description` field, added `TagSummarySection` that shows category + colored tag badges, and added per-character resource filtering and a square-grid view for the character's resources (same filtering UI as resources) (`app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt`).  
- Removed icons from the bottom navigation and updated app strings: `app_name` to `特效TEST`, `quote`/`语录` wording changed to `文本`, and related label updates (`app/src/main/java/com/example/quotepicker/ui/MainScreen.kt`, `app/src/main/res/values/strings.xml`).

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969c9f4805c832bb4641e81a7c9e666)