### PR TITLE
Support grouped video uploads and add preview logging

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -493,25 +493,20 @@ private fun ResourceCreateScreen(
                                 selectedTags.toList(),
                                 selectedCharacters.toList()
                             )
-                            is CreateMode.Media -> vm.addEncryptedMedia(
-                                mode.type,
-                                title.trim(),
-                                if (mode.type == ResourceType.VIDEO) {
-                                    val uris = videoUris
-                                    uris.firstOrNull() ?: return@TextButton
-                                } else {
-                                    mediaUri ?: return@TextButton
-                                },
-                                selectedTags.toList(),
-                                selectedCharacters.toList()
-                            )
-                        }
-                        if (mode is CreateMode.Media && mode.type == ResourceType.VIDEO && videoUris.size > 1) {
-                            videoUris.drop(1).forEachIndexed { index, uri ->
+                            is CreateMode.Media -> if (mode.type == ResourceType.VIDEO) {
+                                val uris = videoUris
+                                vm.addEncryptedMediaGroup(
+                                    mode.type,
+                                    title.trim(),
+                                    uris,
+                                    selectedTags.toList(),
+                                    selectedCharacters.toList()
+                                )
+                            } else {
                                 vm.addEncryptedMedia(
                                     mode.type,
-                                    "${title.trim()} (${index + 2})",
-                                    uri,
+                                    title.trim(),
+                                    mediaUri ?: return@TextButton,
                                     selectedTags.toList(),
                                     selectedCharacters.toList()
                                 )

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -1,6 +1,7 @@
 package com.example.quotepicker.ui.components
 
 import android.net.Uri
+import android.util.Log
 import android.widget.MediaController
 import android.widget.VideoView
 import androidx.compose.foundation.Image
@@ -62,7 +63,7 @@ fun ResourcePreviewScreen(
     onBack: () -> Unit
 ) {
     var quoteImages by remember { mutableStateOf<List<android.graphics.Bitmap>>(emptyList()) }
-    var mediaUri by remember { mutableStateOf<Uri?>(null) }
+    var mediaUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var mediaLoadFailed by remember { mutableStateOf(false) }
     var mediaReloadKey by remember { mutableStateOf(0) }
     var sceneMessages by remember { mutableStateOf<List<SceneMessage>>(emptyList()) }
@@ -83,21 +84,33 @@ fun ResourcePreviewScreen(
         } else if (res.type == ResourceType.QUOTE) {
             quoteImages = decodeQuoteImages(res.quoteImageBase64, vm)
         }
-        mediaUri = when (res.type) {
+        mediaUris = when (res.type) {
             ResourceType.VIDEO, ResourceType.AUDIO -> {
-                val path = res.contentUriOrPath ?: return@LaunchedEffect
+                val raw = res.contentUriOrPath ?: return@LaunchedEffect
+                val paths = parseMediaPaths(raw)
                 val extension = if (res.type == ResourceType.VIDEO) "mp4" else "mp3"
-                val file = withContext(Dispatchers.IO) {
-                    vm.writeDecryptedToCache(path, extension)
+                val uriList = mutableListOf<Uri>()
+                paths.forEachIndexed { index, path ->
+                    Log.d(
+                        "ResourcePreview",
+                        "Preparing media preview type=${res.type} id=${res.id} index=$index path=$path"
+                    )
+                    val file = withContext(Dispatchers.IO) {
+                        vm.writeDecryptedToCache(path, extension)
+                    }
+                    if (file == null) {
+                        Log.e(
+                            "ResourcePreview",
+                            "Failed to load media preview type=${res.type} id=${res.id} index=$index path=$path"
+                        )
+                        mediaLoadFailed = true
+                    } else {
+                        uriList.add(Uri.fromFile(file))
+                    }
                 }
-                if (file == null) {
-                    mediaLoadFailed = true
-                    null
-                } else {
-                    Uri.fromFile(file)
-                }
+                uriList
             }
-            else -> null
+            else -> emptyList()
         }
         sceneMessages = parseSceneMessages(res.sceneJson.orEmpty())
     }
@@ -180,8 +193,8 @@ fun ResourcePreviewScreen(
                             }
                         }
                         ResourceType.VIDEO -> {
-                            if (mediaUri != null) {
-                                MediaPreview(uri = mediaUri!!)
+                            if (mediaUris.isNotEmpty()) {
+                                MediaPreviewPager(uris = mediaUris)
                             } else if (mediaLoadFailed) {
                                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                                     Text("视频加载失败")
@@ -195,8 +208,8 @@ fun ResourcePreviewScreen(
                             }
                         }
                         ResourceType.AUDIO -> {
-                            if (mediaUri != null) {
-                                MediaPreview(uri = mediaUri!!)
+                            if (mediaUris.isNotEmpty()) {
+                                MediaPreview(uri = mediaUris.first())
                                 Text("音频播放中")
                             } else if (mediaLoadFailed) {
                                 Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -237,7 +250,14 @@ private fun MediaPreview(uri: Uri) {
                 controller.setAnchorView(this)
                 setMediaController(controller)
                 setVideoURI(uri)
-                setOnPreparedListener { it.start() }
+                setOnPreparedListener { mediaPlayer ->
+                    Log.d("MediaPreview", "Video prepared uri=$uri duration=${mediaPlayer.duration}")
+                    mediaPlayer.start()
+                }
+                setOnErrorListener { _, what, extra ->
+                    Log.e("MediaPreview", "Video error uri=$uri what=$what extra=$extra")
+                    false
+                }
             }
         },
         update = { view ->
@@ -248,6 +268,34 @@ private fun MediaPreview(uri: Uri) {
             .height(240.dp)
             .background(MaterialTheme.colorScheme.surfaceVariant)
     )
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun MediaPreviewPager(uris: List<Uri>) {
+    val pagerState = rememberPagerState(pageCount = { uris.size })
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        HorizontalPager(state = pagerState) { page ->
+            MediaPreview(uri = uris[page])
+        }
+        if (uris.size > 1) {
+            Text(
+                text = "视频 ${pagerState.currentPage + 1}/${uris.size}",
+                style = MaterialTheme.typography.labelSmall
+            )
+        }
+    }
+}
+
+private fun parseMediaPaths(raw: String): List<String> {
+    val trimmed = raw.trim()
+    if (trimmed.startsWith("[")) {
+        return runCatching {
+            val arr = JSONArray(trimmed)
+            List(arr.length()) { index -> arr.getString(index) }
+        }.getOrDefault(listOf(raw))
+    }
+    return listOf(raw)
 }
 
 @Composable

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -166,6 +166,59 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         )
     }
 
+    fun addEncryptedMediaGroup(
+        type: ResourceType,
+        title: String,
+        uris: List<Uri>,
+        tagIds: List<Long>,
+        characterIds: List<Long>
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        if (characterIds.isEmpty()) return@launch
+        if (uris.isEmpty()) return@launch
+        val resolver = getApplication<Application>().contentResolver
+        val encryptedPaths = mutableListOf<String>()
+        uris.forEachIndexed { index, uri ->
+            val targetName = "${type.name.lowercase()}_${System.currentTimeMillis()}_$index.enc"
+            val input = runCatching { resolver.openInputStream(uri) }
+                .onFailure { error ->
+                    Log.e("ResourceViewModel", "Failed to open media uri=$uri type=$type", error)
+                }
+                .getOrNull()
+            if (input == null) {
+                Log.w("ResourceViewModel", "Skip media uri=$uri type=$type due to open failure")
+                return@forEachIndexed
+            }
+            val encryptedFile = runCatching { input.use { fileManager.encryptToFile(it, targetName) } }
+                .onFailure { error ->
+                    Log.e("ResourceViewModel", "Failed to encrypt media uri=$uri type=$type", error)
+                }
+                .getOrNull()
+            if (encryptedFile != null) {
+                encryptedPaths.add(encryptedFile.absolutePath)
+                Log.d(
+                    "ResourceViewModel",
+                    "Encrypted media saved type=$type path=${encryptedFile.absolutePath} size=${encryptedFile.length()}"
+                )
+            } else {
+                Log.w("ResourceViewModel", "Skip media uri=$uri type=$type due to encryption failure")
+            }
+        }
+        if (encryptedPaths.isEmpty()) {
+            Log.e("ResourceViewModel", "No media saved for group type=$type title=$title")
+            return@launch
+        }
+        val payload = org.json.JSONArray(encryptedPaths).toString()
+        repo.addResource(
+            ResourceEntity(
+                type = type,
+                title = title,
+                contentUriOrPath = payload
+            ),
+            tagIds,
+            characterIds
+        )
+    }
+
     fun updateResource(resource: ResourceEntity) =
         viewModelScope.launch { repo.updateResource(resource) }
 


### PR DESCRIPTION
### Motivation
- Videos sometimes fail to load and it's difficult to diagnose without logs, and users need to attach multiple videos as a single resource and preview them as a group.
- Store grouped video selections in a single resource so a project can contain multiple related files under one title.
- Provide clearer runtime logs and better preview UX to help locate media load/playback failures and to allow paged preview of grouped videos.

### Description
- Added `addEncryptedMediaGroup` in `ResourceViewModel` to encrypt multiple `Uri` inputs, persist their encrypted paths as a JSON array in `contentUriOrPath`, and add robust logging around open/encrypt failures for each item.
- Updated the creation flow in `ResourceScreen` to call `addEncryptedMediaGroup` for `ResourceType.VIDEO` selections (preserving single-file handling for non-video media) by passing `videoUris` from the picker.
- Extended `ResourcePreviewScreen` to parse grouped media paths via `parseMediaPaths`, decrypt each path to cache with `writeDecryptedToCache`, and display multiple videos using a new `MediaPreviewPager`; added logging in the preview pipeline and improved `MediaPreview` error/prepared handlers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d79b20d64832b8a952f30d96da841)