### PR TITLE
Add logging for media encryption and preview caching in ResourceViewModel

### DIFF
--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.util.Base64
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.quotepicker.data.Repository
@@ -137,8 +138,23 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     ) = viewModelScope.launch(Dispatchers.IO) {
         if (characterIds.isEmpty()) return@launch
         val targetName = "${type.name.lowercase()}_${System.currentTimeMillis()}.enc"
-        val input = getApplication<Application>().contentResolver.openInputStream(uri) ?: return@launch
-        val encryptedFile = runCatching { input.use { fileManager.encryptToFile(it, targetName) } }.getOrNull() ?: return@launch
+        val resolver = getApplication<Application>().contentResolver
+        val input = runCatching { resolver.openInputStream(uri) }
+            .onFailure { error ->
+                Log.e("ResourceViewModel", "Failed to open media uri=$uri type=$type", error)
+            }
+            .getOrNull()
+            ?: return@launch
+        val encryptedFile = runCatching { input.use { fileManager.encryptToFile(it, targetName) } }
+            .onFailure { error ->
+                Log.e("ResourceViewModel", "Failed to encrypt media uri=$uri type=$type", error)
+            }
+            .getOrNull()
+            ?: return@launch
+        Log.d(
+            "ResourceViewModel",
+            "Encrypted media saved type=$type path=${encryptedFile.absolutePath} size=${encryptedFile.length()}"
+        )
         repo.addResource(
             ResourceEntity(
                 type = type,
@@ -176,7 +192,17 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                 temp.outputStream().use { output -> input.copyTo(output) }
             }
             temp
-        }.getOrNull()
+        }
+            .onSuccess {
+                Log.d(
+                    "ResourceViewModel",
+                    "Decrypted media cached path=$path temp=${temp.absolutePath} size=${temp.length()}"
+                )
+            }
+            .onFailure { error ->
+                Log.e("ResourceViewModel", "Failed to decrypt media path=$path", error)
+            }
+            .getOrNull()
     }
 
     fun decodeBase64ToBitmap(b64: String): Bitmap? {


### PR DESCRIPTION
### Motivation
- Add observability to diagnose why video/audio saving or preview generation fails by logging failures when opening a media `Uri` and during encryption, and by reporting successful outputs with paths and sizes.
- Make it easier to confirm whether cache preview files are written and to capture errors during decryption and caching in `writeDecryptedToCache`.

### Description
- Import `android.util.Log` and wrap `resolver.openInputStream(uri)` with `runCatching` and a `Log.e` on failure inside `addEncryptedMedia`.
- Wrap the call to `fileManager.encryptToFile` with `runCatching` and log encryption failures with `Log.e` and successes with `Log.d` including `type`, output path and file size.
- Add `Log.d` on successful cache write and `Log.e` on decryption failures inside `writeDecryptedToCache`, reporting the source path, temporary cache path and file size.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969f88bff80832b8bf6ebf983bbb2ec)