### PR TITLE
Improve media preview loading feedback

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -50,8 +50,7 @@ import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.vm.ResourceViewModel
 import java.io.File
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
 
 private data class SceneMessage(val speaker: String, val content: String)
@@ -106,10 +105,10 @@ fun ResourcePreviewScreen(
                         "ResourcePreview",
                         "Preparing media preview type=${res.type} id=${res.id} index=$index path=$path"
                     )
-                    val file = withContext(Dispatchers.IO) {
+                    val file = withTimeoutOrNull(60_000) {
                         vm.writeDecryptedToCache(path, extension)
                     }
-                    if (file == null) {
+                    if (file == null || !file.exists() || file.length() == 0L) {
                         Log.e(
                             "ResourcePreview",
                             "Failed to load media preview type=${res.type} id=${res.id} index=$index path=$path"
@@ -117,7 +116,11 @@ fun ResourcePreviewScreen(
                         mediaLoadFailed = true
                     } else {
                         uriList.add(Uri.fromFile(file))
+                        mediaUris = uriList.toList()
                     }
+                }
+                if (uriList.isEmpty()) {
+                    mediaLoadFailed = true
                 }
                 uriList
             }


### PR DESCRIPTION
### Motivation
- Video/audio preview could hang indefinitely showing "视频加载中…" when decryption stalled or produced an empty/corrupt file, as observed with the `Preparing media preview` log.
- Provide responsive feedback and a retry path instead of leaving the UI stuck during long or failed decryptions.

### Description
- Add a timeout around `writeDecryptedToCache` using `withTimeoutOrNull` (60_000 ms) to avoid waiting forever for decryption. 
- Treat a null result or a file that does not exist or has zero length as a failure and set `mediaLoadFailed` accordingly.
- Update `mediaUris` incrementally as each decrypted file becomes available so the preview can start playing before all files finish decrypting.
- Ensure that if no decrypted files are produced `mediaLoadFailed` is set to true so the UI can show the failure state and offer a retry.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d87fcfc28832ba3fc55056894bed9)