### PR TITLE
Preserve original media extensions in encrypted files and improve preview loading

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -49,6 +49,7 @@ import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.vm.ResourceViewModel
+import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -86,11 +87,21 @@ fun ResourcePreviewScreen(
         }
         mediaUris = when (res.type) {
             ResourceType.VIDEO, ResourceType.AUDIO -> {
-                val raw = res.contentUriOrPath ?: return@LaunchedEffect
+                val raw = res.contentUriOrPath
+                if (raw.isNullOrBlank()) {
+                    Log.e("ResourcePreview", "Missing media path for type=${res.type} id=${res.id}")
+                    mediaLoadFailed = true
+                    return@LaunchedEffect
+                }
                 val paths = parseMediaPaths(raw)
-                val extension = if (res.type == ResourceType.VIDEO) "mp4" else "mp3"
+                if (paths.isEmpty()) {
+                    Log.e("ResourcePreview", "Empty media path list for type=${res.type} id=${res.id}")
+                    mediaLoadFailed = true
+                    return@LaunchedEffect
+                }
                 val uriList = mutableListOf<Uri>()
                 paths.forEachIndexed { index, path ->
+                    val extension = resolvePreviewExtension(path, res.type)
                     Log.d(
                         "ResourcePreview",
                         "Preparing media preview type=${res.type} id=${res.id} index=$index path=$path"
@@ -296,6 +307,13 @@ private fun parseMediaPaths(raw: String): List<String> {
         }.getOrDefault(listOf(raw))
     }
     return listOf(raw)
+}
+
+private fun resolvePreviewExtension(path: String, type: ResourceType): String {
+    val fallback = if (type == ResourceType.VIDEO) "mp4" else "mp3"
+    val fileName = File(path).name.removeSuffix(".enc")
+    val ext = fileName.substringAfterLast('.', "")
+    return if (ext.isNotBlank()) ext else fallback
 }
 
 @Composable

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.security.KeyStoreException
 import android.util.Base64
 import android.util.Log
+import android.webkit.MimeTypeMap
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.quotepicker.data.Repository
@@ -139,7 +140,8 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         characterIds: List<Long>
     ) = viewModelScope.launch(Dispatchers.IO) {
         if (characterIds.isEmpty()) return@launch
-        val targetName = "${type.name.lowercase()}_${System.currentTimeMillis()}.enc"
+        val extension = resolveMediaExtension(uri)
+        val targetName = buildEncryptedName(type, extension)
         val resolver = getApplication<Application>().contentResolver
         val input = runCatching { resolver.openInputStream(uri) }
             .onFailure { error ->
@@ -180,7 +182,8 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         val resolver = getApplication<Application>().contentResolver
         val encryptedPaths = mutableListOf<String>()
         uris.forEachIndexed { index, uri ->
-            val targetName = "${type.name.lowercase()}_${System.currentTimeMillis()}_$index.enc"
+            val extension = resolveMediaExtension(uri)
+            val targetName = buildEncryptedName(type, extension, index)
             val input = runCatching { resolver.openInputStream(uri) }
                 .onFailure { error ->
                     Log.e("ResourceViewModel", "Failed to open media uri=$uri type=$type", error)
@@ -276,6 +279,18 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     private fun isDecryptionFailure(error: Throwable): Boolean {
         return generateSequence(error) { it.cause }
             .any { cause -> cause is AEADBadTagException || cause is KeyStoreException }
+    }
+
+    private fun buildEncryptedName(type: ResourceType, extension: String?, index: Int? = null): String {
+        val suffix = index?.let { "_$it" }.orEmpty()
+        val ext = extension?.let { ".$it" }.orEmpty()
+        return "${type.name.lowercase()}_${System.currentTimeMillis()}$suffix$ext.enc"
+    }
+
+    private fun resolveMediaExtension(uri: Uri): String? {
+        val resolver = getApplication<Application>().contentResolver
+        val mime = resolver.getType(uri)
+        return mime?.let { MimeTypeMap.getSingleton().getExtensionFromMimeType(it) }
     }
 
     fun decodeBase64ToBitmap(b64: String): Bitmap? {


### PR DESCRIPTION
### Motivation
- The preview UI could stay stuck on "视频加载中" because decrypted temp files lacked the original media extension, causing media players to mis-detect formats. 
- Encrypted files previously used a fixed `.enc` suffix with no stored source extension, preventing correct preview caching for video/audio resources.

### Description
- When encrypting media, lookup the source MIME type and append the original extension into the encrypted filename by adding `resolveMediaExtension` and `buildEncryptedName` in `ResourceViewModel` and use them in `addEncryptedMedia` and `addEncryptedMediaGroup` (changes in `app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt`).
- During preview preparation, validate the stored media path and fail fast when missing or empty, and infer the preview file extension from the encrypted filename using `resolvePreviewExtension` to pass the correct extension into `writeDecryptedToCache` (changes in `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`).
- Added defensive logs to surface missing/empty paths and decryption failures to avoid indefinite "loading" state.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d85ec0c28832bb43f6c95512da4ab)