### PR TITLE
Fix keystore IV handling for encrypted media

### DIFF
--- a/app/src/main/java/com/example/quotepicker/util/EncryptedFileManager.kt
+++ b/app/src/main/java/com/example/quotepicker/util/EncryptedFileManager.kt
@@ -12,7 +12,6 @@ import javax.crypto.CipherOutputStream
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 import javax.crypto.spec.GCMParameterSpec
-import kotlin.random.Random
 
 class EncryptedFileManager(private val context: Context) {
     private val keyAlias = "resource_aes_key"
@@ -43,10 +42,10 @@ class EncryptedFileManager(private val context: Context) {
 
     fun encryptToFile(input: InputStream, targetName: String): File {
         val key = getOrCreateKey()
-        val iv = Random.nextBytes(12)
         val cipher = Cipher.getInstance("AES/GCM/NoPadding").apply {
-            init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(128, iv))
+            init(Cipher.ENCRYPT_MODE, key)
         }
+        val iv = cipher.iv
         val outFile = File(encryptedDir(), targetName)
         outFile.outputStream().use { fileOut ->
             fileOut.write(iv)


### PR DESCRIPTION
### Motivation
- Address an `InvalidAlgorithmParameterException` when encrypting media by avoiding a caller-provided IV and letting the Android Keystore generate the IV for AES/GCM encryption.

### Description
- Update `encryptToFile` to stop generating an IV with `Random.nextBytes`, call `Cipher.init(Cipher.ENCRYPT_MODE, key)` so the keystore provides the IV, then persist `cipher.iv` before streaming ciphertext to disk and remove the unused import.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969ff7d1608832b90047e5c7f3ec7e0)