### PR TITLE
Opt in to ExperimentalFoundationApi for HorizontalPager usage

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -51,7 +52,7 @@ import org.json.JSONArray
 
 private data class SceneMessage(val speaker: String, val content: String)
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun ResourcePreviewScreen(
     resource: ResourceWithTagsCharacters,
@@ -246,6 +247,7 @@ private fun parseSceneMessages(raw: String): List<SceneMessage> {
     }.getOrDefault(emptyList())
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun QuoteImagePager(images: List<android.graphics.Bitmap>) {
     if (images.isEmpty()) return


### PR DESCRIPTION
### Motivation
- Enable use of `HorizontalPager` and `rememberPagerState` without experimental API compile errors by opting into `ExperimentalFoundationApi`.

### Description
- Added `import androidx.compose.foundation.ExperimentalFoundationApi` and included `ExperimentalFoundationApi` in the file-level `@OptIn` on `ResourcePreviewScreen`.
- Annotated `QuoteImagePager` with `@OptIn(ExperimentalFoundationApi::class)` where `HorizontalPager` and `rememberPagerState` are used to silence remaining experimental API errors.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969df7c7544832b9c90293446968906)