### PR TITLE
Update grid sizes and add full-screen resource preview

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -54,6 +54,7 @@ import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.ui.components.NameDialog
+import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.SquareGridItem
 import com.example.quotepicker.vm.CharacterViewModel
 import com.example.quotepicker.vm.ResourceViewModel
@@ -76,6 +77,16 @@ fun CharacterScreen(
     var filterTagDialog by remember { mutableStateOf(false) }
     var selectedTagIds by remember { mutableStateOf(setOf<Long>()) }
     var selectedType by remember { mutableStateOf<ResourceType?>(null) }
+    var previewTarget by remember { mutableStateOf<com.example.quotepicker.data.ResourceWithTagsCharacters?>(null) }
+
+    if (previewTarget != null) {
+        ResourcePreviewScreen(
+            resource = previewTarget!!,
+            vm = resourceVm,
+            onBack = { previewTarget = null }
+        )
+        return
+    }
 
     Scaffold(
         modifier = modifier,
@@ -107,10 +118,10 @@ fun CharacterScreen(
                     }
                 } else {
                     LazyVerticalGrid(
-                        columns = GridCells.Adaptive(96.dp),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                        columns = GridCells.Fixed(5),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         items(ui.characters, key = { it.character.id }) { character ->
                             SquareGridItem(
@@ -148,10 +159,10 @@ fun CharacterScreen(
                     }
                 } else {
                     LazyVerticalGrid(
-                        columns = GridCells.Adaptive(110.dp),
+                        columns = GridCells.Fixed(3),
                         contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         items(filteredResources, key = { it.resource.id }) { resource ->
                             val tagLabel = resource.tags.joinToString("、") { it.name }.ifBlank { "无标签" }
@@ -159,7 +170,7 @@ fun CharacterScreen(
                             SquareGridItem(
                                 title = resource.resource.title,
                                 subtitle = subtitle,
-                                onClick = {},
+                                onClick = { previewTarget = resource },
                                 onLongClick = {}
                             )
                         }

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -1,7 +1,5 @@
 package com.example.quotepicker.ui
 
-import android.graphics.BitmapFactory
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,21 +7,18 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.quotepicker.data.ResourceType
+import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.vm.RandomViewModel
 import com.example.quotepicker.vm.ResourceViewModel
 
@@ -31,6 +26,15 @@ import com.example.quotepicker.vm.ResourceViewModel
 fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(), resourceVm: ResourceViewModel = viewModel()) {
     val ui by vm.uiState.collectAsState()
     var showPreview by remember { mutableStateOf(false) }
+
+    if (showPreview && ui.selectedResource != null) {
+        ResourcePreviewScreen(
+            resource = ui.selectedResource!!,
+            vm = resourceVm,
+            onBack = { showPreview = false }
+        )
+        return
+    }
 
     Column(modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
         Button(onClick = { vm.randomCharacter() }) { Text("随机角色") }
@@ -49,53 +53,4 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
             Button(onClick = { showPreview = true }) { Text("预览") }
         }
     }
-
-    if (showPreview && ui.selectedResource != null) {
-        RandomPreviewDialog(resource = ui.selectedResource!!, vm = resourceVm, onDismiss = { showPreview = false })
-    }
-}
-
-@Composable
-private fun RandomPreviewDialog(
-    resource: com.example.quotepicker.data.ResourceWithTagsCharacters,
-    vm: ResourceViewModel,
-    onDismiss: () -> Unit
-) {
-    var bitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
-    LaunchedEffect(resource.resource.id) {
-        val res = resource.resource
-        bitmap = when (res.type) {
-            ResourceType.IMAGE -> {
-                val path = res.contentUriOrPath ?: return@LaunchedEffect
-                val bytes = vm.loadDecryptedBytes(path)
-                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-            }
-            ResourceType.QUOTE -> {
-                val b64 = res.quoteImageBase64 ?: return@LaunchedEffect
-                vm.decodeBase64ToBitmap(b64)
-            }
-            else -> null
-        }
-    }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(resource.resource.title) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                when (resource.resource.type) {
-                    ResourceType.QUOTE -> {
-                        Text(resource.resource.quoteText.orEmpty())
-                        bitmap?.let { Image(bitmap = it.asImageBitmap(), contentDescription = null) }
-                    }
-                    ResourceType.IMAGE -> {
-                        bitmap?.let { Image(bitmap = it.asImageBitmap(), contentDescription = null) }
-                    }
-                    ResourceType.AUDIO -> Text("音频预览请在资源页查看")
-                    ResourceType.VIDEO -> Text("视频预览请在资源页查看")
-                    ResourceType.SCENE -> Text(resource.resource.sceneJson.orEmpty())
-                }
-            }
-        },
-        confirmButton = { Button(onClick = onDismiss) { Text("关闭") } }
-    )
 }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -1,11 +1,8 @@
 package com.example.quotepicker.ui
 
-import android.graphics.BitmapFactory
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -42,7 +39,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -51,7 +47,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -59,10 +54,9 @@ import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
+import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.SquareGridItem
 import com.example.quotepicker.vm.ResourceViewModel
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -79,12 +73,22 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     var deleteTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var filterTagDialog by remember { mutableStateOf(false) }
     var filterCharacterDialog by remember { mutableStateOf(false) }
+    var mediaDialogTitle by remember { mutableStateOf("") }
 
     var selectedResourceInput by remember { mutableStateOf<ResourceInputState?>(null) }
     val mediaLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
         val type = pickedMediaType ?: return@rememberLauncherForActivityResult
         val resolved = uri ?: return@rememberLauncherForActivityResult
         selectedResourceInput = ResourceInputState(title = "", type = type, uri = resolved)
+    }
+
+    if (previewTarget != null) {
+        ResourcePreviewScreen(
+            resource = previewTarget!!,
+            vm = vm,
+            onBack = { previewTarget = null }
+        )
+        return
     }
 
     Scaffold(
@@ -121,10 +125,10 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                 }
             } else {
                 LazyVerticalGrid(
-                    columns = GridCells.Fixed(5),
+                    columns = GridCells.Fixed(3),
                     contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     items(ui.resources, key = { it.resource.id }) { res ->
                         ResourceGridItem(
@@ -145,20 +149,17 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                 TextButton(onClick = { showImageQuoteDialog = true; showAddMenu = false }) { Text("创建图片文本") }
                 TextButton(onClick = { showSceneDialog = true; showAddMenu = false }) { Text("创建聊天情景") }
                 TextButton(onClick = {
-                    pickedMediaType = ResourceType.IMAGE
-                    showAddMenu = false
-                    mediaLauncher.launch("image/*")
-                }) { Text("上传图片") }
-                TextButton(onClick = {
                     pickedMediaType = ResourceType.VIDEO
+                    mediaDialogTitle = "创建视频文本"
                     showAddMenu = false
                     mediaLauncher.launch("video/*")
-                }) { Text("上传视频") }
+                }) { Text("创建视频文本") }
                 TextButton(onClick = {
                     pickedMediaType = ResourceType.AUDIO
+                    mediaDialogTitle = "创建声音文本"
                     showAddMenu = false
                     mediaLauncher.launch("audio/*")
-                }) { Text("上传声音") }
+                }) { Text("创建声音文本") }
             }
         }
     }
@@ -206,6 +207,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     selectedResourceInput?.let { input ->
         MediaDialog(
             input = input,
+            dialogTitle = mediaDialogTitle.ifBlank { "创建${typeLabel(input.type)}文本" },
             categories = ui.categories,
             tags = ui.tags,
             characters = ui.characters,
@@ -233,10 +235,6 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             onConfirm = { vm.updateCharacterFilter(it) },
             onDismiss = { filterCharacterDialog = false }
         )
-    }
-
-    previewTarget?.let { target ->
-        ResourcePreviewDialog(resource = target, vm = vm, onDismiss = { previewTarget = null })
     }
 
     editTarget?.let { target ->
@@ -478,8 +476,12 @@ private fun SceneDialog(
                 OutlinedTextField(
                     value = sceneJson,
                     onValueChange = { sceneJson = it },
-                    label = { Text("sceneJson") },
+                    label = { Text("对话JSON") },
                     modifier = Modifier.fillMaxWidth()
+                )
+                Text(
+                    text = "示例：[{\"speaker\":\"小明\",\"text\":\"你好\"},{\"speaker\":\"小红\",\"text\":\"你好呀\"}]",
+                    style = MaterialTheme.typography.labelSmall
                 )
                 TagSelectionSection(
                     label = "标签",
@@ -510,6 +512,7 @@ private fun SceneDialog(
 @Composable
 private fun MediaDialog(
     input: ResourceInputState,
+    dialogTitle: String,
     categories: List<TagCategoryEntity>,
     tags: List<com.example.quotepicker.data.TagEntity>,
     characters: List<com.example.quotepicker.data.CharacterEntity>,
@@ -521,7 +524,7 @@ private fun MediaDialog(
     var selectedCharacters by remember { mutableStateOf(setOf<Long>()) }
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("上传${typeLabel(input.type)}") },
+        title = { Text(dialogTitle) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("标题") })
@@ -634,57 +637,6 @@ private fun FilterCharacterDialog(
             }) { Text("确定") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
-    )
-}
-
-@Composable
-private fun ResourcePreviewDialog(
-    resource: ResourceWithTagsCharacters,
-    vm: ResourceViewModel,
-    onDismiss: () -> Unit
-) {
-    var bitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
-    LaunchedEffect(resource.resource.id) {
-        val res = resource.resource
-        bitmap = when (res.type) {
-            ResourceType.IMAGE -> {
-                val path = res.contentUriOrPath ?: return@LaunchedEffect
-                val bytes = vm.loadDecryptedBytes(path)
-                BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
-            }
-            ResourceType.QUOTE -> {
-                val b64 = res.quoteImageBase64 ?: return@LaunchedEffect
-                vm.decodeBase64ToBitmap(b64)
-            }
-            else -> null
-        }
-    }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(resource.resource.title) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                when (resource.resource.type) {
-                    ResourceType.QUOTE -> {
-                        Text(resource.resource.quoteText.orEmpty())
-                        bitmap?.let {
-                            Image(bitmap = it.asImageBitmap(), contentDescription = null)
-                        }
-                    }
-                    ResourceType.IMAGE -> {
-                        bitmap?.let {
-                            Image(bitmap = it.asImageBitmap(), contentDescription = null)
-                        } ?: Text("图片加载中…")
-                    }
-                    ResourceType.AUDIO -> Text("音频预览请使用外部播放器（已加密存储）")
-                    ResourceType.VIDEO -> Text("视频预览请使用外部播放器（已加密存储）")
-                    ResourceType.SCENE -> {
-                        Text(resource.resource.sceneJson.orEmpty())
-                    }
-                }
-            }
-        },
-        confirmButton = { TextButton(onClick = onDismiss) { Text("关闭") } }
     )
 }
 

--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -63,7 +63,6 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     var bottomSheetTarget by remember { mutableStateOf<Any?>(null) }
     var deleteCategory by remember { mutableStateOf<TagCategoryEntity?>(null) }
     var deleteTag by remember { mutableStateOf<TagEntity?>(null) }
-    var sortByName by remember { mutableStateOf(true) }
 
     val isInCategory = ui.currentCategory != null
     val categoryTagCounts = remember(ui.allTags) {
@@ -80,11 +79,6 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                         IconButton(onClick = { vm.selectCategory(null) }) {
                             Icon(Icons.Default.ArrowBack, contentDescription = "返回")
                         }
-                    }
-                },
-                actions = {
-                    TextButton(onClick = { sortByName = !sortByName }) {
-                        Text(if (sortByName) "按名称排序✓" else "按名称排序")
                     }
                 }
             )
@@ -104,16 +98,12 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                         Text("暂无标签类别，点击右下角添加")
                     }
                 } else {
-                    val categories = if (sortByName) {
-                        ui.categories.sortedBy { it.name.lowercase() }
-                    } else {
-                        ui.categories
-                    }
+                    val categories = ui.categories.sortedBy { it.name.lowercase() }
                     LazyVerticalGrid(
-                        columns = GridCells.Adaptive(96.dp),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                        columns = GridCells.Fixed(5),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         items(categories, key = { it.id }) { category ->
                             val count = categoryTagCounts[category.id] ?: 0
@@ -132,16 +122,12 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                         Text("暂无标签，点击右下角添加")
                     }
                 } else {
-                    val tags = if (sortByName) {
-                        ui.tags.sortedBy { it.name.lowercase() }
-                    } else {
-                        ui.tags
-                    }
+                    val tags = ui.tags.sortedBy { it.name.lowercase() }
                     LazyVerticalGrid(
-                        columns = GridCells.Adaptive(96.dp),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                        columns = GridCells.Fixed(5),
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
                         items(tags, key = { it.id }) { tag ->
                             val bg = Color(tag.colorArgb)

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -1,0 +1,248 @@
+package com.example.quotepicker.ui.components
+
+import android.net.Uri
+import android.widget.MediaController
+import android.widget.VideoView
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import com.example.quotepicker.data.ResourceType
+import com.example.quotepicker.data.ResourceWithTagsCharacters
+import com.example.quotepicker.vm.ResourceViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+
+private data class SceneMessage(val speaker: String, val content: String)
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+fun ResourcePreviewScreen(
+    resource: ResourceWithTagsCharacters,
+    vm: ResourceViewModel,
+    onBack: () -> Unit
+) {
+    var bitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
+    var mediaUri by remember { mutableStateOf<Uri?>(null) }
+    var sceneMessages by remember { mutableStateOf<List<SceneMessage>>(emptyList()) }
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(resource.resource.id) {
+        val res = resource.resource
+        bitmap = when (res.type) {
+            ResourceType.IMAGE -> {
+                val path = res.contentUriOrPath ?: return@LaunchedEffect
+                val bytes = vm.loadDecryptedBytes(path)
+                android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+            }
+            ResourceType.QUOTE -> {
+                val b64 = res.quoteImageBase64 ?: return@LaunchedEffect
+                vm.decodeBase64ToBitmap(b64)
+            }
+            else -> null
+        }
+        mediaUri = when (res.type) {
+            ResourceType.VIDEO, ResourceType.AUDIO -> {
+                val path = res.contentUriOrPath ?: return@LaunchedEffect
+                val file = withContext(Dispatchers.IO) {
+                    vm.writeDecryptedToCache(path)
+                } ?: return@LaunchedEffect
+                Uri.fromFile(file)
+            }
+            else -> null
+        }
+        sceneMessages = parseSceneMessages(res.sceneJson.orEmpty())
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("资源预览") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                    }
+                }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+                .verticalScroll(scrollState)
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Text(
+                text = resource.resource.title,
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.Bold
+            )
+            if (resource.tags.isNotEmpty()) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    resource.tags.forEach { tag ->
+                        AssistChip(onClick = {}, label = { Text(tag.name) })
+                    }
+                }
+            } else {
+                Text("无标签", style = MaterialTheme.typography.labelMedium)
+            }
+
+            Card(
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
+                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    when (resource.resource.type) {
+                        ResourceType.QUOTE -> {
+                            if (!resource.resource.quoteText.isNullOrBlank()) {
+                                Text(resource.resource.quoteText.orEmpty())
+                            }
+                            bitmap?.let {
+                                Image(
+                                    bitmap = it.asImageBitmap(),
+                                    contentDescription = null,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                        }
+                        ResourceType.IMAGE -> {
+                            bitmap?.let {
+                                Image(
+                                    bitmap = it.asImageBitmap(),
+                                    contentDescription = null,
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            } ?: Text("图片加载中…")
+                        }
+                        ResourceType.VIDEO -> {
+                            if (mediaUri != null) {
+                                MediaPreview(uri = mediaUri!!)
+                            } else {
+                                Text("视频加载中…")
+                            }
+                        }
+                        ResourceType.AUDIO -> {
+                            if (mediaUri != null) {
+                                MediaPreview(uri = mediaUri!!)
+                                Text("音频播放中")
+                            } else {
+                                Text("音频加载中…")
+                            }
+                        }
+                        ResourceType.SCENE -> {
+                            if (sceneMessages.isNotEmpty()) {
+                                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                    sceneMessages.forEach { message ->
+                                        SceneBubble(message = message)
+                                    }
+                                }
+                            } else {
+                                Text(resource.resource.sceneJson.orEmpty())
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun MediaPreview(uri: Uri) {
+    AndroidView(
+        factory = { context ->
+            VideoView(context).apply {
+                val controller = MediaController(context)
+                controller.setAnchorView(this)
+                setMediaController(controller)
+                setVideoURI(uri)
+                setOnPreparedListener { it.start() }
+            }
+        },
+        update = { view ->
+            view.setVideoURI(uri)
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(240.dp)
+            .background(MaterialTheme.colorScheme.surfaceVariant)
+    )
+}
+
+@Composable
+private fun SceneBubble(message: SceneMessage) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Start
+    ) {
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.shapes.medium)
+                .padding(12.dp)
+        ) {
+            Text(
+                text = message.speaker,
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(text = message.content)
+        }
+    }
+}
+
+private fun parseSceneMessages(raw: String): List<SceneMessage> {
+    return runCatching {
+        val array = JSONArray(raw)
+        buildList {
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                val speaker = obj.optString("speaker")
+                val content = obj.optString("text")
+                if (speaker.isNotBlank() || content.isNotBlank()) {
+                    add(SceneMessage(speaker.ifBlank { "角色" }, content))
+                }
+            }
+        }
+    }.getOrDefault(emptyList())
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 
@@ -50,6 +51,7 @@ fun SquareGridItem(
                 Text(
                     text = title,
                     style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
                     color = contentColor,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -16,6 +16,7 @@ import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.util.EncryptedFileManager
 import com.example.quotepicker.util.ImageCompression
+import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -159,6 +160,17 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
 
     suspend fun loadDecryptedBytes(path: String): ByteArray = withContext(Dispatchers.IO) {
         fileManager.openDecryptedStream(path).use { it.readBytes() }
+    }
+
+    suspend fun writeDecryptedToCache(path: String): File? = withContext(Dispatchers.IO) {
+        val cacheDir = getApplication<Application>().cacheDir
+        val temp = File(cacheDir, "preview_${System.currentTimeMillis()}.media")
+        runCatching {
+            fileManager.openDecryptedStream(path).use { input ->
+                temp.outputStream().use { output -> input.copyTo(output) }
+            }
+            temp
+        }.getOrNull()
     }
 
     fun decodeBase64ToBitmap(b64: String): Bitmap? {


### PR DESCRIPTION
### Motivation
- Standardize tag and character listing to denser 5-column grids with bolder names and remove the sort control to match the requested UI emphasis. 
- Make resource grids larger and consistent with character detail screens by showing 3 items per row and allowing resource previews from the character screen. 
- Replace small modal/dialog previews with a full-screen preview that shows name, tags and content (text, image, video, audio) and supports playback and a nicer scene/chat presentation. 
- Adjust resource creation flows so image quote creation remains but uploads are renamed to "创建视频文本"/"创建声音文本" while still allowing actual video/audio uploads. 

### Description
- Updated the grid item presentation by making title text bold in `app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt`. 
- Converted tag and character lists to fixed 5-column grids by switching to `GridCells.Fixed(5)` and removed the sort toggle in `app/src/main/java/com/example/quotepicker/ui/TagScreen.kt`. 
- Changed resource grids to `GridCells.Fixed(3)` and wired clicks from the character resource list to open previews in `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt` and `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`. 
- Replaced inline/dialog previews with a new full-screen `ResourcePreviewScreen` composable in `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt` that renders title, tags, text, images, plays video/audio and renders `sceneJson` as chat bubbles. 
- Adjusted the resource add/upload flow in `ResourceScreen.kt` to rename menu entries to "创建视频文本" and "创建声音文本", added a `dialogTitle` parameter for `MediaDialog`, and added example guidance for the scene JSON field. 
- Added `writeDecryptedToCache` to `ResourceViewModel` (`app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt`) to dump decrypted media to a cache file so full-screen preview can play encrypted audio/video. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969d2d6095c832b899c131927b5045f)