### PR TITLE
Opt in to ExperimentalFoundationApi for pager in ResourcePreviewScreen

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -51,7 +52,7 @@ import org.json.JSONArray
 
 private data class SceneMessage(val speaker: String, val content: String)
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun ResourcePreviewScreen(
     resource: ResourceWithTagsCharacters,


### PR DESCRIPTION
### Motivation
- Enable use of the foundation pager APIs so the preview screen can use `HorizontalPager` and `rememberPagerState` without experimental API errors.

### Description
- Added the `ExperimentalFoundationApi` import and included it in the `@OptIn` annotation in `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969df7c7544832b9c90293446968906)