### PR TITLE
Improve resource/tag UX, real-time character refresh, media handling, and gate visuals

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Dao.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Dao.kt
@@ -13,6 +13,9 @@ interface TagCategoryDao {
     @Query("SELECT * FROM tag_categories ORDER BY name COLLATE NOCASE ASC")
     fun observeCategories(): Flow<List<TagCategoryEntity>>
 
+    @Query("SELECT * FROM tag_categories WHERE name = :name LIMIT 1")
+    suspend fun findByName(name: String): TagCategoryEntity?
+
     @Insert
     suspend fun insert(category: TagCategoryEntity): Long
 
@@ -39,6 +42,9 @@ interface TagDao {
 
     @Delete
     suspend fun delete(tag: TagEntity)
+
+    @Query("UPDATE tags SET categoryId = :newCategoryId WHERE categoryId = :oldCategoryId")
+    suspend fun reassignCategory(oldCategoryId: Long, newCategoryId: Long)
 }
 
 @Dao

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -21,7 +21,19 @@ class Repository private constructor(context: Context) {
 
     suspend fun addCategory(name: String) = categoryDao.insert(TagCategoryEntity(name = name))
     suspend fun updateCategory(category: TagCategoryEntity) = categoryDao.update(category.copy(updatedAt = System.currentTimeMillis()))
-    suspend fun deleteCategory(category: TagCategoryEntity) = categoryDao.delete(category)
+    suspend fun deleteCategory(category: TagCategoryEntity) {
+        if (category.name == ORPHAN_CATEGORY_NAME) return
+        val orphan = ensureOrphanCategory()
+        tagDao.reassignCategory(category.id, orphan.id)
+        categoryDao.delete(category)
+    }
+
+    suspend fun ensureOrphanCategory(): TagCategoryEntity {
+        val existing = categoryDao.findByName(ORPHAN_CATEGORY_NAME)
+        if (existing != null) return existing
+        val id = categoryDao.insert(TagCategoryEntity(name = ORPHAN_CATEGORY_NAME))
+        return TagCategoryEntity(id = id, name = ORPHAN_CATEGORY_NAME)
+    }
 
     suspend fun addTag(categoryId: Long, name: String, colorArgb: Int) =
         tagDao.insert(TagEntity(categoryId = categoryId, name = name, colorArgb = colorArgb))
@@ -72,6 +84,7 @@ class Repository private constructor(context: Context) {
     suspend fun resourceIdsForTags(tagIds: List<Long>) = crossRefDao.resourceIdsForTags(tagIds)
 
     companion object {
+        const val ORPHAN_CATEGORY_NAME = "未分类"
         @Volatile private var INSTANCE: Repository? = null
         fun get(context: Context): Repository =
             INSTANCE ?: synchronized(this) {

--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material3.AssistChip
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -68,8 +69,9 @@ fun CharacterScreen(
     resourceVm: ResourceViewModel = viewModel()
 ) {
     val ui by vm.uiState.collectAsState()
-    val resources by resourceVm.uiState.collectAsState()
-    var selected by remember { mutableStateOf<CharacterWithTags?>(null) }
+    val resources by resourceVm.allResources.collectAsState()
+    var selectedId by remember { mutableStateOf<Long?>(null) }
+    val selected = ui.characters.firstOrNull { it.character.id == selectedId }
     var showAddDialog by remember { mutableStateOf(false) }
     var editCharacter by remember { mutableStateOf<CharacterEntity?>(null) }
     var showTagPicker by remember { mutableStateOf(false) }
@@ -79,6 +81,11 @@ fun CharacterScreen(
     var selectedTagIds by remember { mutableStateOf(setOf<Long>()) }
     var selectedType by remember { mutableStateOf<ResourceType?>(null) }
     var previewTarget by remember { mutableStateOf<com.example.quotepicker.data.ResourceWithTagsCharacters?>(null) }
+
+    LaunchedEffect(selectedId) {
+        selectedTagIds = emptySet()
+        selectedType = null
+    }
 
     if (previewTarget != null) {
         ResourcePreviewScreen(
@@ -96,7 +103,7 @@ fun CharacterScreen(
                 title = { Text(selected?.character?.name ?: "角色") },
                 navigationIcon = {
                     if (selected != null) {
-                        IconButton(onClick = { selected = null }) {
+                        IconButton(onClick = { selectedId = null }) {
                             Icon(Icons.Default.ArrowBack, contentDescription = "返回")
                         }
                     }
@@ -127,7 +134,7 @@ fun CharacterScreen(
                         items(ui.characters, key = { it.character.id }) { character ->
                             SquareGridItem(
                                 title = character.character.name,
-                                onClick = { selected = character },
+                                onClick = { selectedId = character.character.id },
                                 onLongClick = { bottomSheetTarget = character }
                             )
                         }
@@ -147,7 +154,7 @@ fun CharacterScreen(
                     onTypeChange = { selectedType = it },
                     onTagDialog = { filterTagDialog = true }
                 )
-                val filteredResources = resources.resources.filter {
+                val filteredResources = resources.filter {
                     it.characters.any { c -> c.id == char.id }
                 }.filter { res ->
                     val typeMatch = selectedType?.let { it == res.resource.type } ?: true
@@ -328,7 +335,7 @@ private fun TagSummarySection(
         }
         val uncategorized = tags.filter { it.categoryId !in categoryMap.keys }
         if (uncategorized.isNotEmpty()) {
-            Text("其他", style = MaterialTheme.typography.labelMedium)
+            Text("未分类", style = MaterialTheme.typography.labelMedium)
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -350,7 +357,14 @@ private fun CharacterResourceFilterBar(
 ) {
     Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp)) {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            ResourceType.values().forEach { type ->
+            val orderedTypes = listOf(
+                ResourceType.QUOTE,
+                ResourceType.IMAGE,
+                ResourceType.VIDEO,
+                ResourceType.SCENE,
+                ResourceType.AUDIO
+            )
+            orderedTypes.forEach { type ->
                 FilterChip(
                     selected = selectedType == type,
                     onClick = { onTypeChange(if (selectedType == type) null else type) },
@@ -476,7 +490,7 @@ private fun TagSelectionSection(
             }
         }
         if (uncategorized.isNotEmpty()) {
-            Text("其他", style = MaterialTheme.typography.labelMedium)
+            Text("未分类", style = MaterialTheme.typography.labelMedium)
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)

--- a/app/src/main/java/com/example/quotepicker/ui/GateScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/GateScreen.kt
@@ -2,18 +2,23 @@ package com.example.quotepicker.ui
 
 import androidx.compose.animation.core.Animatable
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
@@ -62,9 +67,39 @@ fun GateScreen(onPassed: () -> Unit) {
         ),
         label = "magicCircleRotation"
     )
+    val counterRotation by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = -360f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(4200),
+            repeatMode = RepeatMode.Restart
+        ),
+        label = "magicCircleCounterRotation"
+    )
+    val pulse by infiniteTransition.animateFloat(
+        initialValue = 0.92f,
+        targetValue = 1.08f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1400),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "magicCirclePulse"
+    )
+    val glowAlpha by infiniteTransition.animateFloat(
+        initialValue = 0.15f,
+        targetValue = 0.45f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(1600),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "magicCircleGlow"
+    )
     val density = LocalDensity.current
     val circleSize = 156.dp
+    val innerSize = 110.dp
+    val outerSize = 230.dp
     val circleSizePx = with(density) { circleSize.toPx() }
+    val outerSizePx = with(density) { outerSize.toPx() }
 
     // 解锁目标顺序：右上3次 → 左上1次 → 左下2次
     val targets = listOf(
@@ -138,25 +173,59 @@ fun GateScreen(onPassed: () -> Unit) {
             }
     )
     touchPosition?.let { pos ->
-        Image(
-            painter = painterResource(id = com.example.quotepicker.R.drawable.magic_circle),
-            contentDescription = null,
+        Box(
             modifier = Modifier
                 .offset {
                     IntOffset(
-                        (pos.x - circleSizePx / 2f).roundToInt(),
-                        (pos.y - circleSizePx / 2f).roundToInt()
+                        (pos.x - outerSizePx / 2f).roundToInt(),
+                        (pos.y - outerSizePx / 2f).roundToInt()
                     )
                 }
-                .size(circleSize)
-                .background(Color.Transparent)
-                .graphicsLayer(
-                    alpha = opacity.value,
-                    rotationZ = rotation,
-                    shadowElevation = with(density) { 12.dp.toPx() },
-                    scaleX = 1.05f,
-                    scaleY = 1.05f
+                .size(outerSize)
+                .graphicsLayer(alpha = opacity.value)
+        ) {
+            Canvas(
+                modifier = Modifier
+                    .matchParentSize()
+                    .graphicsLayer(scaleX = pulse, scaleY = pulse, alpha = glowAlpha)
+            ) {
+                val radius = size.minDimension / 2f
+                drawCircle(
+                    brush = Brush.radialGradient(
+                        colors = listOf(Color(0xFF7B4DFF), Color.Transparent)
+                    ),
+                    radius = radius
                 )
-        )
+                drawCircle(
+                    color = Color(0xFFB388FF).copy(alpha = 0.5f),
+                    radius = radius * 0.88f,
+                    style = Stroke(width = radius * 0.08f)
+                )
+            }
+            Image(
+                painter = painterResource(id = com.example.quotepicker.R.drawable.magic_circle),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(circleSize)
+                    .align(Alignment.Center)
+                    .graphicsLayer(
+                        rotationZ = rotation,
+                        shadowElevation = with(density) { 14.dp.toPx() },
+                        scaleX = 1.08f,
+                        scaleY = 1.08f
+                    )
+            )
+            Image(
+                painter = painterResource(id = com.example.quotepicker.R.drawable.magic_circle),
+                contentDescription = null,
+                modifier = Modifier
+                    .size(innerSize)
+                    .align(Alignment.Center)
+                    .graphicsLayer(
+                        rotationZ = counterRotation,
+                        alpha = 0.85f
+                    )
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
@@ -6,6 +6,12 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.Icon
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Casino
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.LocalOffer
+import androidx.compose.material.icons.filled.Person
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -13,9 +19,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.ui.unit.dp
 
 @Composable
 fun MainScreen() {
@@ -27,25 +30,25 @@ fun MainScreen() {
                 NavigationBarItem(
                     selected = currentTab == 0,
                     onClick = { currentTab = 0 },
-                    icon = { Spacer(Modifier.size(0.dp)) },
+                    icon = { Icon(Icons.Default.LocalOffer, contentDescription = null) },
                     label = { Text("标签") }
                 )
                 NavigationBarItem(
                     selected = currentTab == 1,
                     onClick = { currentTab = 1 },
-                    icon = { Spacer(Modifier.size(0.dp)) },
+                    icon = { Icon(Icons.Default.Person, contentDescription = null) },
                     label = { Text("角色") }
                 )
                 NavigationBarItem(
                     selected = currentTab == 2,
                     onClick = { currentTab = 2 },
-                    icon = { Spacer(Modifier.size(0.dp)) },
+                    icon = { Icon(Icons.Default.Folder, contentDescription = null) },
                     label = { Text("资源") }
                 )
                 NavigationBarItem(
                     selected = currentTab == 3,
                     onClick = { currentTab = 3 },
-                    icon = { Spacer(Modifier.size(0.dp)) },
+                    icon = { Icon(Icons.Default.Casino, contentDescription = null) },
                     label = { Text("随机") }
                 )
             }

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -4,11 +4,17 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Casino
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.SkipNext
+import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -37,12 +43,28 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
     }
 
     Column(modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(onClick = { vm.randomCharacter() }) { Text("随机角色") }
+        Button(onClick = { vm.randomCharacter() }) {
+            Icon(Icons.Default.Casino, contentDescription = null)
+            Spacer(Modifier.width(8.dp))
+            Text("随机角色")
+        }
         Text(ui.selectedCharacter?.name ?: "未选择角色")
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            Button(onClick = { vm.randomResource() }, enabled = ui.selectedCharacter != null) { Text("随机资源") }
-            Button(onClick = { vm.nextResource() }, enabled = ui.selectedCharacter != null) { Text("下一个") }
-            Button(onClick = { vm.reset() }) { Text("重置") }
+            Button(onClick = { vm.randomResource() }, enabled = ui.selectedCharacter != null) {
+                Icon(Icons.Default.Casino, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("随机资源")
+            }
+            Button(onClick = { vm.nextResource() }, enabled = ui.selectedCharacter != null) {
+                Icon(Icons.Default.SkipNext, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("下一个")
+            }
+            Button(onClick = { vm.reset() }) {
+                Icon(Icons.Default.Refresh, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("重置")
+            }
         }
         Spacer(Modifier.height(8.dp))
         val res = ui.selectedResource
@@ -50,7 +72,11 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
             Text("暂无资源")
         } else {
             Text("当前资源：${res.resource.title}")
-            Button(onClick = { showPreview = true }) { Text("预览") }
+            Button(onClick = { showPreview = true }) {
+                Icon(Icons.Default.Visibility, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("预览")
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -21,8 +21,13 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Description
+import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.MusicNote
+import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -162,13 +167,29 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     if (showAddMenu) {
         ModalBottomSheet(onDismissRequest = { showAddMenu = false }) {
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                TextButton(onClick = { createMode = CreateMode.Text; showAddMenu = false }) { Text("创建文本") }
-                TextButton(onClick = { createMode = CreateMode.ImageText; showAddMenu = false }) { Text("创建图片文本") }
-                TextButton(onClick = { createMode = CreateMode.Scene; showAddMenu = false }) { Text("创建聊天情景") }
+                TextButton(onClick = { createMode = CreateMode.Text; showAddMenu = false }) {
+                    Icon(Icons.Default.Description, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("创建文本")
+                }
+                TextButton(onClick = { createMode = CreateMode.ImageText; showAddMenu = false }) {
+                    Icon(Icons.Default.Image, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("创建图片文本")
+                }
+                TextButton(onClick = { createMode = CreateMode.Scene; showAddMenu = false }) {
+                    Icon(Icons.Default.Chat, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("创建聊天情景")
+                }
                 TextButton(onClick = { createMode = CreateMode.Media(ResourceType.VIDEO); showAddMenu = false }) {
+                    Icon(Icons.Default.Videocam, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
                     Text("创建视频文本")
                 }
                 TextButton(onClick = { createMode = CreateMode.Media(ResourceType.AUDIO); showAddMenu = false }) {
+                    Icon(Icons.Default.MusicNote, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
                     Text("创建声音文本")
                 }
             }
@@ -244,6 +265,8 @@ private sealed class CreateMode {
     data class Media(val type: ResourceType) : CreateMode()
 }
 
+private data class SceneDraftMessage(val speaker: String, val content: String)
+
 @Composable
 private fun FilterBar(
     selectedType: ResourceType?,
@@ -256,7 +279,14 @@ private fun FilterBar(
 ) {
     Column(Modifier.fillMaxWidth().padding(12.dp)) {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            ResourceType.values().forEach { type ->
+            val orderedTypes = listOf(
+                ResourceType.QUOTE,
+                ResourceType.IMAGE,
+                ResourceType.VIDEO,
+                ResourceType.SCENE,
+                ResourceType.AUDIO
+            )
+            orderedTypes.forEach { type ->
                 FilterChip(
                     selected = selectedType == type,
                     onClick = { onTypeChange(if (selectedType == type) null else type) },
@@ -382,19 +412,25 @@ private fun ResourceCreateScreen(
     var title by remember { mutableStateOf("") }
     var quoteText by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
-    var sceneJson by remember { mutableStateOf("") }
+    var sceneMessages by remember { mutableStateOf<List<SceneDraftMessage>>(emptyList()) }
     var selectedTags by remember { mutableStateOf(setOf<Long>()) }
     var selectedCharacters by remember { mutableStateOf(setOf<Long>()) }
     var imageUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var mediaUri by remember { mutableStateOf<Uri?>(null) }
+    var videoUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var showTagPicker by remember { mutableStateOf(false) }
     var showCharacterPicker by remember { mutableStateOf(false) }
+    var showSceneDialog by remember { mutableStateOf(false) }
+    var editSceneIndex by remember { mutableStateOf<Int?>(null) }
 
     val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) {
         imageUris = it
     }
     val mediaPicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
         mediaUri = uri
+    }
+    val videoPicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
+        videoUris = uris
     }
 
     val screenTitle = when (mode) {
@@ -407,8 +443,8 @@ private fun ResourceCreateScreen(
     val canSubmit = title.isNotBlank() && selectedCharacters.isNotEmpty() && when (mode) {
         CreateMode.Text -> true
         CreateMode.ImageText -> imageUris.isNotEmpty()
-        CreateMode.Scene -> true
-        is CreateMode.Media -> mediaUri != null
+        CreateMode.Scene -> sceneMessages.isNotEmpty()
+        is CreateMode.Media -> if (mode.type == ResourceType.VIDEO) videoUris.isNotEmpty() else mediaUri != null
     }
 
     Scaffold(
@@ -438,17 +474,33 @@ private fun ResourceCreateScreen(
                             CreateMode.Scene -> vm.addScene(
                                 title.trim(),
                                 description.ifBlank { null },
-                                sceneJson,
+                                buildSceneJson(sceneMessages),
                                 selectedTags.toList(),
                                 selectedCharacters.toList()
                             )
                             is CreateMode.Media -> vm.addEncryptedMedia(
                                 mode.type,
                                 title.trim(),
-                                mediaUri ?: return@TextButton,
+                                if (mode.type == ResourceType.VIDEO) {
+                                    val uris = videoUris
+                                    uris.firstOrNull() ?: return@TextButton
+                                } else {
+                                    mediaUri ?: return@TextButton
+                                },
                                 selectedTags.toList(),
                                 selectedCharacters.toList()
                             )
+                        }
+                        if (mode is CreateMode.Media && mode.type == ResourceType.VIDEO && videoUris.size > 1) {
+                            videoUris.drop(1).forEachIndexed { index, uri ->
+                                vm.addEncryptedMedia(
+                                    mode.type,
+                                    "${title.trim()} (${index + 2})",
+                                    uri,
+                                    selectedTags.toList(),
+                                    selectedCharacters.toList()
+                                )
+                            }
                         }
                         onBack()
                     }, enabled = canSubmit) { Text("创建") }
@@ -479,7 +531,11 @@ private fun ResourceCreateScreen(
                     )
                 }
                 CreateMode.ImageText -> {
-                    TextButton(onClick = { imagePicker.launch("image/*") }) { Text("选择图片") }
+                    TextButton(onClick = { imagePicker.launch("image/*") }) {
+                        Icon(Icons.Default.Image, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("选择图片")
+                    }
                     Text(if (imageUris.isEmpty()) "未选择图片" else "已选择 ${imageUris.size} 张图片")
                 }
                 CreateMode.Scene -> {
@@ -489,23 +545,77 @@ private fun ResourceCreateScreen(
                         label = { Text("描述(可选)") },
                         modifier = Modifier.fillMaxWidth()
                     )
-                    OutlinedTextField(
-                        value = sceneJson,
-                        onValueChange = { sceneJson = it },
-                        label = { Text("对话JSON") },
-                        modifier = Modifier.fillMaxWidth()
-                    )
-                    Text(
-                        text = "示例：[{\"speaker\":\"小明\",\"text\":\"你好\"},{\"speaker\":\"小红\",\"text\":\"你好呀\"}]",
-                        style = MaterialTheme.typography.labelSmall
-                    )
+                    TextButton(onClick = { showSceneDialog = true }) {
+                        Icon(Icons.Default.Chat, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("添加对话")
+                    }
+                    if (sceneMessages.isEmpty()) {
+                        Text("暂无对话", style = MaterialTheme.typography.labelSmall)
+                    } else {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            sceneMessages.forEachIndexed { index, message ->
+                                androidx.compose.material3.OutlinedCard {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(12.dp),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Column(
+                                            modifier = Modifier.weight(1f),
+                                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                                        ) {
+                                            Text(
+                                                text = message.speaker.ifBlank { "角色" },
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.primary
+                                            )
+                                            Text(text = message.content)
+                                        }
+                                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                            IconButton(onClick = {
+                                                editSceneIndex = index
+                                                showSceneDialog = true
+                                            }) {
+                                                Icon(Icons.Default.Edit, contentDescription = "编辑")
+                                            }
+                                            IconButton(onClick = {
+                                                sceneMessages = sceneMessages.toMutableList().also { it.removeAt(index) }
+                                            }) {
+                                                Icon(Icons.Default.Delete, contentDescription = "删除")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
                 is CreateMode.Media -> {
                     val label = if (mode.type == ResourceType.VIDEO) "选择视频" else "选择声音"
-                    TextButton(onClick = { mediaPicker.launch(if (mode.type == ResourceType.VIDEO) "video/*" else "audio/*") }) {
+                    TextButton(
+                        onClick = {
+                            if (mode.type == ResourceType.VIDEO) {
+                                videoPicker.launch("video/*")
+                            } else {
+                                mediaPicker.launch("audio/*")
+                            }
+                        }
+                    ) {
+                        Icon(
+                            if (mode.type == ResourceType.VIDEO) Icons.Default.Videocam else Icons.Default.MusicNote,
+                            contentDescription = null
+                        )
+                        Spacer(Modifier.width(8.dp))
                         Text(label)
                     }
-                    Text(mediaUri?.toString() ?: "未选择文件")
+                    if (mode.type == ResourceType.VIDEO) {
+                        Text(if (videoUris.isEmpty()) "未选择视频" else "已选择 ${videoUris.size} 个视频")
+                    } else {
+                        Text(mediaUri?.toString() ?: "未选择文件")
+                    }
                 }
             }
             ResourceTagPickerRow(
@@ -538,6 +648,33 @@ private fun ResourceCreateScreen(
             selectedIds = selectedCharacters,
             onConfirm = { selectedCharacters = it },
             onDismiss = { showCharacterPicker = false }
+        )
+    }
+    if (showSceneDialog) {
+        SceneMessageDialog(
+            title = if (editSceneIndex == null) "添加对话" else "编辑对话",
+            initialSpeaker = editSceneIndex?.let { sceneMessages.getOrNull(it)?.speaker }.orEmpty(),
+            initialContent = editSceneIndex?.let { sceneMessages.getOrNull(it)?.content }.orEmpty(),
+            onConfirm = { speaker, content ->
+                if (speaker.isBlank() && content.isBlank()) {
+                    showSceneDialog = false
+                    editSceneIndex = null
+                } else {
+                    val updated = sceneMessages.toMutableList()
+                    if (editSceneIndex != null) {
+                        updated[editSceneIndex!!] = SceneDraftMessage(speaker.trim(), content.trim())
+                    } else {
+                        updated.add(SceneDraftMessage(speaker.trim(), content.trim()))
+                    }
+                    sceneMessages = updated
+                    showSceneDialog = false
+                    editSceneIndex = null
+                }
+            },
+            onDismiss = {
+                showSceneDialog = false
+                editSceneIndex = null
+            }
         )
     }
 }
@@ -776,7 +913,7 @@ private fun TagSelectionSection(
             }
         }
         if (uncategorized.isNotEmpty()) {
-            Text("其他", style = MaterialTheme.typography.labelMedium)
+            Text("未分类", style = MaterialTheme.typography.labelMedium)
             FlowRow(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)
@@ -817,4 +954,51 @@ private fun TagFilterChip(
             selectedLabelColor = selectedTextColor
         )
     )
+}
+
+@Composable
+private fun SceneMessageDialog(
+    title: String,
+    initialSpeaker: String,
+    initialContent: String,
+    onConfirm: (String, String) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var speaker by remember(initialSpeaker) { mutableStateOf(initialSpeaker) }
+    var content by remember(initialContent) { mutableStateOf(initialContent) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = speaker,
+                    onValueChange = { speaker = it },
+                    label = { Text("角色") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = content,
+                    onValueChange = { content = it },
+                    label = { Text("说话内容") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(speaker, content) }) { Text("确定") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
+}
+
+private fun buildSceneJson(messages: List<SceneDraftMessage>): String {
+    val array = org.json.JSONArray()
+    messages.forEach { message ->
+        val obj = org.json.JSONObject()
+        obj.put("speaker", message.speaker)
+        obj.put("text", message.content)
+        array.put(obj)
+    }
+    return array.toString()
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceGridCard.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceGridCard.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -49,13 +50,18 @@ fun ResourceGridCard(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Text(
+                    text = typeLabel,
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    color = Color(0xFF7B4DFF)
+                )
+                Text(
                     text = title,
                     style = MaterialTheme.typography.bodyMedium,
                     fontWeight = FontWeight.Bold,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
                 )
-                Text(text = typeLabel, style = MaterialTheme.typography.labelSmall)
                 if (tags.isNotEmpty()) {
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(6.dp),

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.AssistChip
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -59,7 +60,6 @@ fun ResourcePreviewScreen(
     vm: ResourceViewModel,
     onBack: () -> Unit
 ) {
-    var bitmap by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
     var quoteImages by remember { mutableStateOf<List<android.graphics.Bitmap>>(emptyList()) }
     var mediaUri by remember { mutableStateOf<Uri?>(null) }
     var sceneMessages by remember { mutableStateOf<List<SceneMessage>>(emptyList()) }
@@ -67,19 +67,17 @@ fun ResourcePreviewScreen(
 
     LaunchedEffect(resource.resource.id) {
         val res = resource.resource
-        bitmap = when (res.type) {
-            ResourceType.IMAGE -> {
-                val path = res.contentUriOrPath ?: return@LaunchedEffect
+        quoteImages = emptyList()
+        if (res.type == ResourceType.IMAGE) {
+            val images = mutableListOf<android.graphics.Bitmap>()
+            res.contentUriOrPath?.let { path ->
                 val bytes = vm.loadDecryptedBytes(path)
-                android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+                android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.let { images.add(it) }
             }
-            ResourceType.QUOTE -> null
-            else -> null
-        }
-        quoteImages = if (res.type == ResourceType.QUOTE) {
-            decodeQuoteImages(res.quoteImageBase64, vm)
-        } else {
-            emptyList()
+            images.addAll(decodeQuoteImages(res.quoteImageBase64, vm))
+            quoteImages = images
+        } else if (res.type == ResourceType.QUOTE) {
+            quoteImages = decodeQuoteImages(res.quoteImageBase64, vm)
         }
         mediaUri = when (res.type) {
             ResourceType.VIDEO, ResourceType.AUDIO -> {
@@ -128,6 +126,14 @@ fun ResourcePreviewScreen(
             } else {
                 Text("无标签", style = MaterialTheme.typography.labelMedium)
             }
+            if (resource.characters.isNotEmpty()) {
+                Text("角色", style = MaterialTheme.typography.labelMedium)
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    resource.characters.forEach { character ->
+                        AssistChip(onClick = {}, label = { Text(character.name) })
+                    }
+                }
+            }
 
             Card(
                 modifier = Modifier.fillMaxWidth()
@@ -146,13 +152,11 @@ fun ResourcePreviewScreen(
                             QuoteImagePager(images = quoteImages)
                         }
                         ResourceType.IMAGE -> {
-                            bitmap?.let {
-                                Image(
-                                    bitmap = it.asImageBitmap(),
-                                    contentDescription = null,
-                                    modifier = Modifier.fillMaxWidth()
-                                )
-                            } ?: Text("图片加载中…")
+                            if (quoteImages.isNotEmpty()) {
+                                QuoteImagePager(images = quoteImages)
+                            } else {
+                                Text("图片加载中…")
+                            }
                         }
                         ResourceType.VIDEO -> {
                             if (mediaUri != null) {

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -46,8 +46,11 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
 
     private val filters = MutableStateFlow(ResourceFilterState())
 
+    val allResources: StateFlow<List<ResourceWithTagsCharacters>> = repo.observeResourcesWithRelations()
+        .stateIn(viewModelScope, SharingStarted.Eagerly, emptyList())
+
     val uiState: StateFlow<ResourceUiState> = combine(
-        repo.observeResourcesWithRelations(),
+        allResources,
         repo.observeCategories(),
         repo.observeAllTags(),
         repo.observeCharacters(),
@@ -104,7 +107,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             }
             val payload = org.json.JSONArray(base64List).toString()
             repo.addResource(
-                ResourceEntity(type = ResourceType.QUOTE, title = title, quoteImageBase64 = payload),
+                ResourceEntity(type = ResourceType.IMAGE, title = title, quoteImageBase64 = payload),
                 tagIds,
                 characterIds
             )


### PR DESCRIPTION
### Motivation
- Make tag-category deletion safe by moving orphaned tags into a dedicated category instead of leaving them uncategorized. 
- Ensure character-related UI reflects changes immediately when selecting/editing characters and when resources are added. 
- Improve resource creation/preview for images and videos, support multi-video upload, and make the resource UI more discoverable and attractive. 
- Polish the white-screen gate animation to be visually richer and clearer for users. 

### Description
- Database and repository: added `TagCategoryDao.findByName` and `TagDao.reassignCategory`, and changed `Repository.deleteCategory` to reassign tags into an `ORPHAN_CATEGORY_NAME` (`"未分类"`) via `ensureOrphanCategory` before deleting a category. 
- Resource model & viewmodel: introduced `ResourceViewModel.allResources` `StateFlow` and switched UI usage to this unfiltered stream, and changed `addImageQuote` to store image quotes as `ResourceType.IMAGE` with base64 payload. 
- Character & resource UIs: switched character selection to track `selectedId` and derive the selected item so filters and resources refresh immediately, reset character-local filters on selection change with `LaunchedEffect`, and use `allResources` for real-time resource lists. 
- Resource creation & preview: reordered resource type chips to `文本, 图片, 视频, 情景, 声音` (text, image, video, scene, audio), added icons across creation menus and buttons, implemented dialog-based scene message editing with `SceneMessageDialog` and `buildSceneJson`, added multi-video picker and logic to upload multiple video files, moved resource `typeLabel` above the title with purple styling in `ResourceGridCard`, and enhanced `ResourcePreviewScreen` to show associated characters and support image galleries and video/audio preview via decrypted cached files. 
- Misc UI touches: added icons to bottom navigation (`MainScreen`) and `RandomScreen` buttons, and enhanced the gate screen `GateScreen` magic circle with layered glow, pulse, and counter-rotation effects. 

### Testing
- No automated tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969e5ace44c832b9b76b5c2d5a1a89e)