### PR TITLE
Improve media preview loading resilience

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -63,12 +63,15 @@ fun ResourcePreviewScreen(
 ) {
     var quoteImages by remember { mutableStateOf<List<android.graphics.Bitmap>>(emptyList()) }
     var mediaUri by remember { mutableStateOf<Uri?>(null) }
+    var mediaLoadFailed by remember { mutableStateOf(false) }
+    var mediaReloadKey by remember { mutableStateOf(0) }
     var sceneMessages by remember { mutableStateOf<List<SceneMessage>>(emptyList()) }
     val scrollState = rememberScrollState()
 
-    LaunchedEffect(resource.resource.id) {
+    LaunchedEffect(resource.resource.id, mediaReloadKey) {
         val res = resource.resource
         quoteImages = emptyList()
+        mediaLoadFailed = false
         if (res.type == ResourceType.IMAGE) {
             val images = mutableListOf<android.graphics.Bitmap>()
             res.contentUriOrPath?.let { path ->
@@ -83,10 +86,16 @@ fun ResourcePreviewScreen(
         mediaUri = when (res.type) {
             ResourceType.VIDEO, ResourceType.AUDIO -> {
                 val path = res.contentUriOrPath ?: return@LaunchedEffect
+                val extension = if (res.type == ResourceType.VIDEO) "mp4" else "mp3"
                 val file = withContext(Dispatchers.IO) {
-                    vm.writeDecryptedToCache(path)
-                } ?: return@LaunchedEffect
-                Uri.fromFile(file)
+                    vm.writeDecryptedToCache(path, extension)
+                }
+                if (file == null) {
+                    mediaLoadFailed = true
+                    null
+                } else {
+                    Uri.fromFile(file)
+                }
             }
             else -> null
         }
@@ -173,6 +182,14 @@ fun ResourcePreviewScreen(
                         ResourceType.VIDEO -> {
                             if (mediaUri != null) {
                                 MediaPreview(uri = mediaUri!!)
+                            } else if (mediaLoadFailed) {
+                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    Text("视频加载失败")
+                                    AssistChip(
+                                        onClick = { mediaReloadKey += 1 },
+                                        label = { Text("重试") }
+                                    )
+                                }
                             } else {
                                 Text("视频加载中…")
                             }
@@ -181,6 +198,14 @@ fun ResourcePreviewScreen(
                             if (mediaUri != null) {
                                 MediaPreview(uri = mediaUri!!)
                                 Text("音频播放中")
+                            } else if (mediaLoadFailed) {
+                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                    Text("音频加载失败")
+                                    AssistChip(
+                                        onClick = { mediaReloadKey += 1 },
+                                        label = { Text("重试") }
+                                    )
+                                }
                             } else {
                                 Text("音频加载中…")
                             }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -184,9 +184,10 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         fileManager.openDecryptedStream(path).use { it.readBytes() }
     }
 
-    suspend fun writeDecryptedToCache(path: String): File? = withContext(Dispatchers.IO) {
+    suspend fun writeDecryptedToCache(path: String, extension: String? = null): File? = withContext(Dispatchers.IO) {
         val cacheDir = getApplication<Application>().cacheDir
-        val temp = File(cacheDir, "preview_${System.currentTimeMillis()}.media")
+        val normalizedExtension = extension?.let { if (it.startsWith(".")) it else ".$it" } ?: ".media"
+        val temp = File(cacheDir, "preview_${System.currentTimeMillis()}$normalizedExtension")
         runCatching {
             fileManager.openDecryptedStream(path).use { input ->
                 temp.outputStream().use { output -> input.copyTo(output) }


### PR DESCRIPTION
### Motivation
- Video/audio previews could get stuck showing "loading" when decrypted cache files lacked a recognizable extension or decryption failed. 
- The preview flow needs a way to surface decryption/playback failures and allow users to retry loading. 
- Caching decrypted media with an appropriate extension improves compatibility with platform media players.

### Description
- Add `mediaLoadFailed` and `mediaReloadKey` state to `ResourcePreviewScreen` and include `mediaReloadKey` in the `LaunchedEffect` key so retrying forces a reload. 
- When decrypting media for preview, call `vm.writeDecryptedToCache(path, extension)` with `mp4` for video and `mp3` for audio so cached files have proper extensions. 
- Update `writeDecryptedToCache` signature in `ResourceViewModel` to accept an optional `extension` and create cache files named `preview_<ts><extension>`. 
- Show a failure message and an `AssistChip` retry button in the preview UI when loading fails, which increments `mediaReloadKey` to attempt reload.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a00d9a8d8832b8d80fbb8a234ec15)