### PR TITLE
Stabilize video preview playback and handle decryption timeouts

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.AssistChip
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -50,8 +51,7 @@ import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.vm.ResourceViewModel
 import java.io.File
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
 
 private data class SceneMessage(val speaker: String, val content: String)
@@ -106,10 +106,10 @@ fun ResourcePreviewScreen(
                         "ResourcePreview",
                         "Preparing media preview type=${res.type} id=${res.id} index=$index path=$path"
                     )
-                    val file = withContext(Dispatchers.IO) {
+                    val file = withTimeoutOrNull(60_000) {
                         vm.writeDecryptedToCache(path, extension)
                     }
-                    if (file == null) {
+                    if (file == null || !file.exists() || file.length() == 0L) {
                         Log.e(
                             "ResourcePreview",
                             "Failed to load media preview type=${res.type} id=${res.id} index=$index path=$path"
@@ -117,7 +117,11 @@ fun ResourcePreviewScreen(
                         mediaLoadFailed = true
                     } else {
                         uriList.add(Uri.fromFile(file))
+                        mediaUris = uriList.toList()
                     }
+                }
+                if (uriList.isEmpty()) {
+                    mediaLoadFailed = true
                 }
                 uriList
             }
@@ -254,6 +258,12 @@ fun ResourcePreviewScreen(
 
 @Composable
 private fun MediaPreview(uri: Uri) {
+    val viewHolder = remember { mutableStateOf<VideoView?>(null) }
+    DisposableEffect(Unit) {
+        onDispose {
+            viewHolder.value?.stopPlayback()
+        }
+    }
     AndroidView(
         factory = { context ->
             VideoView(context).apply {
@@ -261,6 +271,7 @@ private fun MediaPreview(uri: Uri) {
                 controller.setAnchorView(this)
                 setMediaController(controller)
                 setVideoURI(uri)
+                tag = uri
                 setOnPreparedListener { mediaPlayer ->
                     Log.d("MediaPreview", "Video prepared uri=$uri duration=${mediaPlayer.duration}")
                     mediaPlayer.start()
@@ -269,10 +280,14 @@ private fun MediaPreview(uri: Uri) {
                     Log.e("MediaPreview", "Video error uri=$uri what=$what extra=$extra")
                     false
                 }
+                viewHolder.value = this
             }
         },
         update = { view ->
-            view.setVideoURI(uri)
+            if (view.tag != uri) {
+                view.tag = uri
+                view.setVideoURI(uri)
+            }
         },
         modifier = Modifier
             .fillMaxWidth()


### PR DESCRIPTION
### Motivation
- Prevent the video/audio preview from hanging indefinitely when decryption stalls or produces an empty/corrupt file. 
- Reduce resource leaks and "resource failed to call release" warnings caused by VideoView instances that keep playing after leaving composition. 

### Description
- Add a timeout around `vm.writeDecryptedToCache` using `withTimeoutOrNull(60_000)` and treat `null`, non-existent, or zero-length files as failures so previews don't wait forever. 
- Update `mediaUris` incrementally as each decrypted file becomes available and set `mediaLoadFailed` if no decrypted files are produced. 
- In `MediaPreview`, remember a `VideoView` reference and use `DisposableEffect` to call `stopPlayback()` when the preview leaves composition. 
- Avoid redundant `VideoView.setVideoURI` calls by tagging the view with the current `Uri` and only calling `setVideoURI` when the `Uri` changes. 

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d87fcfc28832ba3fc55056894bed9)