### PR TITLE
Compact preview metadata, persist media URIs, and add scene "continue" action

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -1,5 +1,6 @@
 package com.example.quotepicker.ui
 
+import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -53,6 +54,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.ResourceType
@@ -423,14 +425,27 @@ private fun ResourceCreateScreen(
     var showSceneDialog by remember { mutableStateOf(false) }
     var editSceneIndex by remember { mutableStateOf<Int?>(null) }
 
+    val context = LocalContext.current
     val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) {
         imageUris = it
     }
-    val mediaPicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+    val mediaPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         mediaUri = uri
+        uri?.let {
+            context.contentResolver.takePersistableUriPermission(
+                it,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+        }
     }
-    val videoPicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
+    val videoPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
         videoUris = uris
+        uris.forEach { uri ->
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+        }
     }
 
     val screenTitle = when (mode) {
@@ -598,9 +613,9 @@ private fun ResourceCreateScreen(
                     TextButton(
                         onClick = {
                             if (mode.type == ResourceType.VIDEO) {
-                                videoPicker.launch("video/*")
+                                videoPicker.launch(arrayOf("video/*"))
                             } else {
-                                mediaPicker.launch("audio/*")
+                                mediaPicker.launch(arrayOf("audio/*"))
                             }
                         }
                     ) {
@@ -670,6 +685,17 @@ private fun ResourceCreateScreen(
                     showSceneDialog = false
                     editSceneIndex = null
                 }
+            },
+            onAddAnother = if (editSceneIndex == null) {
+                { speaker, content ->
+                    if (speaker.isNotBlank() || content.isNotBlank()) {
+                        val updated = sceneMessages.toMutableList()
+                        updated.add(SceneDraftMessage(speaker.trim(), content.trim()))
+                        sceneMessages = updated
+                    }
+                }
+            } else {
+                null
             },
             onDismiss = {
                 showSceneDialog = false
@@ -962,10 +988,12 @@ private fun SceneMessageDialog(
     initialSpeaker: String,
     initialContent: String,
     onConfirm: (String, String) -> Unit,
+    onAddAnother: ((String, String) -> Unit)?,
     onDismiss: () -> Unit
 ) {
     var speaker by remember(initialSpeaker) { mutableStateOf(initialSpeaker) }
     var content by remember(initialContent) { mutableStateOf(initialContent) }
+    val hasContent = speaker.isNotBlank() || content.isNotBlank()
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(title) },
@@ -986,7 +1014,19 @@ private fun SceneMessageDialog(
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(speaker, content) }) { Text("确定") }
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                if (onAddAnother != null) {
+                    TextButton(
+                        onClick = {
+                            onAddAnother(speaker, content)
+                            speaker = ""
+                            content = ""
+                        },
+                        enabled = hasContent
+                    ) { Text("继续添加") }
+                }
+                TextButton(onClick = { onConfirm(speaker, content) }, enabled = hasContent) { Text("确定") }
+            }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -6,6 +6,7 @@ import android.widget.VideoView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -117,21 +118,32 @@ fun ResourcePreviewScreen(
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold
             )
-            if (resource.tags.isNotEmpty()) {
-                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    resource.tags.forEach { tag ->
-                        TagBadge(tag = tag)
+            ResourceMetaRow(label = "标签") {
+                if (resource.tags.isNotEmpty()) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        resource.tags.forEach { tag ->
+                            TagBadge(tag = tag)
+                        }
                     }
+                } else {
+                    Text("无标签", style = MaterialTheme.typography.labelSmall)
                 }
-            } else {
-                Text("无标签", style = MaterialTheme.typography.labelMedium)
             }
-            if (resource.characters.isNotEmpty()) {
-                Text("角色", style = MaterialTheme.typography.labelMedium)
-                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    resource.characters.forEach { character ->
-                        AssistChip(onClick = {}, label = { Text(character.name) })
+            ResourceMetaRow(label = "角色") {
+                if (resource.characters.isNotEmpty()) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                        verticalArrangement = Arrangement.spacedBy(6.dp)
+                    ) {
+                        resource.characters.forEach { character ->
+                            AssistChip(onClick = {}, label = { Text(character.name) })
+                        }
                     }
+                } else {
+                    Text("未选择角色", style = MaterialTheme.typography.labelSmall)
                 }
             }
 
@@ -249,6 +261,28 @@ private fun parseSceneMessages(raw: String): List<SceneMessage> {
             }
         }
     }.getOrDefault(emptyList())
+}
+
+@Composable
+private fun ResourceMetaRow(
+    label: String,
+    content: @Composable () -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Box(modifier = Modifier.weight(1f)) {
+            content()
+        }
+    }
 }
 
 @OptIn(ExperimentalFoundationApi::class)


### PR DESCRIPTION
### Motivation
- Make resource preview metadata (tags and characters) visually more compact and consistent. 
- Fix media creation so videos/audio selected from system file picker can actually be read later by the app. 
- Allow adding multiple scene dialogue messages without closing the dialog to speed up scene creation.

### Description
- Introduced a shared `ResourceMetaRow` composable and refactored the preview UI to use it for `标签` and `角色`, reduced chip spacing and adjusted label styles in `ResourcePreviewScreen.kt`. 
- Switched media pickers in `ResourceCreateScreen` from `GetContent`/`GetMultipleContents` to `OpenDocument`/`OpenMultipleDocuments` and used `LocalContext` + `takePersistableUriPermission` to persist read permission for selected URIs in `ResourceScreen.kt`. 
- Updated the launcher calls to use `arrayOf("video/*")` / `arrayOf("audio/*")` to match the `OpenDocument` APIs. 
- Added a "继续添加" (continue/`add another`) action to the scene message dialog by extending `SceneMessageDialog` with an optional `onAddAnother` callback and wiring it so users can append multiple `SceneDraftMessage` entries without closing the dialog. 
- Minor imports and safety checks added to ensure blank messages are not appended.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f29cde28832bbd82b80a9534ce13)