### PR TITLE
Handle decryption failures and clean up corrupted encrypted media

### DIFF
--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.security.KeyStoreException
 import android.util.Base64
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
@@ -18,6 +19,7 @@ import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.util.EncryptedFileManager
 import com.example.quotepicker.util.ImageCompression
 import java.io.File
+import javax.crypto.AEADBadTagException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -234,7 +236,11 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     suspend fun loadDecryptedBytes(path: String): ByteArray = withContext(Dispatchers.IO) {
-        fileManager.openDecryptedStream(path).use { it.readBytes() }
+        runCatching {
+            fileManager.openDecryptedStream(path).use { it.readBytes() }
+        }
+            .onFailure { error -> handleDecryptionFailure(path, error) }
+            .getOrDefault(ByteArray(0))
     }
 
     suspend fun writeDecryptedToCache(path: String, extension: String? = null): File? = withContext(Dispatchers.IO) {
@@ -246,7 +252,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                 temp.outputStream().use { output -> input.copyTo(output) }
             }
             temp
-        }
+            }
             .onSuccess {
                 Log.d(
                     "ResourceViewModel",
@@ -254,9 +260,22 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                 )
             }
             .onFailure { error ->
+                handleDecryptionFailure(path, error)
+                runCatching { if (temp.exists()) temp.delete() }
                 Log.e("ResourceViewModel", "Failed to decrypt media path=$path", error)
             }
             .getOrNull()
+    }
+
+    private fun handleDecryptionFailure(path: String, error: Throwable) {
+        if (!isDecryptionFailure(error)) return
+        Log.w("ResourceViewModel", "Deleting corrupted encrypted media path=$path", error)
+        fileManager.deleteEncryptedFile(path)
+    }
+
+    private fun isDecryptionFailure(error: Throwable): Boolean {
+        return generateSequence(error) { it.cause }
+            .any { cause -> cause is AEADBadTagException || cause is KeyStoreException }
     }
 
     fun decodeBase64ToBitmap(b64: String): Bitmap? {


### PR DESCRIPTION
### Motivation
- Decryption of AES/GCM-encrypted media can fail with `AEADBadTagException` / keystore verification errors which cause repeated preview failures and noisy logs.
- Corrupted or tampered encrypted files should be removed to avoid recurring failures when attempting to preview or load media.
- Temporary cache files created during failed decrypts must be cleaned to avoid leaving invalid preview artifacts.

### Description
- Guarded calls to decryption in `loadDecryptedBytes` and `writeDecryptedToCache` using `runCatching` to return safe defaults on failure. 
- Added `handleDecryptionFailure` which inspects the cause chain for `AEADBadTagException` or `KeyStoreException` and deletes the underlying encrypted file via `EncryptedFileManager`. 
- Ensure temporary preview files are removed on decryption failure and added logging when corrupted encrypted media are deleted. 
- Added imports for `AEADBadTagException` and `KeyStoreException`.

### Testing
- No automated tests were executed for this change.
- Behavior verified by adding defensive logging and cleanup paths; CI/manual test runs were not performed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d83ff392c832ba37e77db357deb82)