### PR TITLE
Replace matchParentSize with fillMaxSize in GateScreen

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/GateScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/GateScreen.kt
@@ -9,7 +9,6 @@ import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.*
@@ -186,7 +185,7 @@ fun GateScreen(onPassed: () -> Unit) {
         ) {
             Canvas(
                 modifier = Modifier
-                    .matchParentSize()
+                    .fillMaxSize()
                     .graphicsLayer(scaleX = pulse, scaleY = pulse, alpha = glowAlpha)
             ) {
                 val radius = size.minDimension / 2f


### PR DESCRIPTION
### Motivation
- Fix a canvas sizing/unresolved reference issue by replacing `matchParentSize` with `fillMaxSize` for the `Canvas` in `app/src/main/java/com/example/quotepicker/ui/GateScreen.kt`.

### Description
- Remove the `matchParentSize` import and change the `Canvas` modifier from `.matchParentSize()` to `.fillMaxSize()` so the radial glow covers the intended area.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ea3e3dfc832bb3dacc37838768c0)