### PR TITLE
Revamp resource create/edit flows and tag styling

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -1,6 +1,5 @@
 package com.example.quotepicker.ui
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -45,7 +44,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.data.CharacterEntity
@@ -54,6 +52,9 @@ import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.ui.components.NameDialog
+import com.example.quotepicker.ui.components.TagBadge
+import com.example.quotepicker.ui.components.tagTextColor
+import com.example.quotepicker.ui.components.ResourceGridCard
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.SquareGridItem
 import com.example.quotepicker.vm.CharacterViewModel
@@ -165,11 +166,10 @@ fun CharacterScreen(
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
                         items(filteredResources, key = { it.resource.id }) { resource ->
-                            val tagLabel = resource.tags.joinToString("、") { it.name }.ifBlank { "无标签" }
-                            val subtitle = "${typeLabel(resource.resource.type)}\n标签：$tagLabel"
-                            SquareGridItem(
+                            ResourceGridCard(
                                 title = resource.resource.title,
-                                subtitle = subtitle,
+                                typeLabel = typeLabel(resource.resource.type),
+                                tags = resource.tags,
                                 onClick = { previewTarget = resource },
                                 onLongClick = {}
                             )
@@ -342,19 +342,6 @@ private fun TagSummarySection(
 }
 
 @Composable
-private fun TagBadge(tag: TagEntity) {
-    val bg = Color(tag.colorArgb)
-    val textColor = if (bg.luminance() < 0.5f) Color.White else Color.Black
-    Box(
-        modifier = Modifier
-            .background(bg, shape = MaterialTheme.shapes.small)
-            .padding(horizontal = 10.dp, vertical = 6.dp)
-    ) {
-        Text(text = tag.name, color = textColor, style = MaterialTheme.typography.labelSmall)
-    }
-}
-
-@Composable
 private fun CharacterResourceFilterBar(
     selectedType: ResourceType?,
     selectedTagIds: Set<Long>,
@@ -468,7 +455,7 @@ private fun TagSelectionSection(
                     items.forEach { tag ->
                         val isSelected = selected.contains(tag.id)
                         val tagColor = Color(tag.colorArgb)
-                        val selectedTextColor = if (tagColor.luminance() < 0.5f) Color.White else Color.Black
+                        val selectedTextColor = tagTextColor(tagColor)
                         FilterChip(
                             selected = isSelected,
                             onClick = {
@@ -478,7 +465,7 @@ private fun TagSelectionSection(
                             },
                             label = { Text(tag.name) },
                             colors = FilterChipDefaults.filterChipColors(
-                                containerColor = Color.White,
+                                containerColor = tagColor.copy(alpha = 0.2f),
                                 selectedContainerColor = tagColor,
                                 labelColor = MaterialTheme.colorScheme.onSurface,
                                 selectedLabelColor = selectedTextColor
@@ -497,7 +484,7 @@ private fun TagSelectionSection(
                 uncategorized.forEach { tag ->
                     val isSelected = selected.contains(tag.id)
                     val tagColor = Color(tag.colorArgb)
-                    val selectedTextColor = if (tagColor.luminance() < 0.5f) Color.White else Color.Black
+                    val selectedTextColor = tagTextColor(tagColor)
                     FilterChip(
                         selected = isSelected,
                         onClick = {
@@ -507,7 +494,7 @@ private fun TagSelectionSection(
                         },
                         label = { Text(tag.name) },
                         colors = FilterChipDefaults.filterChipColors(
-                            containerColor = Color.White,
+                            containerColor = tagColor.copy(alpha = 0.2f),
                             selectedContainerColor = tagColor,
                             labelColor = MaterialTheme.colorScheme.onSurface,
                             selectedLabelColor = selectedTextColor

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -3,7 +3,6 @@ package com.example.quotepicker.ui
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -21,6 +20,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material3.AlertDialog
@@ -47,15 +47,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import com.example.quotepicker.data.TagCategoryEntity
-import com.example.quotepicker.data.TagEntity
+import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
+import com.example.quotepicker.data.TagCategoryEntity
+import com.example.quotepicker.data.TagEntity
+import com.example.quotepicker.ui.components.ResourceGridCard
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
-import com.example.quotepicker.ui.components.SquareGridItem
+import com.example.quotepicker.ui.components.TagBadge
+import com.example.quotepicker.ui.components.tagTextColor
 import com.example.quotepicker.vm.ResourceViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -63,23 +65,36 @@ import com.example.quotepicker.vm.ResourceViewModel
 fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewModel()) {
     val ui by vm.uiState.collectAsState()
     var showAddMenu by remember { mutableStateOf(false) }
-    var showTextDialog by remember { mutableStateOf(false) }
-    var showImageQuoteDialog by remember { mutableStateOf(false) }
-    var showSceneDialog by remember { mutableStateOf(false) }
-    var pickedMediaType by remember { mutableStateOf<ResourceType?>(null) }
+    var createMode by remember { mutableStateOf<CreateMode?>(null) }
     var previewTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var editTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var bottomSheetTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var deleteTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var filterTagDialog by remember { mutableStateOf(false) }
     var filterCharacterDialog by remember { mutableStateOf(false) }
-    var mediaDialogTitle by remember { mutableStateOf("") }
 
-    var selectedResourceInput by remember { mutableStateOf<ResourceInputState?>(null) }
-    val mediaLauncher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri: Uri? ->
-        val type = pickedMediaType ?: return@rememberLauncherForActivityResult
-        val resolved = uri ?: return@rememberLauncherForActivityResult
-        selectedResourceInput = ResourceInputState(title = "", type = type, uri = resolved)
+    createMode?.let { mode ->
+        ResourceCreateScreen(
+            mode = mode,
+            categories = ui.categories,
+            tags = ui.tags,
+            characters = ui.characters,
+            vm = vm,
+            onBack = { createMode = null }
+        )
+        return
+    }
+
+    editTarget?.let { target ->
+        ResourceEditScreen(
+            resource = target,
+            categories = ui.categories,
+            tags = ui.tags,
+            characters = ui.characters,
+            vm = vm,
+            onBack = { editTarget = null }
+        )
+        return
     }
 
     if (previewTarget != null) {
@@ -131,8 +146,10 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     items(ui.resources, key = { it.resource.id }) { res ->
-                        ResourceGridItem(
-                            resource = res,
+                        ResourceGridCard(
+                            title = res.resource.title,
+                            typeLabel = typeLabel(res.resource.type),
+                            tags = res.tags,
                             onClick = { previewTarget = res },
                             onLongClick = { bottomSheetTarget = res }
                         )
@@ -145,78 +162,17 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     if (showAddMenu) {
         ModalBottomSheet(onDismissRequest = { showAddMenu = false }) {
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                TextButton(onClick = { showTextDialog = true; showAddMenu = false }) { Text("创建文本") }
-                TextButton(onClick = { showImageQuoteDialog = true; showAddMenu = false }) { Text("创建图片文本") }
-                TextButton(onClick = { showSceneDialog = true; showAddMenu = false }) { Text("创建聊天情景") }
-                TextButton(onClick = {
-                    pickedMediaType = ResourceType.VIDEO
-                    mediaDialogTitle = "创建视频文本"
-                    showAddMenu = false
-                    mediaLauncher.launch("video/*")
-                }) { Text("创建视频文本") }
-                TextButton(onClick = {
-                    pickedMediaType = ResourceType.AUDIO
-                    mediaDialogTitle = "创建声音文本"
-                    showAddMenu = false
-                    mediaLauncher.launch("audio/*")
-                }) { Text("创建声音文本") }
+                TextButton(onClick = { createMode = CreateMode.Text; showAddMenu = false }) { Text("创建文本") }
+                TextButton(onClick = { createMode = CreateMode.ImageText; showAddMenu = false }) { Text("创建图片文本") }
+                TextButton(onClick = { createMode = CreateMode.Scene; showAddMenu = false }) { Text("创建聊天情景") }
+                TextButton(onClick = { createMode = CreateMode.Media(ResourceType.VIDEO); showAddMenu = false }) {
+                    Text("创建视频文本")
+                }
+                TextButton(onClick = { createMode = CreateMode.Media(ResourceType.AUDIO); showAddMenu = false }) {
+                    Text("创建声音文本")
+                }
             }
         }
-    }
-
-    if (showTextDialog) {
-        QuoteDialog(
-            title = "创建文本",
-            onConfirm = { title, text, tagIds, characterIds ->
-                vm.addTextQuote(title, text, tagIds, characterIds)
-                showTextDialog = false
-            },
-            categories = ui.categories,
-            tags = ui.tags,
-            characters = ui.characters,
-            onDismiss = { showTextDialog = false }
-        )
-    }
-
-    if (showImageQuoteDialog) {
-        ImageQuoteDialog(
-            categories = ui.categories,
-            tags = ui.tags,
-            characters = ui.characters,
-            onConfirm = { title, uri, tagIds, characterIds ->
-                vm.addImageQuote(title, uri, tagIds, characterIds)
-                showImageQuoteDialog = false
-            },
-            onDismiss = { showImageQuoteDialog = false }
-        )
-    }
-
-    if (showSceneDialog) {
-        SceneDialog(
-            categories = ui.categories,
-            tags = ui.tags,
-            characters = ui.characters,
-            onConfirm = { title, desc, json, tagIds, characterIds ->
-                vm.addScene(title, desc, json, tagIds, characterIds)
-                showSceneDialog = false
-            },
-            onDismiss = { showSceneDialog = false }
-        )
-    }
-
-    selectedResourceInput?.let { input ->
-        MediaDialog(
-            input = input,
-            dialogTitle = mediaDialogTitle.ifBlank { "创建${typeLabel(input.type)}文本" },
-            categories = ui.categories,
-            tags = ui.tags,
-            characters = ui.characters,
-            onConfirm = { title, tagIds, characterIds ->
-                vm.addEncryptedMedia(input.type, title, input.uri, tagIds, characterIds)
-                selectedResourceInput = null
-            },
-            onDismiss = { selectedResourceInput = null }
-        )
     }
 
     if (filterTagDialog) {
@@ -234,26 +190,6 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             selectedId = ui.filters.selectedCharacterId,
             onConfirm = { vm.updateCharacterFilter(it) },
             onDismiss = { filterCharacterDialog = false }
-        )
-    }
-
-    editTarget?.let { target ->
-        ResourceEditDialog(
-            resource = target,
-            categories = ui.categories,
-            tags = ui.tags,
-            characters = ui.characters,
-            onConfirm = { title, tagIds, characterIds ->
-                vm.updateResource(target.resource.copy(title = title))
-                vm.updateResourceTags(target.resource.id, tagIds)
-                vm.updateResourceCharacters(target.resource.id, characterIds)
-                editTarget = null
-            },
-            onDelete = {
-                deleteTarget = target
-                editTarget = null
-            },
-            onDismiss = { editTarget = null }
         )
     }
 
@@ -301,11 +237,18 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     }
 }
 
+private sealed class CreateMode {
+    data object Text : CreateMode()
+    data object ImageText : CreateMode()
+    data object Scene : CreateMode()
+    data class Media(val type: ResourceType) : CreateMode()
+}
+
 @Composable
 private fun FilterBar(
     selectedType: ResourceType?,
     selectedTagIds: Set<Long>,
-    characters: List<com.example.quotepicker.data.CharacterEntity>,
+    characters: List<CharacterEntity>,
     selectedCharacterId: Long?,
     onTypeChange: (ResourceType?) -> Unit,
     onCharacterDialog: () -> Unit,
@@ -314,12 +257,12 @@ private fun FilterBar(
     Column(Modifier.fillMaxWidth().padding(12.dp)) {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             ResourceType.values().forEach { type ->
-            FilterChip(
-                selected = selectedType == type,
-                onClick = { onTypeChange(if (selectedType == type) null else type) },
-                label = { Text(typeLabel(type)) }
-            )
-        }
+                FilterChip(
+                    selected = selectedType == type,
+                    onClick = { onTypeChange(if (selectedType == type) null else type) },
+                    label = { Text(typeLabel(type)) }
+                )
+            }
         }
         Spacer(Modifier.height(8.dp))
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
@@ -341,224 +284,10 @@ private fun typeLabel(type: ResourceType): String = when (type) {
     ResourceType.SCENE -> "情景"
 }
 
-data class ResourceInputState(
-    val title: String,
-    val type: ResourceType,
-    val uri: Uri
-)
-
-@Composable
-private fun QuoteDialog(
-    title: String,
-    categories: List<TagCategoryEntity>,
-    tags: List<com.example.quotepicker.data.TagEntity>,
-    characters: List<com.example.quotepicker.data.CharacterEntity>,
-    onConfirm: (String, String, List<Long>, List<Long>) -> Unit,
-    onDismiss: () -> Unit
-) {
-    var quoteTitle by remember { mutableStateOf("") }
-    var quoteText by remember { mutableStateOf("") }
-    var selectedTags by remember { mutableStateOf(setOf<Long>()) }
-    var selectedCharacters by remember { mutableStateOf(setOf<Long>()) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(title) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(
-                    value = quoteTitle,
-                    onValueChange = { quoteTitle = it },
-                    label = { Text("标题") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                OutlinedTextField(
-                    value = quoteText,
-                    onValueChange = { quoteText = it },
-                    label = { Text("文本内容") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                TagSelectionSection(
-                    label = "标签",
-                    categories = categories,
-                    tags = tags,
-                    selected = selectedTags,
-                    onChange = { selectedTags = it }
-                )
-                CharacterSelectionSection(
-                    label = "角色",
-                    characters = characters,
-                    selected = selectedCharacters,
-                    onChange = { selectedCharacters = it }
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                if (quoteTitle.isNotBlank() && selectedCharacters.isNotEmpty()) {
-                    onConfirm(quoteTitle.trim(), quoteText.trim(), selectedTags.toList(), selectedCharacters.toList())
-                }
-            }) { Text("确定") }
-        },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
-    )
-}
-
-@Composable
-private fun ImageQuoteDialog(
-    categories: List<TagCategoryEntity>,
-    tags: List<com.example.quotepicker.data.TagEntity>,
-    characters: List<com.example.quotepicker.data.CharacterEntity>,
-    onConfirm: (String, Uri, List<Long>, List<Long>) -> Unit,
-    onDismiss: () -> Unit
-) {
-    var title by remember { mutableStateOf("") }
-    var imageUri by remember { mutableStateOf<Uri?>(null) }
-    var selectedTags by remember { mutableStateOf(setOf<Long>()) }
-    var selectedCharacters by remember { mutableStateOf(setOf<Long>()) }
-    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        imageUri = uri
-    }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("创建图片文本") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("标题") })
-                TextButton(onClick = { launcher.launch("image/*") }) { Text("选择图片") }
-                Text(imageUri?.toString() ?: "未选择图片")
-                TagSelectionSection(
-                    label = "标签",
-                    categories = categories,
-                    tags = tags,
-                    selected = selectedTags,
-                    onChange = { selectedTags = it }
-                )
-                CharacterSelectionSection(
-                    label = "角色",
-                    characters = characters,
-                    selected = selectedCharacters,
-                    onChange = { selectedCharacters = it }
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                val uri = imageUri ?: return@TextButton
-                if (title.isNotBlank() && selectedCharacters.isNotEmpty()) {
-                    onConfirm(title.trim(), uri, selectedTags.toList(), selectedCharacters.toList())
-                }
-            }) { Text("确定") }
-        },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
-    )
-}
-
-@Composable
-private fun SceneDialog(
-    categories: List<TagCategoryEntity>,
-    tags: List<com.example.quotepicker.data.TagEntity>,
-    characters: List<com.example.quotepicker.data.CharacterEntity>,
-    onConfirm: (String, String?, String, List<Long>, List<Long>) -> Unit,
-    onDismiss: () -> Unit
-) {
-    var title by remember { mutableStateOf("") }
-    var desc by remember { mutableStateOf("") }
-    var sceneJson by remember { mutableStateOf("") }
-    var selectedTags by remember { mutableStateOf(setOf<Long>()) }
-    var selectedCharacters by remember { mutableStateOf(setOf<Long>()) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("创建聊天情景") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("标题") })
-                OutlinedTextField(value = desc, onValueChange = { desc = it }, label = { Text("描述(可选)") })
-                OutlinedTextField(
-                    value = sceneJson,
-                    onValueChange = { sceneJson = it },
-                    label = { Text("对话JSON") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Text(
-                    text = "示例：[{\"speaker\":\"小明\",\"text\":\"你好\"},{\"speaker\":\"小红\",\"text\":\"你好呀\"}]",
-                    style = MaterialTheme.typography.labelSmall
-                )
-                TagSelectionSection(
-                    label = "标签",
-                    categories = categories,
-                    tags = tags,
-                    selected = selectedTags,
-                    onChange = { selectedTags = it }
-                )
-                CharacterSelectionSection(
-                    label = "角色",
-                    characters = characters,
-                    selected = selectedCharacters,
-                    onChange = { selectedCharacters = it }
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                if (title.isNotBlank() && selectedCharacters.isNotEmpty()) {
-                    onConfirm(title.trim(), desc.ifBlank { null }, sceneJson, selectedTags.toList(), selectedCharacters.toList())
-                }
-            }) { Text("确定") }
-        },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
-    )
-}
-
-@Composable
-private fun MediaDialog(
-    input: ResourceInputState,
-    dialogTitle: String,
-    categories: List<TagCategoryEntity>,
-    tags: List<com.example.quotepicker.data.TagEntity>,
-    characters: List<com.example.quotepicker.data.CharacterEntity>,
-    onConfirm: (String, List<Long>, List<Long>) -> Unit,
-    onDismiss: () -> Unit
-) {
-    var title by remember { mutableStateOf("") }
-    var selectedTags by remember { mutableStateOf(setOf<Long>()) }
-    var selectedCharacters by remember { mutableStateOf(setOf<Long>()) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(dialogTitle) },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("标题") })
-                Text(input.uri.toString())
-                TagSelectionSection(
-                    label = "标签",
-                    categories = categories,
-                    tags = tags,
-                    selected = selectedTags,
-                    onChange = { selectedTags = it }
-                )
-                CharacterSelectionSection(
-                    label = "角色",
-                    characters = characters,
-                    selected = selectedCharacters,
-                    onChange = { selectedCharacters = it }
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                if (title.isNotBlank() && selectedCharacters.isNotEmpty()) {
-                    onConfirm(title.trim(), selectedTags.toList(), selectedCharacters.toList())
-                }
-            }) { Text("确定") }
-        },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
-    )
-}
-
 @Composable
 private fun FilterTagDialog(
     categories: List<TagCategoryEntity>,
-    tags: List<com.example.quotepicker.data.TagEntity>,
+    tags: List<TagEntity>,
     selectedIds: Set<Long>,
     onConfirm: (Set<Long>) -> Unit,
     onDismiss: () -> Unit
@@ -589,7 +318,7 @@ private fun FilterTagDialog(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun FilterCharacterDialog(
-    characters: List<com.example.quotepicker.data.CharacterEntity>,
+    characters: List<CharacterEntity>,
     selectedId: Long?,
     onConfirm: (Long?) -> Unit,
     onDismiss: () -> Unit
@@ -640,71 +369,377 @@ private fun FilterCharacterDialog(
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-private fun ResourceEditDialog(
+private fun ResourceCreateScreen(
+    mode: CreateMode,
+    categories: List<TagCategoryEntity>,
+    tags: List<TagEntity>,
+    characters: List<CharacterEntity>,
+    vm: ResourceViewModel,
+    onBack: () -> Unit
+) {
+    var title by remember { mutableStateOf("") }
+    var quoteText by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var sceneJson by remember { mutableStateOf("") }
+    var selectedTags by remember { mutableStateOf(setOf<Long>()) }
+    var selectedCharacters by remember { mutableStateOf(setOf<Long>()) }
+    var imageUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
+    var mediaUri by remember { mutableStateOf<Uri?>(null) }
+    var showTagPicker by remember { mutableStateOf(false) }
+    var showCharacterPicker by remember { mutableStateOf(false) }
+
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) {
+        imageUris = it
+    }
+    val mediaPicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+        mediaUri = uri
+    }
+
+    val screenTitle = when (mode) {
+        CreateMode.Text -> "创建文本"
+        CreateMode.ImageText -> "创建图片文本"
+        CreateMode.Scene -> "创建聊天情景"
+        is CreateMode.Media -> "创建${typeLabel(mode.type)}文本"
+    }
+
+    val canSubmit = title.isNotBlank() && selectedCharacters.isNotEmpty() && when (mode) {
+        CreateMode.Text -> true
+        CreateMode.ImageText -> imageUris.isNotEmpty()
+        CreateMode.Scene -> true
+        is CreateMode.Media -> mediaUri != null
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(screenTitle) },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    TextButton(onClick = {
+                        when (mode) {
+                            CreateMode.Text -> vm.addTextQuote(
+                                title.trim(),
+                                quoteText.trim(),
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            CreateMode.ImageText -> vm.addImageQuote(
+                                title.trim(),
+                                imageUris,
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            CreateMode.Scene -> vm.addScene(
+                                title.trim(),
+                                description.ifBlank { null },
+                                sceneJson,
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            is CreateMode.Media -> vm.addEncryptedMedia(
+                                mode.type,
+                                title.trim(),
+                                mediaUri ?: return@TextButton,
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                        }
+                        onBack()
+                    }, enabled = canSubmit) { Text("创建") }
+                }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text("标题") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            when (mode) {
+                CreateMode.Text -> {
+                    OutlinedTextField(
+                        value = quoteText,
+                        onValueChange = { quoteText = it },
+                        label = { Text("文本内容") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+                CreateMode.ImageText -> {
+                    TextButton(onClick = { imagePicker.launch("image/*") }) { Text("选择图片") }
+                    Text(if (imageUris.isEmpty()) "未选择图片" else "已选择 ${imageUris.size} 张图片")
+                }
+                CreateMode.Scene -> {
+                    OutlinedTextField(
+                        value = description,
+                        onValueChange = { description = it },
+                        label = { Text("描述(可选)") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = sceneJson,
+                        onValueChange = { sceneJson = it },
+                        label = { Text("对话JSON") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    Text(
+                        text = "示例：[{\"speaker\":\"小明\",\"text\":\"你好\"},{\"speaker\":\"小红\",\"text\":\"你好呀\"}]",
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                }
+                is CreateMode.Media -> {
+                    val label = if (mode.type == ResourceType.VIDEO) "选择视频" else "选择声音"
+                    TextButton(onClick = { mediaPicker.launch(if (mode.type == ResourceType.VIDEO) "video/*" else "audio/*") }) {
+                        Text(label)
+                    }
+                    Text(mediaUri?.toString() ?: "未选择文件")
+                }
+            }
+            ResourceTagPickerRow(
+                label = "标签",
+                allTags = tags,
+                selected = selectedTags,
+                onPick = { showTagPicker = true }
+            )
+            ResourceCharacterPickerRow(
+                label = "角色",
+                characters = characters,
+                selected = selectedCharacters,
+                onPick = { showCharacterPicker = true }
+            )
+        }
+    }
+
+    if (showTagPicker) {
+        TagPickerDialog(
+            categories = categories,
+            tags = tags,
+            selectedIds = selectedTags,
+            onConfirm = { selectedTags = it },
+            onDismiss = { showTagPicker = false }
+        )
+    }
+    if (showCharacterPicker) {
+        CharacterPickerDialog(
+            characters = characters,
+            selectedIds = selectedCharacters,
+            onConfirm = { selectedCharacters = it },
+            onDismiss = { showCharacterPicker = false }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ResourceEditScreen(
     resource: ResourceWithTagsCharacters,
     categories: List<TagCategoryEntity>,
-    tags: List<com.example.quotepicker.data.TagEntity>,
-    characters: List<com.example.quotepicker.data.CharacterEntity>,
-    onConfirm: (String, List<Long>, List<Long>) -> Unit,
-    onDelete: () -> Unit,
-    onDismiss: () -> Unit
+    tags: List<TagEntity>,
+    characters: List<CharacterEntity>,
+    vm: ResourceViewModel,
+    onBack: () -> Unit
 ) {
     var title by remember { mutableStateOf(resource.resource.title) }
     var selectedTags by remember { mutableStateOf(resource.tags.map { it.id }.toSet()) }
     var selectedCharacters by remember { mutableStateOf(resource.characters.map { it.id }.toSet()) }
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text("编辑资源") },
-        text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("标题") })
-                TagSelectionSection(
-                    label = "标签",
-                    categories = categories,
-                    tags = tags,
-                    selected = selectedTags,
-                    onChange = { selectedTags = it }
-                )
-                CharacterSelectionSection(
-                    label = "角色",
-                    characters = characters,
-                    selected = selectedCharacters,
-                    onChange = { selectedCharacters = it }
-                )
-            }
-        },
-        confirmButton = {
-            TextButton(onClick = {
-                if (title.isNotBlank() && selectedCharacters.isNotEmpty()) {
-                    onConfirm(title.trim(), selectedTags.toList(), selectedCharacters.toList())
+    var showTagPicker by remember { mutableStateOf(false) }
+    var showCharacterPicker by remember { mutableStateOf(false) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("编辑资源") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    TextButton(onClick = {
+                        if (title.isNotBlank() && selectedCharacters.isNotEmpty()) {
+                            vm.updateResource(resource.resource.copy(title = title.trim()))
+                            vm.updateResourceTags(resource.resource.id, selectedTags.toList())
+                            vm.updateResourceCharacters(resource.resource.id, selectedCharacters.toList())
+                            onBack()
+                        }
+                    }) { Text("保存") }
                 }
-            }) { Text("保存") }
-        },
-        dismissButton = {
-            TextButton(onClick = onDelete) {
-                Icon(Icons.Default.Delete, contentDescription = null)
-                Spacer(Modifier.width(8.dp))
-                Text("删除")
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(text = typeLabel(resource.resource.type), style = MaterialTheme.typography.labelMedium)
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text("标题") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            ResourceTagPickerRow(
+                label = "标签",
+                allTags = tags,
+                selected = selectedTags,
+                onPick = { showTagPicker = true }
+            )
+            ResourceCharacterPickerRow(
+                label = "角色",
+                characters = characters,
+                selected = selectedCharacters,
+                onPick = { showCharacterPicker = true }
+            )
+        }
+    }
+
+    if (showTagPicker) {
+        TagPickerDialog(
+            categories = categories,
+            tags = tags,
+            selectedIds = selectedTags,
+            onConfirm = { selectedTags = it },
+            onDismiss = { showTagPicker = false }
+        )
+    }
+    if (showCharacterPicker) {
+        CharacterPickerDialog(
+            characters = characters,
+            selectedIds = selectedCharacters,
+            onConfirm = { selectedCharacters = it },
+            onDismiss = { showCharacterPicker = false }
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ResourceTagPickerRow(
+    label: String,
+    allTags: List<TagEntity>,
+    selected: Set<Long>,
+    onPick: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(label, style = MaterialTheme.typography.titleMedium)
+            TextButton(onClick = onPick) { Text("选择") }
+        }
+        val selectedTags = allTags.filter { selected.contains(it.id) }
+        if (selectedTags.isEmpty()) {
+            Text("未选择标签", style = MaterialTheme.typography.labelMedium)
+        } else {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                selectedTags.forEach { tag ->
+                    TagBadge(tag = tag)
+                }
             }
         }
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ResourceCharacterPickerRow(
+    label: String,
+    characters: List<CharacterEntity>,
+    selected: Set<Long>,
+    onPick: () -> Unit
+) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Text(label, style = MaterialTheme.typography.titleMedium)
+            TextButton(onClick = onPick) { Text("选择") }
+        }
+        val selectedCharacters = characters.filter { selected.contains(it.id) }
+        if (selectedCharacters.isEmpty()) {
+            Text("未选择角色", style = MaterialTheme.typography.labelMedium)
+        } else {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                selectedCharacters.forEach { character ->
+                    AssistChip(onClick = {}, label = { Text(character.name) })
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagPickerDialog(
+    categories: List<TagCategoryEntity>,
+    tags: List<TagEntity>,
+    selectedIds: Set<Long>,
+    onConfirm: (Set<Long>) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var selected by remember { mutableStateOf(selectedIds.toMutableSet()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("选择标签") },
+        text = {
+            TagSelectionSection(
+                label = "标签",
+                categories = categories,
+                tags = tags,
+                selected = selected,
+                onChange = { selected = it.toMutableSet() }
+            )
+        },
+        confirmButton = { TextButton(onClick = { onConfirm(selected); onDismiss() }) { Text("确定") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun ResourceGridItem(
-    resource: ResourceWithTagsCharacters,
-    onClick: () -> Unit,
-    onLongClick: () -> Unit
+private fun CharacterPickerDialog(
+    characters: List<CharacterEntity>,
+    selectedIds: Set<Long>,
+    onConfirm: (Set<Long>) -> Unit,
+    onDismiss: () -> Unit
 ) {
-    val tagLabel = resource.tags.joinToString("、") { it.name }.ifBlank { "无标签" }
-    val subtitle = "${typeLabel(resource.resource.type)}\n标签：$tagLabel"
-    SquareGridItem(
-        title = resource.resource.title,
-        subtitle = subtitle,
-        onClick = onClick,
-        onLongClick = onLongClick
+    var selected by remember { mutableStateOf(selectedIds.toMutableSet()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("选择角色") },
+        text = {
+            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                characters.forEach { character ->
+                    val isSelected = selected.contains(character.id)
+                    FilterChip(
+                        selected = isSelected,
+                        onClick = {
+                            if (isSelected) selected.remove(character.id) else selected.add(character.id)
+                            selected = selected.toMutableSet()
+                        },
+                        label = { Text(character.name) },
+                        colors = FilterChipDefaults.filterChipColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    )
+                }
+            }
+        },
+        confirmButton = { TextButton(onClick = { onConfirm(selected); onDismiss() }) { Text("确定") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )
 }
 
@@ -742,10 +777,10 @@ private fun TagSelectionSection(
         }
         if (uncategorized.isNotEmpty()) {
             Text("其他", style = MaterialTheme.typography.labelMedium)
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
                 uncategorized.forEach { tag ->
                     TagFilterChip(
                         tag = tag,
@@ -766,7 +801,7 @@ private fun TagFilterChip(
 ) {
     val isSelected = selected.contains(tag.id)
     val tagColor = Color(tag.colorArgb)
-    val selectedTextColor = if (tagColor.luminance() < 0.5f) Color.White else Color.Black
+    val selectedTextColor = tagTextColor(tagColor)
     FilterChip(
         selected = isSelected,
         onClick = {
@@ -776,45 +811,10 @@ private fun TagFilterChip(
         },
         label = { Text(tag.name) },
         colors = FilterChipDefaults.filterChipColors(
-            containerColor = Color.White,
+            containerColor = tagColor.copy(alpha = 0.2f),
             selectedContainerColor = tagColor,
             labelColor = MaterialTheme.colorScheme.onSurface,
             selectedLabelColor = selectedTextColor
         )
     )
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun CharacterSelectionSection(
-    label: String,
-    characters: List<com.example.quotepicker.data.CharacterEntity>,
-    selected: Set<Long>,
-    onChange: (Set<Long>) -> Unit
-) {
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text(label)
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            characters.forEach { character ->
-                val isSelected = selected.contains(character.id)
-                FilterChip(
-                    selected = isSelected,
-                    onClick = {
-                        val newSet = selected.toMutableSet()
-                        if (isSelected) newSet.remove(character.id) else newSet.add(character.id)
-                        onChange(newSet)
-                    },
-                    label = { Text(character.name) },
-                    colors = FilterChipDefaults.filterChipColors(
-                        containerColor = Color.White,
-                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
-                    )
-                )
-            }
-        }
-    }
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceGridCard.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceGridCard.kt
@@ -1,0 +1,75 @@
+package com.example.quotepicker.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.example.quotepicker.data.TagEntity
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
+@Composable
+fun ResourceGridCard(
+    title: String,
+    typeLabel: String,
+    tags: List<TagEntity>,
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .aspectRatio(1f)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick),
+        colors = CardDefaults.outlinedCardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(10.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(6.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyMedium,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis
+                )
+                Text(text = typeLabel, style = MaterialTheme.typography.labelSmall)
+                if (tags.isNotEmpty()) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        tags.forEach { tag ->
+                            TagBadge(tag = tag)
+                        }
+                    }
+                } else {
+                    Spacer(modifier = Modifier.padding(top = 4.dp))
+                    Text(text = "无标签", style = MaterialTheme.typography.labelSmall)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -17,9 +17,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -42,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
+import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -57,6 +59,7 @@ fun ResourcePreviewScreen(
     onBack: () -> Unit
 ) {
     var bitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
+    var quoteImages by remember { mutableStateOf<List<android.graphics.Bitmap>>(emptyList()) }
     var mediaUri by remember { mutableStateOf<Uri?>(null) }
     var sceneMessages by remember { mutableStateOf<List<SceneMessage>>(emptyList()) }
     val scrollState = rememberScrollState()
@@ -69,11 +72,13 @@ fun ResourcePreviewScreen(
                 val bytes = vm.loadDecryptedBytes(path)
                 android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
             }
-            ResourceType.QUOTE -> {
-                val b64 = res.quoteImageBase64 ?: return@LaunchedEffect
-                vm.decodeBase64ToBitmap(b64)
-            }
+            ResourceType.QUOTE -> null
             else -> null
+        }
+        quoteImages = if (res.type == ResourceType.QUOTE) {
+            decodeQuoteImages(res.quoteImageBase64, vm)
+        } else {
+            emptyList()
         }
         mediaUri = when (res.type) {
             ResourceType.VIDEO, ResourceType.AUDIO -> {
@@ -116,7 +121,7 @@ fun ResourcePreviewScreen(
             if (resource.tags.isNotEmpty()) {
                 FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                     resource.tags.forEach { tag ->
-                        AssistChip(onClick = {}, label = { Text(tag.name) })
+                        TagBadge(tag = tag)
                     }
                 }
             } else {
@@ -137,13 +142,7 @@ fun ResourcePreviewScreen(
                             if (!resource.resource.quoteText.isNullOrBlank()) {
                                 Text(resource.resource.quoteText.orEmpty())
                             }
-                            bitmap?.let {
-                                Image(
-                                    bitmap = it.asImageBitmap(),
-                                    contentDescription = null,
-                                    modifier = Modifier.fillMaxWidth()
-                                )
-                            }
+                            QuoteImagePager(images = quoteImages)
                         }
                         ResourceType.IMAGE -> {
                             bitmap?.let {
@@ -245,4 +244,46 @@ private fun parseSceneMessages(raw: String): List<SceneMessage> {
             }
         }
     }.getOrDefault(emptyList())
+}
+
+@Composable
+private fun QuoteImagePager(images: List<android.graphics.Bitmap>) {
+    if (images.isEmpty()) return
+    if (images.size == 1) {
+        Image(
+            bitmap = images.first().asImageBitmap(),
+            contentDescription = null,
+            modifier = Modifier.fillMaxWidth()
+        )
+        return
+    }
+    val pagerState = rememberPagerState(pageCount = { images.size })
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        HorizontalPager(state = pagerState, modifier = Modifier.fillMaxWidth()) { page ->
+            Image(
+                bitmap = images[page].asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+        Text(
+            text = "${pagerState.currentPage + 1}/${images.size}",
+            style = MaterialTheme.typography.labelSmall,
+            modifier = Modifier.align(Alignment.CenterHorizontally)
+        )
+    }
+}
+
+private fun decodeQuoteImages(payload: String?, vm: ResourceViewModel): List<android.graphics.Bitmap> {
+    if (payload.isNullOrBlank()) return emptyList()
+    val base64List = runCatching {
+        val array = JSONArray(payload)
+        buildList {
+            for (i in 0 until array.length()) {
+                val item = array.optString(i)
+                if (item.isNotBlank()) add(item)
+            }
+        }
+    }.getOrElse { listOf(payload) }
+    return base64List.mapNotNull { vm.decodeBase64ToBitmap(it) }
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/TagBadge.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/TagBadge.kt
@@ -1,0 +1,33 @@
+package com.example.quotepicker.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.unit.dp
+import com.example.quotepicker.data.TagEntity
+
+@Composable
+fun TagBadge(
+    tag: TagEntity,
+    modifier: Modifier = Modifier
+) {
+    val bg = Color(tag.colorArgb)
+    val textColor = tagTextColor(bg)
+    Box(
+        modifier = modifier
+            .background(bg, shape = MaterialTheme.shapes.small)
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Text(text = tag.name, color = textColor, style = MaterialTheme.typography.labelSmall)
+    }
+}
+
+fun tagTextColor(color: Color): Color {
+    return if (color.luminance() < 0.5f) Color.White else Color.Black
+}

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -96,12 +96,15 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             )
         }
 
-    fun addImageQuote(title: String, imageUri: Uri, tagIds: List<Long>, characterIds: List<Long>) =
+    fun addImageQuote(title: String, imageUris: List<Uri>, tagIds: List<Long>, characterIds: List<Long>) =
         viewModelScope.launch(Dispatchers.IO) {
             if (characterIds.isEmpty()) return@launch
-            val base64 = ImageCompression.encodeToBase64(getApplication(), imageUri)
+            val base64List = imageUris.mapNotNull { uri ->
+                ImageCompression.encodeToBase64(getApplication(), uri).ifBlank { null }
+            }
+            val payload = org.json.JSONArray(base64List).toString()
             repo.addResource(
-                ResourceEntity(type = ResourceType.QUOTE, title = title, quoteImageBase64 = base64),
+                ResourceEntity(type = ResourceType.QUOTE, title = title, quoteImageBase64 = payload),
                 tagIds,
                 characterIds
             )
@@ -132,7 +135,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         if (characterIds.isEmpty()) return@launch
         val targetName = "${type.name.lowercase()}_${System.currentTimeMillis()}.enc"
         val input = getApplication<Application>().contentResolver.openInputStream(uri) ?: return@launch
-        val encryptedFile = fileManager.encryptToFile(input, targetName)
+        val encryptedFile = runCatching { input.use { fileManager.encryptToFile(it, targetName) } }.getOrNull() ?: return@launch
         repo.addResource(
             ResourceEntity(
                 type = type,


### PR DESCRIPTION
### Motivation

- Implement UX changes to make media creation consistent with images: show a full-page form first and then select video/audio files, and to avoid modal-only flows for resource creation/editing. 
- Make tags visually prominent by rendering colored backgrounds wherever tags are shown. 
- Support multi-image "图片文本" resources and provide a paged preview UI for browsing multiple bound images.

### Description

- Replace small modal dialogs for creating/editing resources with full-page screens: new `ResourceCreateScreen` and `ResourceEditScreen` flow controlled from `ResourceScreen` and represented by `CreateMode` (text, image-text, scene, media). (see `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`).
- Add reusable tag UI and card components: `TagBadge` (`app/src/main/java/com/example/quotepicker/ui/components/TagBadge.kt`) and `ResourceGridCard` (`app/src/main/java/com/example/quotepicker/ui/components/ResourceGridCard.kt`) and switch lists/previews to use them so tags render with background color and readable text color via `tagTextColor`.
- Support multi-image quotes: `ResourceViewModel.addImageQuote` now accepts `List<Uri>` and stores a JSON array of base64 payloads; preview uses a `QuoteImagePager` with `HorizontalPager` to page through decoded bitmaps (`app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`).
- Safer media encryption handling: `addEncryptedMedia` wraps input stream usage and handles encryption with `runCatching` to avoid leaking streams or throwing during encryption (`app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt`).
- Update tag selection chips to show a faint colored container when unselected and full tag color when selected (`containerColor = tagColor.copy(alpha = 0.2f)` and `selectedContainerColor = tagColor`) and compute label contrast with `tagTextColor`.

### Testing

- No automated tests were executed as part of this change. 
- Manual/local verification steps are recommended: build the app, exercise creating/editing resources (text/image/video/audio/scene), pick tags/roles, and preview multi-image quotes to validate paging and tag rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969db0e94f4832bbb191b60f7d628d8)