### PR TITLE
Make media decryption cancellable for previews

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -51,7 +51,6 @@ import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.vm.ResourceViewModel
 import java.io.File
-import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
 
 private data class SceneMessage(val speaker: String, val content: String)
@@ -106,9 +105,7 @@ fun ResourcePreviewScreen(
                         "ResourcePreview",
                         "Preparing media preview type=${res.type} id=${res.id} index=$index path=$path"
                     )
-                    val file = withTimeoutOrNull(60_000) {
-                        vm.writeDecryptedToCache(path, extension)
-                    }
+                    val file = vm.writeDecryptedToCache(path, extension)
                     if (file == null || !file.exists() || file.length() == 0L) {
                         Log.e(
                             "ResourcePreview",

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -27,8 +27,10 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 
 data class ResourceFilterState(
     val selectedType: ResourceType? = null,
@@ -246,28 +248,48 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             .getOrDefault(ByteArray(0))
     }
 
-    suspend fun writeDecryptedToCache(path: String, extension: String? = null): File? = withContext(Dispatchers.IO) {
+    suspend fun writeDecryptedToCache(
+        path: String,
+        extension: String? = null,
+        timeoutMs: Long = 60_000
+    ): File? = withContext(Dispatchers.IO) {
         val cacheDir = getApplication<Application>().cacheDir
         val normalizedExtension = extension?.let { if (it.startsWith(".")) it else ".$it" } ?: ".media"
         val temp = File(cacheDir, "preview_${System.currentTimeMillis()}$normalizedExtension")
-        runCatching {
-            fileManager.openDecryptedStream(path).use { input ->
-                temp.outputStream().use { output -> input.copyTo(output) }
+        val result = withTimeoutOrNull(timeoutMs) {
+            runCatching {
+                fileManager.openDecryptedStream(path).use { input ->
+                    temp.outputStream().use { output ->
+                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        while (true) {
+                            ensureActive()
+                            val read = input.read(buffer)
+                            if (read <= 0) break
+                            output.write(buffer, 0, read)
+                        }
+                        output.flush()
+                    }
+                }
+                temp
             }
-            temp
-            }
-            .onSuccess {
-                Log.d(
-                    "ResourceViewModel",
-                    "Decrypted media cached path=$path temp=${temp.absolutePath} size=${temp.length()}"
-                )
-            }
-            .onFailure { error ->
-                handleDecryptionFailure(path, error)
-                runCatching { if (temp.exists()) temp.delete() }
-                Log.e("ResourceViewModel", "Failed to decrypt media path=$path", error)
-            }
-            .getOrNull()
+                .onSuccess {
+                    Log.d(
+                        "ResourceViewModel",
+                        "Decrypted media cached path=$path temp=${temp.absolutePath} size=${temp.length()}"
+                    )
+                }
+                .onFailure { error ->
+                    handleDecryptionFailure(path, error)
+                    runCatching { if (temp.exists()) temp.delete() }
+                    Log.e("ResourceViewModel", "Failed to decrypt media path=$path", error)
+                }
+                .getOrNull()
+        }
+        if (result == null) {
+            Log.e("ResourceViewModel", "Decrypt media timeout path=$path after ${timeoutMs}ms")
+            runCatching { if (temp.exists()) temp.delete() }
+        }
+        result
     }
 
     private fun handleDecryptionFailure(path: String, error: Throwable) {


### PR DESCRIPTION
### Motivation
- Previewing video/audio could hang showing "加载中" because decryption was performed with a blocking `input.copyTo(output)` that could not be cancelled, preventing `mediaUris` from being populated.

### Description
- Replace the blocking copy in `writeDecryptedToCache` with a chunked read/write loop that calls `ensureActive()` so the operation is cancellable, and add a `timeoutMs` parameter with a default of `60000` ms to abort long-running decrypts and clean up temporary files (changes in `app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt`).
- Add timeout logging and ensure temporary files are deleted on failure or timeout, and keep existing decryption-failure handling that deletes corrupted encrypted inputs.
- Simplify the preview side to call the view model's cancellable `writeDecryptedToCache` directly (remove outer `withTimeoutOrNull`) so cancellation and timeout are consistently handled by the VM (changes in `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d901c5704832b8cf9023e8f9b2e2d)