### PR TITLE
Refactor tag categories and resource model to support flows, grouped tags, and encrypted media

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
@@ -13,6 +13,12 @@ class Converters {
 
     @TypeConverter
     fun toType(raw: String): ResourceType = ResourceType.valueOf(raw)
+
+    @TypeConverter
+    fun fromCategoryType(type: TagCategoryType): String = type.name
+
+    @TypeConverter
+    fun toCategoryType(raw: String): TagCategoryType = TagCategoryType.valueOf(raw)
 }
 
 @Database(
@@ -25,7 +31,7 @@ class Converters {
         CharacterTagCrossRef::class,
         ResourceCharacterCrossRef::class
     ],
-    version = 2,
+    version = 3,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/quotepicker/data/Dao.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Dao.kt
@@ -13,8 +13,11 @@ interface TagCategoryDao {
     @Query("SELECT * FROM tag_categories ORDER BY name COLLATE NOCASE ASC")
     fun observeCategories(): Flow<List<TagCategoryEntity>>
 
-    @Query("SELECT * FROM tag_categories WHERE name = :name LIMIT 1")
-    suspend fun findByName(name: String): TagCategoryEntity?
+    @Query("SELECT * FROM tag_categories WHERE type = :type ORDER BY name COLLATE NOCASE ASC")
+    fun observeCategoriesByType(type: TagCategoryType): Flow<List<TagCategoryEntity>>
+
+    @Query("SELECT * FROM tag_categories WHERE name = :name AND type = :type LIMIT 1")
+    suspend fun findByName(name: String, type: TagCategoryType): TagCategoryEntity?
 
     @Insert
     suspend fun insert(category: TagCategoryEntity): Long

--- a/app/src/main/java/com/example/quotepicker/data/Entities.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Entities.kt
@@ -6,14 +6,17 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.Relation
 
-enum class ResourceType { IMAGE, VIDEO, AUDIO, QUOTE, SCENE }
+enum class ResourceType { FLOW, TEXT, IMAGE, VIDEO, SCENE }
+
+enum class TagCategoryType { CHARACTER, RESOURCE }
 
 @Entity(
     tableName = "tag_categories",
-    indices = [Index(value = ["name"], unique = true)]
+    indices = [Index(value = ["type", "name"], unique = true)]
 )
 data class TagCategoryEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val type: TagCategoryType = TagCategoryType.RESOURCE,
     val name: String,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis()

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -13,26 +13,31 @@ class Repository private constructor(context: Context) {
 
     fun observeCategories(): Flow<List<TagCategoryEntity>> = categoryDao.observeCategories()
     fun observeTagsByCategory(categoryId: Long): Flow<List<TagEntity>> = tagDao.observeTagsByCategory(categoryId)
+    fun observeCategoriesByType(type: TagCategoryType): Flow<List<TagCategoryEntity>> =
+        categoryDao.observeCategoriesByType(type)
     fun observeAllTags(): Flow<List<TagEntity>> = tagDao.observeAllTags()
     fun observeCharacters(): Flow<List<CharacterEntity>> = characterDao.observeCharacters()
     fun observeCharactersWithTags(): Flow<List<CharacterWithTags>> = characterDao.observeCharactersWithTags()
     fun observeResources(): Flow<List<ResourceEntity>> = resourceDao.observeResources()
     fun observeResourcesWithRelations(): Flow<List<ResourceWithTagsCharacters>> = resourceDao.observeResourcesWithRelations()
 
-    suspend fun addCategory(name: String) = categoryDao.insert(TagCategoryEntity(name = name))
-    suspend fun updateCategory(category: TagCategoryEntity) = categoryDao.update(category.copy(updatedAt = System.currentTimeMillis()))
+    suspend fun addCategory(name: String, type: TagCategoryType) =
+        categoryDao.insert(TagCategoryEntity(name = name, type = type))
+
+    suspend fun updateCategory(category: TagCategoryEntity) =
+        categoryDao.update(category.copy(updatedAt = System.currentTimeMillis()))
     suspend fun deleteCategory(category: TagCategoryEntity) {
         if (category.name == ORPHAN_CATEGORY_NAME) return
-        val orphan = ensureOrphanCategory()
+        val orphan = ensureOrphanCategory(category.type)
         tagDao.reassignCategory(category.id, orphan.id)
         categoryDao.delete(category)
     }
 
-    suspend fun ensureOrphanCategory(): TagCategoryEntity {
-        val existing = categoryDao.findByName(ORPHAN_CATEGORY_NAME)
+    suspend fun ensureOrphanCategory(type: TagCategoryType): TagCategoryEntity {
+        val existing = categoryDao.findByName(ORPHAN_CATEGORY_NAME, type)
         if (existing != null) return existing
-        val id = categoryDao.insert(TagCategoryEntity(name = ORPHAN_CATEGORY_NAME))
-        return TagCategoryEntity(id = id, name = ORPHAN_CATEGORY_NAME)
+        val id = categoryDao.insert(TagCategoryEntity(name = ORPHAN_CATEGORY_NAME, type = type))
+        return TagCategoryEntity(id = id, name = ORPHAN_CATEGORY_NAME, type = type)
     }
 
     suspend fun addTag(categoryId: Long, name: String, colorArgb: Int) =

--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -70,6 +70,7 @@ fun CharacterScreen(
 ) {
     val ui by vm.uiState.collectAsState()
     val resources by resourceVm.allResources.collectAsState()
+    val resourceUi by resourceVm.uiState.collectAsState()
     var selectedId by remember { mutableStateOf<Long?>(null) }
     val selected = ui.characters.firstOrNull { it.character.id == selectedId }
     var showAddDialog by remember { mutableStateOf(false) }
@@ -218,8 +219,8 @@ fun CharacterScreen(
     }
     if (filterTagDialog) {
         TagFilterDialog(
-            categories = ui.categories,
-            tags = ui.tags,
+            categories = resourceUi.categories,
+            tags = resourceUi.tags,
             selectedIds = selectedTagIds,
             onConfirm = { selectedTagIds = it },
             onDismiss = { filterTagDialog = false }
@@ -358,11 +359,11 @@ private fun CharacterResourceFilterBar(
     Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp)) {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             val orderedTypes = listOf(
-                ResourceType.QUOTE,
+                ResourceType.FLOW,
+                ResourceType.TEXT,
                 ResourceType.IMAGE,
                 ResourceType.VIDEO,
-                ResourceType.SCENE,
-                ResourceType.AUDIO
+                ResourceType.SCENE
             )
             orderedTypes.forEach { type ->
                 FilterChip(
@@ -409,10 +410,10 @@ private fun TagFilterDialog(
 }
 
 private fun typeLabel(type: ResourceType): String = when (type) {
+    ResourceType.FLOW -> "流程"
     ResourceType.IMAGE -> "图片"
     ResourceType.VIDEO -> "视频"
-    ResourceType.AUDIO -> "声音"
-    ResourceType.QUOTE -> "文本"
+    ResourceType.TEXT -> "文本"
     ResourceType.SCENE -> "情景"
 }
 

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -22,12 +22,13 @@ import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
-import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
@@ -65,7 +66,11 @@ import com.example.quotepicker.ui.components.ResourceGridCard
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.ui.components.tagTextColor
+import com.example.quotepicker.vm.FlowUpdateItem
+import com.example.quotepicker.vm.ImageUpdateItem
 import com.example.quotepicker.vm.ResourceViewModel
+import com.example.quotepicker.vm.SceneMessageDraft
+import com.example.quotepicker.vm.VideoUpdateItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -169,30 +174,30 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     if (showAddMenu) {
         ModalBottomSheet(onDismissRequest = { showAddMenu = false }) {
             Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                TextButton(onClick = { createMode = CreateMode.Flow; showAddMenu = false }) {
+                    Icon(Icons.Default.Description, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("创建流程")
+                }
                 TextButton(onClick = { createMode = CreateMode.Text; showAddMenu = false }) {
                     Icon(Icons.Default.Description, contentDescription = null)
                     Spacer(Modifier.width(8.dp))
                     Text("创建文本")
                 }
-                TextButton(onClick = { createMode = CreateMode.ImageText; showAddMenu = false }) {
-                    Icon(Icons.Default.Image, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text("创建图片文本")
-                }
                 TextButton(onClick = { createMode = CreateMode.Scene; showAddMenu = false }) {
                     Icon(Icons.Default.Chat, contentDescription = null)
                     Spacer(Modifier.width(8.dp))
-                    Text("创建聊天情景")
+                    Text("创建情景")
                 }
-                TextButton(onClick = { createMode = CreateMode.Media(ResourceType.VIDEO); showAddMenu = false }) {
+                TextButton(onClick = { createMode = CreateMode.ImageGroup; showAddMenu = false }) {
+                    Icon(Icons.Default.Image, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("上传图片组")
+                }
+                TextButton(onClick = { createMode = CreateMode.VideoGroup; showAddMenu = false }) {
                     Icon(Icons.Default.Videocam, contentDescription = null)
                     Spacer(Modifier.width(8.dp))
-                    Text("创建视频文本")
-                }
-                TextButton(onClick = { createMode = CreateMode.Media(ResourceType.AUDIO); showAddMenu = false }) {
-                    Icon(Icons.Default.MusicNote, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text("创建声音文本")
+                    Text("上传视频组")
                 }
             }
         }
@@ -261,13 +266,12 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
 }
 
 private sealed class CreateMode {
+    data object Flow : CreateMode()
     data object Text : CreateMode()
-    data object ImageText : CreateMode()
+    data object ImageGroup : CreateMode()
     data object Scene : CreateMode()
-    data class Media(val type: ResourceType) : CreateMode()
+    data object VideoGroup : CreateMode()
 }
-
-private data class SceneDraftMessage(val speaker: String, val content: String)
 
 @Composable
 private fun FilterBar(
@@ -282,11 +286,11 @@ private fun FilterBar(
     Column(Modifier.fillMaxWidth().padding(12.dp)) {
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             val orderedTypes = listOf(
-                ResourceType.QUOTE,
+                ResourceType.FLOW,
+                ResourceType.TEXT,
                 ResourceType.IMAGE,
                 ResourceType.VIDEO,
-                ResourceType.SCENE,
-                ResourceType.AUDIO
+                ResourceType.SCENE
             )
             orderedTypes.forEach { type ->
                 FilterChip(
@@ -309,10 +313,10 @@ private fun FilterBar(
 }
 
 private fun typeLabel(type: ResourceType): String = when (type) {
+    ResourceType.FLOW -> "流程"
     ResourceType.IMAGE -> "图片"
     ResourceType.VIDEO -> "视频"
-    ResourceType.AUDIO -> "声音"
-    ResourceType.QUOTE -> "文本"
+    ResourceType.TEXT -> "文本"
     ResourceType.SCENE -> "情景"
 }
 
@@ -412,31 +416,24 @@ private fun ResourceCreateScreen(
     onBack: () -> Unit
 ) {
     var title by remember { mutableStateOf("") }
-    var quoteText by remember { mutableStateOf("") }
+    var textContent by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
-    var sceneMessages by remember { mutableStateOf<List<SceneDraftMessage>>(emptyList()) }
+    var sceneMessages by remember { mutableStateOf<List<SceneMessageDraft>>(emptyList()) }
+    var flowItems by remember { mutableStateOf<List<FlowUpdateItem>>(emptyList()) }
     var selectedTags by remember { mutableStateOf(setOf<Long>()) }
     var selectedCharacters by remember { mutableStateOf(setOf<Long>()) }
     var imageUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
-    var mediaUri by remember { mutableStateOf<Uri?>(null) }
     var videoUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var showTagPicker by remember { mutableStateOf(false) }
     var showCharacterPicker by remember { mutableStateOf(false) }
     var showSceneDialog by remember { mutableStateOf(false) }
     var editSceneIndex by remember { mutableStateOf<Int?>(null) }
+    var showFlowDialog by remember { mutableStateOf(false) }
+    var editFlowIndex by remember { mutableStateOf<Int?>(null) }
 
     val context = LocalContext.current
     val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) {
         imageUris = it
-    }
-    val mediaPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
-        mediaUri = uri
-        uri?.let {
-            context.contentResolver.takePersistableUriPermission(
-                it,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION
-            )
-        }
     }
     val videoPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
         videoUris = uris
@@ -449,17 +446,31 @@ private fun ResourceCreateScreen(
     }
 
     val screenTitle = when (mode) {
+        CreateMode.Flow -> "创建流程"
         CreateMode.Text -> "创建文本"
-        CreateMode.ImageText -> "创建图片文本"
-        CreateMode.Scene -> "创建聊天情景"
-        is CreateMode.Media -> "创建${typeLabel(mode.type)}文本"
+        CreateMode.ImageGroup -> "上传图片组"
+        CreateMode.Scene -> "创建情景"
+        CreateMode.VideoGroup -> "上传视频组"
+    }
+
+    val titleLabel = when (mode) {
+        CreateMode.Flow -> "流程名"
+        CreateMode.Text -> "文本名"
+        CreateMode.Scene -> "情景名"
+        CreateMode.ImageGroup -> "名称"
+        CreateMode.VideoGroup -> "名称"
     }
 
     val canSubmit = title.isNotBlank() && selectedCharacters.isNotEmpty() && when (mode) {
-        CreateMode.Text -> true
-        CreateMode.ImageText -> imageUris.isNotEmpty()
+        CreateMode.Flow -> flowItems.isNotEmpty()
+        CreateMode.Text -> textContent.isNotBlank()
+        CreateMode.ImageGroup -> imageUris.isNotEmpty()
         CreateMode.Scene -> sceneMessages.isNotEmpty()
-        is CreateMode.Media -> if (mode.type == ResourceType.VIDEO) videoUris.isNotEmpty() else mediaUri != null
+        CreateMode.VideoGroup -> videoUris.isNotEmpty()
+    }
+
+    val selectedSpeakerNames = remember(selectedCharacters, characters) {
+        characters.filter { selectedCharacters.contains(it.id) }.map { it.name }
     }
 
     Scaffold(
@@ -474,13 +485,19 @@ private fun ResourceCreateScreen(
                 actions = {
                     TextButton(onClick = {
                         when (mode) {
-                            CreateMode.Text -> vm.addTextQuote(
+                            CreateMode.Flow -> vm.addFlow(
                                 title.trim(),
-                                quoteText.trim(),
+                                flowItems,
                                 selectedTags.toList(),
                                 selectedCharacters.toList()
                             )
-                            CreateMode.ImageText -> vm.addImageQuote(
+                            CreateMode.Text -> vm.addTextResource(
+                                title.trim(),
+                                textContent.trim(),
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            CreateMode.ImageGroup -> vm.addImageGroup(
                                 title.trim(),
                                 imageUris,
                                 selectedTags.toList(),
@@ -493,24 +510,12 @@ private fun ResourceCreateScreen(
                                 selectedTags.toList(),
                                 selectedCharacters.toList()
                             )
-                            is CreateMode.Media -> if (mode.type == ResourceType.VIDEO) {
-                                val uris = videoUris
-                                vm.addEncryptedMediaGroup(
-                                    mode.type,
-                                    title.trim(),
-                                    uris,
-                                    selectedTags.toList(),
-                                    selectedCharacters.toList()
-                                )
-                            } else {
-                                vm.addEncryptedMedia(
-                                    mode.type,
-                                    title.trim(),
-                                    mediaUri ?: return@TextButton,
-                                    selectedTags.toList(),
-                                    selectedCharacters.toList()
-                                )
-                            }
+                            CreateMode.VideoGroup -> vm.addVideoGroup(
+                                title.trim(),
+                                videoUris,
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
                         }
                         onBack()
                     }, enabled = canSubmit) { Text("创建") }
@@ -528,19 +533,77 @@ private fun ResourceCreateScreen(
             OutlinedTextField(
                 value = title,
                 onValueChange = { title = it },
-                label = { Text("标题") },
+                label = { Text(titleLabel) },
                 modifier = Modifier.fillMaxWidth()
             )
             when (mode) {
+                CreateMode.Flow -> {
+                    TextButton(onClick = { showFlowDialog = true }) {
+                        Icon(Icons.Default.Description, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("添加步骤")
+                    }
+                    if (flowItems.isEmpty()) {
+                        Text("暂无步骤", style = MaterialTheme.typography.labelSmall)
+                    } else {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            flowItems.forEachIndexed { index, item ->
+                                androidx.compose.material3.OutlinedCard {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(12.dp),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Column(
+                                            modifier = Modifier.weight(1f),
+                                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                                        ) {
+                                            Text(
+                                                text = typeLabel(item.type),
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.primary
+                                            )
+                                            val summary = when (item.type) {
+                                                ResourceType.TEXT -> item.text.orEmpty()
+                                                ResourceType.SCENE -> "对话 ${item.sceneMessages.size} 条"
+                                                ResourceType.IMAGE -> "图片 ${item.images.size} 张"
+                                                ResourceType.VIDEO -> "视频 ${item.videos.size} 个"
+                                                else -> ""
+                                            }
+                                            if (summary.isNotBlank()) {
+                                                Text(text = summary, style = MaterialTheme.typography.bodySmall)
+                                            }
+                                        }
+                                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                            IconButton(onClick = {
+                                                editFlowIndex = index
+                                                showFlowDialog = true
+                                            }) {
+                                                Icon(Icons.Default.Edit, contentDescription = "编辑")
+                                            }
+                                            IconButton(onClick = {
+                                                flowItems = flowItems.toMutableList().also { it.removeAt(index) }
+                                            }) {
+                                                Icon(Icons.Default.Delete, contentDescription = "删除")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 CreateMode.Text -> {
                     OutlinedTextField(
-                        value = quoteText,
-                        onValueChange = { quoteText = it },
+                        value = textContent,
+                        onValueChange = { textContent = it },
                         label = { Text("文本内容") },
                         modifier = Modifier.fillMaxWidth()
                     )
                 }
-                CreateMode.ImageText -> {
+                CreateMode.ImageGroup -> {
                     TextButton(onClick = { imagePicker.launch("image/*") }) {
                         Icon(Icons.Default.Image, contentDescription = null)
                         Spacer(Modifier.width(8.dp))
@@ -555,7 +618,7 @@ private fun ResourceCreateScreen(
                         label = { Text("描述(可选)") },
                         modifier = Modifier.fillMaxWidth()
                     )
-                    TextButton(onClick = { showSceneDialog = true }) {
+                    TextButton(onClick = { showSceneDialog = true }, enabled = selectedSpeakerNames.isNotEmpty()) {
                         Icon(Icons.Default.Chat, contentDescription = null)
                         Spacer(Modifier.width(8.dp))
                         Text("添加对话")
@@ -603,28 +666,449 @@ private fun ResourceCreateScreen(
                         }
                     }
                 }
-                is CreateMode.Media -> {
-                    val label = if (mode.type == ResourceType.VIDEO) "选择视频" else "选择声音"
-                    TextButton(
-                        onClick = {
-                            if (mode.type == ResourceType.VIDEO) {
-                                videoPicker.launch(arrayOf("video/*"))
-                            } else {
-                                mediaPicker.launch(arrayOf("audio/*"))
+                CreateMode.VideoGroup -> {
+                    TextButton(onClick = { videoPicker.launch(arrayOf("video/*")) }) {
+                        Icon(Icons.Default.Videocam, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("选择视频")
+                    }
+                    Text(if (videoUris.isEmpty()) "未选择视频" else "已选择 ${videoUris.size} 个视频")
+                }
+            }
+            ResourceTagPickerRow(
+                label = "标签",
+                allTags = tags,
+                selected = selectedTags,
+                onPick = { showTagPicker = true }
+            )
+            ResourceCharacterPickerRow(
+                label = "角色",
+                characters = characters,
+                selected = selectedCharacters,
+                onPick = { showCharacterPicker = true }
+            )
+        }
+    }
+
+    if (showTagPicker) {
+        TagPickerDialog(
+            categories = categories,
+            tags = tags,
+            selectedIds = selectedTags,
+            onConfirm = { selectedTags = it },
+            onDismiss = { showTagPicker = false }
+        )
+    }
+    if (showCharacterPicker) {
+        CharacterPickerDialog(
+            characters = characters,
+            selectedIds = selectedCharacters,
+            onConfirm = { selectedCharacters = it },
+            onDismiss = { showCharacterPicker = false }
+        )
+    }
+    if (showSceneDialog) {
+        SceneMessageDialog(
+            title = if (editSceneIndex == null) "添加对话" else "编辑对话",
+            allowedSpeakers = selectedSpeakerNames,
+            initialSpeaker = editSceneIndex?.let { sceneMessages.getOrNull(it)?.speaker }.orEmpty(),
+            initialContent = editSceneIndex?.let { sceneMessages.getOrNull(it)?.content }.orEmpty(),
+            onConfirm = { speaker, content ->
+                if (speaker.isBlank() && content.isBlank()) {
+                    showSceneDialog = false
+                    editSceneIndex = null
+                } else {
+                    val updated = sceneMessages.toMutableList()
+                    if (editSceneIndex != null) {
+                        updated[editSceneIndex!!] = SceneMessageDraft(speaker.trim(), content.trim())
+                    } else {
+                        updated.add(SceneMessageDraft(speaker.trim(), content.trim()))
+                    }
+                    sceneMessages = updated
+                    showSceneDialog = false
+                    editSceneIndex = null
+                }
+            },
+            onAddAnother = if (editSceneIndex == null) {
+                { speaker, content ->
+                    if (speaker.isNotBlank() || content.isNotBlank()) {
+                        val updated = sceneMessages.toMutableList()
+                        updated.add(SceneMessageDraft(speaker.trim(), content.trim()))
+                        sceneMessages = updated
+                    }
+                }
+            } else {
+                null
+            },
+            onDismiss = {
+                showSceneDialog = false
+                editSceneIndex = null
+            }
+        )
+    }
+    if (showFlowDialog) {
+        FlowStepDialog(
+            allowedSpeakers = selectedSpeakerNames,
+            initialItem = editFlowIndex?.let { flowItems.getOrNull(it) },
+            onConfirm = { item ->
+                val updated = flowItems.toMutableList()
+                if (editFlowIndex != null) {
+                    updated[editFlowIndex!!] = item
+                } else {
+                    updated.add(item)
+                }
+                flowItems = updated
+                showFlowDialog = false
+                editFlowIndex = null
+            },
+            onDismiss = {
+                showFlowDialog = false
+                editFlowIndex = null
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ResourceEditScreen(
+    resource: ResourceWithTagsCharacters,
+    categories: List<TagCategoryEntity>,
+    tags: List<TagEntity>,
+    characters: List<CharacterEntity>,
+    vm: ResourceViewModel,
+    onBack: () -> Unit
+) {
+    var title by remember { mutableStateOf(resource.resource.title) }
+    var selectedTags by remember { mutableStateOf(resource.tags.map { it.id }.toSet()) }
+    var selectedCharacters by remember { mutableStateOf(resource.characters.map { it.id }.toSet()) }
+    var showTagPicker by remember { mutableStateOf(false) }
+    var showCharacterPicker by remember { mutableStateOf(false) }
+    var textContent by remember { mutableStateOf(resource.resource.quoteText.orEmpty()) }
+    var description by remember { mutableStateOf(resource.resource.quoteText.orEmpty()) }
+    var sceneMessages by remember { mutableStateOf(parseSceneMessages(resource.resource.sceneJson)) }
+    var imageItems by remember { mutableStateOf(parseImageItems(resource.resource.quoteImageBase64)) }
+    var videoItems by remember { mutableStateOf(parseVideoItems(resource.resource.contentUriOrPath)) }
+    var flowItems by remember { mutableStateOf(parseFlowItems(resource.resource.sceneJson)) }
+    var showSceneDialog by remember { mutableStateOf(false) }
+    var editSceneIndex by remember { mutableStateOf<Int?>(null) }
+    var showFlowDialog by remember { mutableStateOf(false) }
+    var editFlowIndex by remember { mutableStateOf<Int?>(null) }
+
+    val context = LocalContext.current
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
+        val updated = imageItems.toMutableList()
+        uris.forEach { uri -> updated.add(ImageUpdateItem(uri = uri)) }
+        imageItems = updated
+    }
+    val videoPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+        val updated = videoItems.toMutableList()
+        uris.forEach { uri ->
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+            updated.add(VideoUpdateItem(uri = uri))
+        }
+        videoItems = updated
+    }
+
+    val selectedSpeakerNames = remember(selectedCharacters, characters) {
+        characters.filter { selectedCharacters.contains(it.id) }.map { it.name }
+    }
+
+    val canSave = title.isNotBlank() && selectedCharacters.isNotEmpty() && when (resource.resource.type) {
+        ResourceType.FLOW -> flowItems.isNotEmpty()
+        ResourceType.TEXT -> textContent.isNotBlank()
+        ResourceType.IMAGE -> imageItems.isNotEmpty()
+        ResourceType.VIDEO -> videoItems.isNotEmpty()
+        ResourceType.SCENE -> sceneMessages.isNotEmpty()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("编辑资源") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    TextButton(onClick = {
+                        when (resource.resource.type) {
+                            ResourceType.FLOW -> vm.updateFlow(
+                                resource.resource,
+                                title.trim(),
+                                flowItems,
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            ResourceType.TEXT -> vm.updateTextResource(
+                                resource.resource,
+                                title.trim(),
+                                textContent.trim(),
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            ResourceType.IMAGE -> vm.updateImageGroup(
+                                resource.resource,
+                                title.trim(),
+                                imageItems,
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            ResourceType.VIDEO -> vm.updateVideoGroup(
+                                resource.resource,
+                                title.trim(),
+                                videoItems,
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            ResourceType.SCENE -> vm.updateSceneResource(
+                                resource.resource,
+                                title.trim(),
+                                description.ifBlank { null },
+                                buildSceneJson(sceneMessages),
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                        }
+                        onBack()
+                    }, enabled = canSave) { Text("保存") }
+                }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text(text = typeLabel(resource.resource.type), style = MaterialTheme.typography.labelMedium)
+            OutlinedTextField(
+                value = title,
+                onValueChange = { title = it },
+                label = { Text("名称") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            when (resource.resource.type) {
+                ResourceType.TEXT -> {
+                    OutlinedTextField(
+                        value = textContent,
+                        onValueChange = { textContent = it },
+                        label = { Text("文本内容") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+                ResourceType.IMAGE -> {
+                    TextButton(onClick = { imagePicker.launch("image/*") }) {
+                        Icon(Icons.Default.Image, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("追加图片")
+                    }
+                    if (imageItems.isEmpty()) {
+                        Text("暂无图片", style = MaterialTheme.typography.labelSmall)
+                    } else {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            imageItems.forEachIndexed { index, _ ->
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Text(text = "图片 ${index + 1}")
+                                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        IconButton(onClick = {
+                                            if (index > 0) {
+                                                imageItems = imageItems.toMutableList().also {
+                                                    it.add(index - 1, it.removeAt(index))
+                                                }
+                                            }
+                                        }) {
+                                            Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上移")
+                                        }
+                                        IconButton(onClick = {
+                                            if (index < imageItems.lastIndex) {
+                                                imageItems = imageItems.toMutableList().also {
+                                                    it.add(index + 1, it.removeAt(index))
+                                                }
+                                            }
+                                        }) {
+                                            Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下移")
+                                        }
+                                        IconButton(onClick = {
+                                            imageItems = imageItems.toMutableList().also { it.removeAt(index) }
+                                        }) {
+                                            Icon(Icons.Default.Delete, contentDescription = "删除")
+                                        }
+                                    }
+                                }
                             }
                         }
-                    ) {
-                        Icon(
-                            if (mode.type == ResourceType.VIDEO) Icons.Default.Videocam else Icons.Default.MusicNote,
-                            contentDescription = null
-                        )
-                        Spacer(Modifier.width(8.dp))
-                        Text(label)
                     }
-                    if (mode.type == ResourceType.VIDEO) {
-                        Text(if (videoUris.isEmpty()) "未选择视频" else "已选择 ${videoUris.size} 个视频")
+                }
+                ResourceType.VIDEO -> {
+                    TextButton(onClick = { videoPicker.launch(arrayOf("video/*")) }) {
+                        Icon(Icons.Default.Videocam, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("追加视频")
+                    }
+                    if (videoItems.isEmpty()) {
+                        Text("暂无视频", style = MaterialTheme.typography.labelSmall)
                     } else {
-                        Text(mediaUri?.toString() ?: "未选择文件")
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            videoItems.forEachIndexed { index, item ->
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    val label = item.path?.let { "视频 ${index + 1}" } ?: "新视频 ${index + 1}"
+                                    Text(text = label)
+                                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        IconButton(onClick = {
+                                            if (index > 0) {
+                                                videoItems = videoItems.toMutableList().also {
+                                                    it.add(index - 1, it.removeAt(index))
+                                                }
+                                            }
+                                        }) {
+                                            Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上移")
+                                        }
+                                        IconButton(onClick = {
+                                            if (index < videoItems.lastIndex) {
+                                                videoItems = videoItems.toMutableList().also {
+                                                    it.add(index + 1, it.removeAt(index))
+                                                }
+                                            }
+                                        }) {
+                                            Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下移")
+                                        }
+                                        IconButton(onClick = {
+                                            videoItems = videoItems.toMutableList().also { it.removeAt(index) }
+                                        }) {
+                                            Icon(Icons.Default.Delete, contentDescription = "删除")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                ResourceType.SCENE -> {
+                    OutlinedTextField(
+                        value = description,
+                        onValueChange = { description = it },
+                        label = { Text("描述(可选)") },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    TextButton(onClick = { showSceneDialog = true }, enabled = selectedSpeakerNames.isNotEmpty()) {
+                        Icon(Icons.Default.Chat, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("追加对话")
+                    }
+                    if (sceneMessages.isEmpty()) {
+                        Text("暂无对话", style = MaterialTheme.typography.labelSmall)
+                    } else {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            sceneMessages.forEachIndexed { index, message ->
+                                androidx.compose.material3.OutlinedCard {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(12.dp),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Column(
+                                            modifier = Modifier.weight(1f),
+                                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                                        ) {
+                                            Text(
+                                                text = message.speaker.ifBlank { "角色" },
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.primary
+                                            )
+                                            Text(text = message.content)
+                                        }
+                                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                            IconButton(onClick = {
+                                                editSceneIndex = index
+                                                showSceneDialog = true
+                                            }) {
+                                                Icon(Icons.Default.Edit, contentDescription = "编辑")
+                                            }
+                                            IconButton(onClick = {
+                                                sceneMessages = sceneMessages.toMutableList().also { it.removeAt(index) }
+                                            }) {
+                                                Icon(Icons.Default.Delete, contentDescription = "删除")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                ResourceType.FLOW -> {
+                    TextButton(onClick = { showFlowDialog = true }) {
+                        Icon(Icons.Default.Description, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("追加步骤")
+                    }
+                    if (flowItems.isEmpty()) {
+                        Text("暂无步骤", style = MaterialTheme.typography.labelSmall)
+                    } else {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            flowItems.forEachIndexed { index, item ->
+                                androidx.compose.material3.OutlinedCard {
+                                    Row(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(12.dp),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Column(
+                                            modifier = Modifier.weight(1f),
+                                            verticalArrangement = Arrangement.spacedBy(4.dp)
+                                        ) {
+                                            Text(
+                                                text = typeLabel(item.type),
+                                                style = MaterialTheme.typography.labelMedium,
+                                                color = MaterialTheme.colorScheme.primary
+                                            )
+                                            val summary = when (item.type) {
+                                                ResourceType.TEXT -> item.text.orEmpty()
+                                                ResourceType.SCENE -> "对话 ${item.sceneMessages.size} 条"
+                                                ResourceType.IMAGE -> "图片 ${item.images.size} 张"
+                                                ResourceType.VIDEO -> "视频 ${item.videos.size} 个"
+                                                else -> ""
+                                            }
+                                            if (summary.isNotBlank()) {
+                                                Text(text = summary, style = MaterialTheme.typography.bodySmall)
+                                            }
+                                        }
+                                        Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                            IconButton(onClick = {
+                                                editFlowIndex = index
+                                                showFlowDialog = true
+                                            }) {
+                                                Icon(Icons.Default.Edit, contentDescription = "编辑")
+                                            }
+                                            IconButton(onClick = {
+                                                flowItems = flowItems.toMutableList().also { it.removeAt(index) }
+                                            }) {
+                                                Icon(Icons.Default.Delete, contentDescription = "删除")
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }
@@ -663,6 +1147,7 @@ private fun ResourceCreateScreen(
     if (showSceneDialog) {
         SceneMessageDialog(
             title = if (editSceneIndex == null) "添加对话" else "编辑对话",
+            allowedSpeakers = selectedSpeakerNames,
             initialSpeaker = editSceneIndex?.let { sceneMessages.getOrNull(it)?.speaker }.orEmpty(),
             initialContent = editSceneIndex?.let { sceneMessages.getOrNull(it)?.content }.orEmpty(),
             onConfirm = { speaker, content ->
@@ -672,9 +1157,9 @@ private fun ResourceCreateScreen(
                 } else {
                     val updated = sceneMessages.toMutableList()
                     if (editSceneIndex != null) {
-                        updated[editSceneIndex!!] = SceneDraftMessage(speaker.trim(), content.trim())
+                        updated[editSceneIndex!!] = SceneMessageDraft(speaker.trim(), content.trim())
                     } else {
-                        updated.add(SceneDraftMessage(speaker.trim(), content.trim()))
+                        updated.add(SceneMessageDraft(speaker.trim(), content.trim()))
                     }
                     sceneMessages = updated
                     showSceneDialog = false
@@ -685,7 +1170,7 @@ private fun ResourceCreateScreen(
                 { speaker, content ->
                     if (speaker.isNotBlank() || content.isNotBlank()) {
                         val updated = sceneMessages.toMutableList()
-                        updated.add(SceneDraftMessage(speaker.trim(), content.trim()))
+                        updated.add(SceneMessageDraft(speaker.trim(), content.trim()))
                         sceneMessages = updated
                     }
                 }
@@ -698,90 +1183,25 @@ private fun ResourceCreateScreen(
             }
         )
     }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun ResourceEditScreen(
-    resource: ResourceWithTagsCharacters,
-    categories: List<TagCategoryEntity>,
-    tags: List<TagEntity>,
-    characters: List<CharacterEntity>,
-    vm: ResourceViewModel,
-    onBack: () -> Unit
-) {
-    var title by remember { mutableStateOf(resource.resource.title) }
-    var selectedTags by remember { mutableStateOf(resource.tags.map { it.id }.toSet()) }
-    var selectedCharacters by remember { mutableStateOf(resource.characters.map { it.id }.toSet()) }
-    var showTagPicker by remember { mutableStateOf(false) }
-    var showCharacterPicker by remember { mutableStateOf(false) }
-
-    Scaffold(
-        topBar = {
-            TopAppBar(
-                title = { Text("编辑资源") },
-                navigationIcon = {
-                    IconButton(onClick = onBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "返回")
-                    }
-                },
-                actions = {
-                    TextButton(onClick = {
-                        if (title.isNotBlank() && selectedCharacters.isNotEmpty()) {
-                            vm.updateResource(resource.resource.copy(title = title.trim()))
-                            vm.updateResourceTags(resource.resource.id, selectedTags.toList())
-                            vm.updateResourceCharacters(resource.resource.id, selectedCharacters.toList())
-                            onBack()
-                        }
-                    }) { Text("保存") }
+    if (showFlowDialog) {
+        FlowStepDialog(
+            allowedSpeakers = selectedSpeakerNames,
+            initialItem = editFlowIndex?.let { flowItems.getOrNull(it) },
+            onConfirm = { item ->
+                val updated = flowItems.toMutableList()
+                if (editFlowIndex != null) {
+                    updated[editFlowIndex!!] = item
+                } else {
+                    updated.add(item)
                 }
-            )
-        }
-    ) { inner ->
-        Column(
-            modifier = Modifier
-                .padding(inner)
-                .fillMaxSize()
-                .padding(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Text(text = typeLabel(resource.resource.type), style = MaterialTheme.typography.labelMedium)
-            OutlinedTextField(
-                value = title,
-                onValueChange = { title = it },
-                label = { Text("标题") },
-                modifier = Modifier.fillMaxWidth()
-            )
-            ResourceTagPickerRow(
-                label = "标签",
-                allTags = tags,
-                selected = selectedTags,
-                onPick = { showTagPicker = true }
-            )
-            ResourceCharacterPickerRow(
-                label = "角色",
-                characters = characters,
-                selected = selectedCharacters,
-                onPick = { showCharacterPicker = true }
-            )
-        }
-    }
-
-    if (showTagPicker) {
-        TagPickerDialog(
-            categories = categories,
-            tags = tags,
-            selectedIds = selectedTags,
-            onConfirm = { selectedTags = it },
-            onDismiss = { showTagPicker = false }
-        )
-    }
-    if (showCharacterPicker) {
-        CharacterPickerDialog(
-            characters = characters,
-            selectedIds = selectedCharacters,
-            onConfirm = { selectedCharacters = it },
-            onDismiss = { showCharacterPicker = false }
+                flowItems = updated
+                showFlowDialog = false
+                editFlowIndex = null
+            },
+            onDismiss = {
+                showFlowDialog = false
+                editFlowIndex = null
+            }
         )
     }
 }
@@ -980,26 +1400,48 @@ private fun TagFilterChip(
 @Composable
 private fun SceneMessageDialog(
     title: String,
+    allowedSpeakers: List<String>,
     initialSpeaker: String,
     initialContent: String,
     onConfirm: (String, String) -> Unit,
     onAddAnother: ((String, String) -> Unit)?,
     onDismiss: () -> Unit
 ) {
-    var speaker by remember(initialSpeaker) { mutableStateOf(initialSpeaker) }
+    var speaker by remember(initialSpeaker, allowedSpeakers) {
+        mutableStateOf(if (initialSpeaker in allowedSpeakers) initialSpeaker else allowedSpeakers.firstOrNull().orEmpty())
+    }
     var content by remember(initialContent) { mutableStateOf(initialContent) }
-    val hasContent = speaker.isNotBlank() || content.isNotBlank()
+    val canPickSpeaker = allowedSpeakers.isNotEmpty()
+    val hasContent = speaker.isNotBlank() && content.isNotBlank()
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(title) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                OutlinedTextField(
-                    value = speaker,
-                    onValueChange = { speaker = it },
-                    label = { Text("角色") },
-                    modifier = Modifier.fillMaxWidth()
-                )
+                if (allowedSpeakers.isEmpty()) {
+                    Text("请先选择角色再添加对话", style = MaterialTheme.typography.labelMedium)
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        Text("角色")
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            allowedSpeakers.forEach { name ->
+                                FilterChip(
+                                    selected = speaker == name,
+                                    onClick = { speaker = name },
+                                    label = { Text(name) },
+                                    colors = FilterChipDefaults.filterChipColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                        selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                                        selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                                    )
+                                )
+                            }
+                        }
+                    }
+                }
                 OutlinedTextField(
                     value = content,
                     onValueChange = { content = it },
@@ -1017,17 +1459,358 @@ private fun SceneMessageDialog(
                             speaker = ""
                             content = ""
                         },
-                        enabled = hasContent
+                        enabled = hasContent && canPickSpeaker
                     ) { Text("继续添加") }
                 }
-                TextButton(onClick = { onConfirm(speaker, content) }, enabled = hasContent) { Text("确定") }
+                TextButton(onClick = { onConfirm(speaker, content) }, enabled = hasContent && canPickSpeaker) { Text("确定") }
             }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )
 }
 
-private fun buildSceneJson(messages: List<SceneDraftMessage>): String {
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
+@Composable
+private fun FlowStepDialog(
+    allowedSpeakers: List<String>,
+    initialItem: FlowUpdateItem?,
+    onConfirm: (FlowUpdateItem) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var selectedType by remember { mutableStateOf(initialItem?.type ?: ResourceType.TEXT) }
+    var text by remember { mutableStateOf(initialItem?.text.orEmpty()) }
+    var sceneMessages by remember { mutableStateOf(initialItem?.sceneMessages ?: emptyList()) }
+    var imageItems by remember { mutableStateOf(initialItem?.images ?: emptyList()) }
+    var videoItems by remember { mutableStateOf(initialItem?.videos ?: emptyList()) }
+    var showSceneDialog by remember { mutableStateOf(false) }
+    var editSceneIndex by remember { mutableStateOf<Int?>(null) }
+
+    val context = LocalContext.current
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
+        val updated = imageItems.toMutableList()
+        uris.forEach { uri -> updated.add(ImageUpdateItem(uri = uri)) }
+        imageItems = updated
+    }
+    val videoPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+        val updated = videoItems.toMutableList()
+        uris.forEach { uri ->
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION
+            )
+            updated.add(VideoUpdateItem(uri = uri))
+        }
+        videoItems = updated
+    }
+
+    val canSubmit = when (selectedType) {
+        ResourceType.TEXT -> text.isNotBlank()
+        ResourceType.SCENE -> sceneMessages.isNotEmpty() && allowedSpeakers.isNotEmpty()
+        ResourceType.IMAGE -> imageItems.isNotEmpty()
+        ResourceType.VIDEO -> videoItems.isNotEmpty()
+        else -> false
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("流程步骤") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("步骤类型")
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    listOf(ResourceType.TEXT, ResourceType.SCENE, ResourceType.IMAGE, ResourceType.VIDEO).forEach { type ->
+                        FilterChip(
+                            selected = selectedType == type,
+                            onClick = { selectedType = type },
+                            label = { Text(typeLabel(type)) }
+                        )
+                    }
+                }
+                when (selectedType) {
+                    ResourceType.TEXT -> {
+                        OutlinedTextField(
+                            value = text,
+                            onValueChange = { text = it },
+                            label = { Text("文本内容") },
+                            modifier = Modifier.fillMaxWidth()
+                        )
+                    }
+                    ResourceType.SCENE -> {
+                        TextButton(onClick = { showSceneDialog = true }, enabled = allowedSpeakers.isNotEmpty()) {
+                            Icon(Icons.Default.Chat, contentDescription = null)
+                            Spacer(Modifier.width(8.dp))
+                            Text("添加对话")
+                        }
+                        if (sceneMessages.isEmpty()) {
+                            Text("暂无对话", style = MaterialTheme.typography.labelSmall)
+                        } else {
+                            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                sceneMessages.forEachIndexed { index, message ->
+                                    androidx.compose.material3.OutlinedCard {
+                                        Row(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(12.dp),
+                                            horizontalArrangement = Arrangement.SpaceBetween,
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            Column(
+                                                modifier = Modifier.weight(1f),
+                                                verticalArrangement = Arrangement.spacedBy(4.dp)
+                                            ) {
+                                                Text(
+                                                    text = message.speaker.ifBlank { "角色" },
+                                                    style = MaterialTheme.typography.labelMedium,
+                                                    color = MaterialTheme.colorScheme.primary
+                                                )
+                                                Text(text = message.content)
+                                            }
+                                            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                                IconButton(onClick = {
+                                                    editSceneIndex = index
+                                                    showSceneDialog = true
+                                                }) {
+                                                    Icon(Icons.Default.Edit, contentDescription = "编辑")
+                                                }
+                                                IconButton(onClick = {
+                                                    sceneMessages = sceneMessages.toMutableList().also { it.removeAt(index) }
+                                                }) {
+                                                    Icon(Icons.Default.Delete, contentDescription = "删除")
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    ResourceType.IMAGE -> {
+                        TextButton(onClick = { imagePicker.launch("image/*") }) {
+                            Icon(Icons.Default.Image, contentDescription = null)
+                            Spacer(Modifier.width(8.dp))
+                            Text("选择图片")
+                        }
+                        if (imageItems.isEmpty()) {
+                            Text("未选择图片")
+                        } else {
+                            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                                Text("已选择 ${imageItems.size} 张图片")
+                                imageItems.forEachIndexed { index, _ ->
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Text("图片 ${index + 1}")
+                                        IconButton(onClick = {
+                                            imageItems = imageItems.toMutableList().also { it.removeAt(index) }
+                                        }) {
+                                            Icon(Icons.Default.Delete, contentDescription = "删除")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    ResourceType.VIDEO -> {
+                        TextButton(onClick = { videoPicker.launch(arrayOf("video/*")) }) {
+                            Icon(Icons.Default.Videocam, contentDescription = null)
+                            Spacer(Modifier.width(8.dp))
+                            Text("选择视频")
+                        }
+                        if (videoItems.isEmpty()) {
+                            Text("未选择视频")
+                        } else {
+                            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                                Text("已选择 ${videoItems.size} 个视频")
+                                videoItems.forEachIndexed { index, _ ->
+                                    Row(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.SpaceBetween,
+                                        verticalAlignment = Alignment.CenterVertically
+                                    ) {
+                                        Text("视频 ${index + 1}")
+                                        IconButton(onClick = {
+                                            videoItems = videoItems.toMutableList().also { it.removeAt(index) }
+                                        }) {
+                                            Icon(Icons.Default.Delete, contentDescription = "删除")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else -> {}
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(
+                onClick = {
+                    onConfirm(
+                        FlowUpdateItem(
+                            type = selectedType,
+                            text = text,
+                            sceneMessages = sceneMessages,
+                            images = imageItems,
+                            videos = videoItems
+                        )
+                    )
+                },
+                enabled = canSubmit
+            ) { Text("确定") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
+
+    if (showSceneDialog) {
+        SceneMessageDialog(
+            title = if (editSceneIndex == null) "添加对话" else "编辑对话",
+            allowedSpeakers = allowedSpeakers,
+            initialSpeaker = editSceneIndex?.let { sceneMessages.getOrNull(it)?.speaker }.orEmpty(),
+            initialContent = editSceneIndex?.let { sceneMessages.getOrNull(it)?.content }.orEmpty(),
+            onConfirm = { speaker, content ->
+                if (speaker.isBlank() && content.isBlank()) {
+                    showSceneDialog = false
+                    editSceneIndex = null
+                } else {
+                    val updated = sceneMessages.toMutableList()
+                    if (editSceneIndex != null) {
+                        updated[editSceneIndex!!] = SceneMessageDraft(speaker.trim(), content.trim())
+                    } else {
+                        updated.add(SceneMessageDraft(speaker.trim(), content.trim()))
+                    }
+                    sceneMessages = updated
+                    showSceneDialog = false
+                    editSceneIndex = null
+                }
+            },
+            onAddAnother = if (editSceneIndex == null) {
+                { speaker, content ->
+                    if (speaker.isNotBlank() || content.isNotBlank()) {
+                        val updated = sceneMessages.toMutableList()
+                        updated.add(SceneMessageDraft(speaker.trim(), content.trim()))
+                        sceneMessages = updated
+                    }
+                }
+            } else {
+                null
+            },
+            onDismiss = {
+                showSceneDialog = false
+                editSceneIndex = null
+            }
+        )
+    }
+}
+
+private fun parseSceneMessages(raw: String?): List<SceneMessageDraft> {
+    if (raw.isNullOrBlank()) return emptyList()
+    return runCatching {
+        val array = org.json.JSONArray(raw)
+        buildList {
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                val speaker = obj.optString("speaker")
+                val content = obj.optString("text")
+                if (speaker.isNotBlank() || content.isNotBlank()) {
+                    add(SceneMessageDraft(speaker.ifBlank { "角色" }, content))
+                }
+            }
+        }
+    }.getOrDefault(emptyList())
+}
+
+private fun parseImageItems(payload: String?): List<ImageUpdateItem> {
+    if (payload.isNullOrBlank()) return emptyList()
+    val base64List = runCatching {
+        val array = org.json.JSONArray(payload)
+        buildList {
+            for (i in 0 until array.length()) {
+                val item = array.optString(i)
+                if (item.isNotBlank()) add(item)
+            }
+        }
+    }.getOrElse { listOf(payload) }
+    return base64List.map { ImageUpdateItem(base64 = it) }
+}
+
+private fun parseVideoItems(raw: String?): List<VideoUpdateItem> {
+    if (raw.isNullOrBlank()) return emptyList()
+    val list = if (raw.trim().startsWith("[")) {
+        runCatching {
+            val array = org.json.JSONArray(raw)
+            List(array.length()) { index -> array.getString(index) }
+        }.getOrDefault(listOf(raw))
+    } else {
+        listOf(raw)
+    }
+    return list.map { VideoUpdateItem(path = it) }
+}
+
+private fun parseFlowItems(raw: String?): List<FlowUpdateItem> {
+    if (raw.isNullOrBlank()) return emptyList()
+    return runCatching {
+        val array = org.json.JSONArray(raw)
+        buildList {
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                val type = runCatching { ResourceType.valueOf(obj.optString("type")) }.getOrNull() ?: continue
+                when (type) {
+                    ResourceType.TEXT -> add(
+                        FlowUpdateItem(type = type, text = obj.optString("text"))
+                    )
+                    ResourceType.SCENE -> {
+                        val messages = obj.optJSONArray("messages")
+                        val parsed = buildList {
+                            if (messages != null) {
+                                for (j in 0 until messages.length()) {
+                                    val msg = messages.optJSONObject(j) ?: continue
+                                    val speaker = msg.optString("speaker")
+                                    val content = msg.optString("text")
+                                    if (speaker.isNotBlank() || content.isNotBlank()) {
+                                        add(SceneMessageDraft(speaker.ifBlank { "角色" }, content))
+                                    }
+                                }
+                            }
+                        }
+                        add(FlowUpdateItem(type = type, sceneMessages = parsed))
+                    }
+                    ResourceType.IMAGE -> {
+                        val images = obj.optJSONArray("images")
+                        val parsed = buildList {
+                            if (images != null) {
+                                for (j in 0 until images.length()) {
+                                    val item = images.optString(j)
+                                    if (item.isNotBlank()) add(ImageUpdateItem(base64 = item))
+                                }
+                            }
+                        }
+                        add(FlowUpdateItem(type = type, images = parsed))
+                    }
+                    ResourceType.VIDEO -> {
+                        val videos = obj.optJSONArray("videos")
+                        val parsed = buildList {
+                            if (videos != null) {
+                                for (j in 0 until videos.length()) {
+                                    val item = videos.optString(j)
+                                    if (item.isNotBlank()) add(VideoUpdateItem(path = item))
+                                }
+                            }
+                        }
+                        add(FlowUpdateItem(type = type, videos = parsed))
+                    }
+                    else -> {}
+                }
+            }
+        }
+    }.getOrDefault(emptyList())
+}
+
+private fun buildSceneJson(messages: List<SceneMessageDraft>): String {
     val array = org.json.JSONArray()
     messages.forEach { message ->
         val obj = org.json.JSONObject()

--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
@@ -22,8 +23,11 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
@@ -44,6 +48,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.data.TagCategoryEntity
+import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.ui.components.NameDialog
 import com.example.quotepicker.ui.components.SquareGridItem
@@ -67,6 +72,12 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     val isInCategory = ui.currentCategory != null
     val categoryTagCounts = remember(ui.allTags) {
         ui.allTags.groupingBy { it.categoryId }.eachCount()
+    }
+    val characterCategories = remember(ui.categories) {
+        ui.categories.filter { it.type == TagCategoryType.CHARACTER }
+    }
+    val resourceCategories = remember(ui.categories) {
+        ui.categories.filter { it.type == TagCategoryType.RESOURCE }
     }
 
     Scaffold(
@@ -93,26 +104,55 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     ) { inner ->
         Column(Modifier.padding(inner).fillMaxSize()) {
             if (!isInCategory) {
-                if (ui.categories.isEmpty()) {
+                if (characterCategories.isEmpty() && resourceCategories.isEmpty()) {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Text("暂无标签类别，点击右下角添加")
                     }
                 } else {
-                    val categories = ui.categories.sortedBy { it.name.lowercase() }
                     LazyVerticalGrid(
                         columns = GridCells.Fixed(5),
                         contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
                         horizontalArrangement = Arrangement.spacedBy(8.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        items(categories, key = { it.id }) { category ->
-                            val count = categoryTagCounts[category.id] ?: 0
-                            SquareGridItem(
-                                title = category.name,
-                                subtitle = "标签 $count",
-                                onClick = { vm.selectCategory(category.id) },
-                                onLongClick = { bottomSheetTarget = category }
-                            )
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            Text("角色标签", style = MaterialTheme.typography.titleMedium)
+                        }
+                        if (characterCategories.isEmpty()) {
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                Text("暂无角色标签类别", style = MaterialTheme.typography.labelMedium)
+                            }
+                        } else {
+                            items(characterCategories.sortedBy { it.name.lowercase() }, key = { it.id }) { category ->
+                                val count = categoryTagCounts[category.id] ?: 0
+                                SquareGridItem(
+                                    title = category.name,
+                                    subtitle = "标签 $count",
+                                    onClick = { vm.selectCategory(category.id) },
+                                    onLongClick = { bottomSheetTarget = category }
+                                )
+                            }
+                        }
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            Spacer(Modifier.height(8.dp))
+                        }
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            Text("资源标签", style = MaterialTheme.typography.titleMedium)
+                        }
+                        if (resourceCategories.isEmpty()) {
+                            item(span = { GridItemSpan(maxLineSpan) }) {
+                                Text("暂无资源标签类别", style = MaterialTheme.typography.labelMedium)
+                            }
+                        } else {
+                            items(resourceCategories.sortedBy { it.name.lowercase() }, key = { it.id }) { category ->
+                                val count = categoryTagCounts[category.id] ?: 0
+                                SquareGridItem(
+                                    title = category.name,
+                                    subtitle = "标签 $count",
+                                    onClick = { vm.selectCategory(category.id) },
+                                    onLongClick = { bottomSheetTarget = category }
+                                )
+                            }
                         }
                     }
                 }
@@ -147,10 +187,9 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     }
 
     if (showCategoryDialog) {
-        NameDialog(
+        CategoryDialog(
             title = "新增类别",
-            initial = "",
-            onConfirm = { vm.addCategory(it) },
+            onConfirm = { name, type -> vm.addCategory(name, type) },
             onDismiss = { showCategoryDialog = false }
         )
     }
@@ -291,6 +330,59 @@ private fun TagDialog(
         confirmButton = {
             TextButton(onClick = {
                 if (name.isNotBlank()) onConfirm(name.trim(), palette[colorIndex])
+                onDismiss()
+            }) { Text("确定") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
+}
+
+@Composable
+private fun CategoryDialog(
+    title: String,
+    onConfirm: (String, TagCategoryType) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var name by remember { mutableStateOf("") }
+    var selectedType by remember { mutableStateOf(TagCategoryType.CHARACTER) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(title) },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = name,
+                    onValueChange = { name = it },
+                    label = { Text("类别名称") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    FilterChip(
+                        selected = selectedType == TagCategoryType.CHARACTER,
+                        onClick = { selectedType = TagCategoryType.CHARACTER },
+                        label = { Text("角色标签") },
+                        colors = FilterChipDefaults.filterChipColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    )
+                    FilterChip(
+                        selected = selectedType == TagCategoryType.RESOURCE,
+                        onClick = { selectedType = TagCategoryType.RESOURCE },
+                        label = { Text("资源标签") },
+                        colors = FilterChipDefaults.filterChipColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                            selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                            selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                if (name.isNotBlank()) onConfirm(name.trim(), selectedType)
                 onDismiss()
             }) { Text("确定") }
         },

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -55,6 +55,15 @@ import org.json.JSONArray
 
 private data class SceneMessage(val speaker: String, val content: String)
 
+private data class FlowPreviewItem(
+    val type: ResourceType,
+    val text: String = "",
+    val sceneMessages: List<SceneMessage> = emptyList(),
+    val images: List<android.graphics.Bitmap> = emptyList(),
+    val mediaUris: List<Uri> = emptyList(),
+    val mediaFailed: Boolean = false
+)
+
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
 fun ResourcePreviewScreen(
@@ -67,25 +76,23 @@ fun ResourcePreviewScreen(
     var mediaLoadFailed by remember { mutableStateOf(false) }
     var mediaReloadKey by remember { mutableStateOf(0) }
     var sceneMessages by remember { mutableStateOf<List<SceneMessage>>(emptyList()) }
+    var flowItems by remember { mutableStateOf<List<FlowPreviewItem>>(emptyList()) }
     val scrollState = rememberScrollState()
 
     LaunchedEffect(resource.resource.id, mediaReloadKey) {
         val res = resource.resource
         quoteImages = emptyList()
         mediaLoadFailed = false
+        flowItems = emptyList()
         if (res.type == ResourceType.IMAGE) {
-            val images = mutableListOf<android.graphics.Bitmap>()
-            res.contentUriOrPath?.let { path ->
-                val bytes = vm.loadDecryptedBytes(path)
-                android.graphics.BitmapFactory.decodeByteArray(bytes, 0, bytes.size)?.let { images.add(it) }
-            }
-            images.addAll(decodeQuoteImages(res.quoteImageBase64, vm))
-            quoteImages = images
-        } else if (res.type == ResourceType.QUOTE) {
             quoteImages = decodeQuoteImages(res.quoteImageBase64, vm)
+        } else if (res.type == ResourceType.TEXT) {
+            quoteImages = decodeQuoteImages(res.quoteImageBase64, vm)
+        } else if (res.type == ResourceType.FLOW) {
+            flowItems = parseFlowItems(res.sceneJson.orEmpty(), vm)
         }
         mediaUris = when (res.type) {
-            ResourceType.VIDEO, ResourceType.AUDIO -> {
+            ResourceType.VIDEO -> {
                 val raw = res.contentUriOrPath
                 if (raw.isNullOrBlank()) {
                     Log.e("ResourcePreview", "Missing media path for type=${res.type} id=${res.id}")
@@ -100,7 +107,7 @@ fun ResourcePreviewScreen(
                 }
                 val uriList = mutableListOf<Uri>()
                 paths.forEachIndexed { index, path ->
-                    val extension = resolvePreviewExtension(path, res.type)
+                    val extension = resolvePreviewExtension(path)
                     Log.d(
                         "ResourcePreview",
                         "Preparing media preview type=${res.type} id=${res.id} index=$index path=$path"
@@ -124,7 +131,7 @@ fun ResourcePreviewScreen(
             }
             else -> emptyList()
         }
-        sceneMessages = parseSceneMessages(res.sceneJson.orEmpty())
+        sceneMessages = if (res.type == ResourceType.SCENE) parseSceneMessages(res.sceneJson.orEmpty()) else emptyList()
     }
 
     Scaffold(
@@ -191,7 +198,7 @@ fun ResourcePreviewScreen(
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
                     when (resource.resource.type) {
-                        ResourceType.QUOTE -> {
+                        ResourceType.TEXT -> {
                             if (!resource.resource.quoteText.isNullOrBlank()) {
                                 Text(resource.resource.quoteText.orEmpty())
                             }
@@ -219,22 +226,6 @@ fun ResourcePreviewScreen(
                                 Text("视频加载中…")
                             }
                         }
-                        ResourceType.AUDIO -> {
-                            if (mediaUris.isNotEmpty()) {
-                                MediaPreview(uri = mediaUris.first())
-                                Text("音频播放中")
-                            } else if (mediaLoadFailed) {
-                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    Text("音频加载失败")
-                                    AssistChip(
-                                        onClick = { mediaReloadKey += 1 },
-                                        label = { Text("重试") }
-                                    )
-                                }
-                            } else {
-                                Text("音频加载中…")
-                            }
-                        }
                         ResourceType.SCENE -> {
                             if (sceneMessages.isNotEmpty()) {
                                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -244,6 +235,45 @@ fun ResourcePreviewScreen(
                                 }
                             } else {
                                 Text(resource.resource.sceneJson.orEmpty())
+                            }
+                        }
+                        ResourceType.FLOW -> {
+                            if (flowItems.isEmpty()) {
+                                Text("流程内容为空")
+                            } else {
+                                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                    flowItems.forEachIndexed { index, item ->
+                                        Card(modifier = Modifier.fillMaxWidth()) {
+                                            Column(
+                                                modifier = Modifier
+                                                    .fillMaxWidth()
+                                                    .padding(12.dp),
+                                                verticalArrangement = Arrangement.spacedBy(8.dp)
+                                            ) {
+                                                Text("步骤 ${index + 1} - ${typeLabel(item.type)}")
+                                                when (item.type) {
+                                                    ResourceType.TEXT -> Text(item.text)
+                                                    ResourceType.SCENE -> {
+                                                        item.sceneMessages.forEach { message ->
+                                                            SceneBubble(message = message)
+                                                        }
+                                                    }
+                                                    ResourceType.IMAGE -> QuoteImagePager(images = item.images)
+                                                    ResourceType.VIDEO -> {
+                                                        if (item.mediaUris.isNotEmpty()) {
+                                                            MediaPreviewPager(uris = item.mediaUris)
+                                                        } else if (item.mediaFailed) {
+                                                            Text("视频加载失败")
+                                                        } else {
+                                                            Text("视频加载中…")
+                                                        }
+                                                    }
+                                                    else -> {}
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
                             }
                         }
                     }
@@ -321,8 +351,8 @@ private fun parseMediaPaths(raw: String): List<String> {
     return listOf(raw)
 }
 
-private fun resolvePreviewExtension(path: String, type: ResourceType): String {
-    val fallback = if (type == ResourceType.VIDEO) "mp4" else "mp3"
+private fun resolvePreviewExtension(path: String): String {
+    val fallback = "mp4"
     val fileName = File(path).name.removeSuffix(".enc")
     val ext = fileName.substringAfterLast('.', "")
     return if (ext.isNotBlank()) ext else fallback
@@ -364,6 +394,82 @@ private fun parseSceneMessages(raw: String): List<SceneMessage> {
             }
         }
     }.getOrDefault(emptyList())
+}
+
+private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<FlowPreviewItem> {
+    if (raw.isBlank()) return emptyList()
+    return runCatching {
+        val array = JSONArray(raw)
+        buildList {
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                val type = runCatching { ResourceType.valueOf(obj.optString("type")) }.getOrNull() ?: continue
+                when (type) {
+                    ResourceType.TEXT -> add(
+                        FlowPreviewItem(type = type, text = obj.optString("text"))
+                    )
+                    ResourceType.SCENE -> {
+                        val messages = obj.optJSONArray("messages") ?: JSONArray()
+                        val parsed = buildList {
+                            for (j in 0 until messages.length()) {
+                                val msg = messages.optJSONObject(j) ?: continue
+                                val speaker = msg.optString("speaker")
+                                val content = msg.optString("text")
+                                if (speaker.isNotBlank() || content.isNotBlank()) {
+                                    add(SceneMessage(speaker.ifBlank { "角色" }, content))
+                                }
+                            }
+                        }
+                        add(FlowPreviewItem(type = type, sceneMessages = parsed))
+                    }
+                    ResourceType.IMAGE -> {
+                        val images = obj.optJSONArray("images") ?: JSONArray()
+                        val bitmaps = buildList {
+                            for (j in 0 until images.length()) {
+                                val item = images.optString(j)
+                                if (item.isNotBlank()) {
+                                    vm.decodeBase64ToBitmap(item)?.let { add(it) }
+                                }
+                            }
+                        }
+                        add(FlowPreviewItem(type = type, images = bitmaps))
+                    }
+                    ResourceType.VIDEO -> {
+                        val videos = obj.optJSONArray("videos") ?: JSONArray()
+                        val uriList = mutableListOf<Uri>()
+                        var failed = false
+                        for (j in 0 until videos.length()) {
+                            val path = videos.optString(j)
+                            if (path.isBlank()) continue
+                            val extension = resolvePreviewExtension(path)
+                            val file = vm.writeDecryptedToCache(path, extension)
+                            if (file == null || !file.exists() || file.length() == 0L) {
+                                failed = true
+                            } else {
+                                uriList.add(Uri.fromFile(file))
+                            }
+                        }
+                        add(
+                            FlowPreviewItem(
+                                type = type,
+                                mediaUris = uriList,
+                                mediaFailed = failed
+                            )
+                        )
+                    }
+                    else -> {}
+                }
+            }
+        }
+    }.getOrDefault(emptyList())
+}
+
+private fun typeLabel(type: ResourceType): String = when (type) {
+    ResourceType.FLOW -> "流程"
+    ResourceType.TEXT -> "文本"
+    ResourceType.IMAGE -> "图片"
+    ResourceType.VIDEO -> "视频"
+    ResourceType.SCENE -> "情景"
 }
 
 @Composable

--- a/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
@@ -7,6 +7,7 @@ import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.CharacterWithTags
 import com.example.quotepicker.data.Repository
 import com.example.quotepicker.data.TagCategoryEntity
+import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -28,7 +29,10 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
         repo.observeCategories(),
         repo.observeAllTags()
     ) { characters, categories, tags ->
-        CharacterUiState(characters = characters, categories = categories, tags = tags)
+        val roleCategories = categories.filter { it.type == TagCategoryType.CHARACTER }
+        val roleCategoryIds = roleCategories.map { it.id }.toSet()
+        val roleTags = tags.filter { it.categoryId in roleCategoryIds }
+        CharacterUiState(characters = characters, categories = roleCategories, tags = roleTags)
     }.stateIn(viewModelScope, SharingStarted.Eagerly, CharacterUiState())
 
     fun addCharacter(name: String) = viewModelScope.launch { repo.addCharacter(name) }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -15,6 +15,7 @@ import com.example.quotepicker.data.ResourceEntity
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.data.TagCategoryEntity
+import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.util.EncryptedFileManager
@@ -46,6 +47,29 @@ data class ResourceUiState(
     val filters: ResourceFilterState = ResourceFilterState()
 )
 
+data class ImageUpdateItem(
+    val base64: String? = null,
+    val uri: Uri? = null
+)
+
+data class VideoUpdateItem(
+    val path: String? = null,
+    val uri: Uri? = null
+)
+
+data class SceneMessageDraft(
+    val speaker: String,
+    val content: String
+)
+
+data class FlowUpdateItem(
+    val type: ResourceType,
+    val text: String? = null,
+    val sceneMessages: List<SceneMessageDraft> = emptyList(),
+    val images: List<ImageUpdateItem> = emptyList(),
+    val videos: List<VideoUpdateItem> = emptyList()
+)
+
 class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     private val repo = Repository.get(app)
     private val fileManager = EncryptedFileManager(app)
@@ -62,6 +86,9 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         repo.observeCharacters(),
         filters
     ) { resources, categories, tags, characters, filter ->
+        val resourceCategories = categories.filter { it.type == TagCategoryType.RESOURCE }
+        val resourceCategoryIds = resourceCategories.map { it.id }.toSet()
+        val resourceTags = tags.filter { it.categoryId in resourceCategoryIds }
         val filtered = resources.filter { res ->
             val typeMatch = filter.selectedType?.let { it == res.resource.type } ?: true
             val charMatch = filter.selectedCharacterId?.let { id ->
@@ -76,8 +103,8 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         }
         ResourceUiState(
             resources = filtered,
-            categories = categories,
-            tags = tags,
+            categories = resourceCategories,
+            tags = resourceTags,
             characters = characters,
             filters = filter
         )
@@ -95,17 +122,17 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         filters.value = filters.value.copy(selectedCharacterId = characterId)
     }
 
-    fun addTextQuote(title: String, text: String, tagIds: List<Long>, characterIds: List<Long>) =
+    fun addTextResource(title: String, text: String, tagIds: List<Long>, characterIds: List<Long>) =
         viewModelScope.launch {
             if (characterIds.isEmpty()) return@launch
             repo.addResource(
-                ResourceEntity(type = ResourceType.QUOTE, title = title, quoteText = text),
+                ResourceEntity(type = ResourceType.TEXT, title = title, quoteText = text),
                 tagIds,
                 characterIds
             )
         }
 
-    fun addImageQuote(title: String, imageUris: List<Uri>, tagIds: List<Long>, characterIds: List<Long>) =
+    fun addImageGroup(title: String, imageUris: List<Uri>, tagIds: List<Long>, characterIds: List<Long>) =
         viewModelScope.launch(Dispatchers.IO) {
             if (characterIds.isEmpty()) return@launch
             val base64List = imageUris.mapNotNull { uri ->
@@ -133,6 +160,42 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                 characterIds
             )
         }
+
+    fun addVideoGroup(title: String, uris: List<Uri>, tagIds: List<Long>, characterIds: List<Long>) =
+        viewModelScope.launch(Dispatchers.IO) {
+            if (characterIds.isEmpty()) return@launch
+            val encryptedPaths = encryptMediaGroup(ResourceType.VIDEO, uris)
+            if (encryptedPaths.isEmpty()) return@launch
+            val payload = org.json.JSONArray(encryptedPaths).toString()
+            repo.addResource(
+                ResourceEntity(
+                    type = ResourceType.VIDEO,
+                    title = title,
+                    contentUriOrPath = payload
+                ),
+                tagIds,
+                characterIds
+            )
+        }
+
+    fun addFlow(
+        title: String,
+        items: List<FlowUpdateItem>,
+        tagIds: List<Long>,
+        characterIds: List<Long>
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        if (characterIds.isEmpty()) return@launch
+        val payload = buildFlowPayloadWithVideos(items).first
+        repo.addResource(
+            ResourceEntity(
+                type = ResourceType.FLOW,
+                title = title,
+                sceneJson = payload
+            ),
+            tagIds,
+            characterIds
+        )
+    }
 
     fun addEncryptedMedia(
         type: ResourceType,
@@ -229,6 +292,83 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     fun updateResource(resource: ResourceEntity) =
         viewModelScope.launch { repo.updateResource(resource) }
 
+    fun updateTextResource(
+        resource: ResourceEntity,
+        title: String,
+        text: String,
+        tagIds: List<Long>,
+        characterIds: List<Long>
+    ) = viewModelScope.launch {
+        if (characterIds.isEmpty()) return@launch
+        repo.updateResource(resource.copy(title = title, quoteText = text))
+        updateResourceTags(resource.id, tagIds)
+        updateResourceCharacters(resource.id, characterIds)
+    }
+
+    fun updateSceneResource(
+        resource: ResourceEntity,
+        title: String,
+        description: String?,
+        sceneJson: String,
+        tagIds: List<Long>,
+        characterIds: List<Long>
+    ) = viewModelScope.launch {
+        if (characterIds.isEmpty()) return@launch
+        repo.updateResource(
+            resource.copy(title = title, quoteText = description, sceneJson = sceneJson)
+        )
+        updateResourceTags(resource.id, tagIds)
+        updateResourceCharacters(resource.id, characterIds)
+    }
+
+    fun updateImageGroup(
+        resource: ResourceEntity,
+        title: String,
+        items: List<ImageUpdateItem>,
+        tagIds: List<Long>,
+        characterIds: List<Long>
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        if (characterIds.isEmpty()) return@launch
+        val payload = org.json.JSONArray(encodeImageItems(items)).toString()
+        repo.updateResource(resource.copy(title = title, quoteImageBase64 = payload))
+        updateResourceTags(resource.id, tagIds)
+        updateResourceCharacters(resource.id, characterIds)
+    }
+
+    fun updateVideoGroup(
+        resource: ResourceEntity,
+        title: String,
+        items: List<VideoUpdateItem>,
+        tagIds: List<Long>,
+        characterIds: List<Long>
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        if (characterIds.isEmpty()) return@launch
+        val oldPaths = parseMediaPaths(resource.contentUriOrPath)
+        val newPaths = resolveVideoItems(items)
+        if (newPaths.isEmpty()) return@launch
+        val payload = org.json.JSONArray(newPaths).toString()
+        repo.updateResource(resource.copy(title = title, contentUriOrPath = payload))
+        deleteEncryptedPaths(oldPaths.filterNot { it in newPaths })
+        updateResourceTags(resource.id, tagIds)
+        updateResourceCharacters(resource.id, characterIds)
+    }
+
+    fun updateFlow(
+        resource: ResourceEntity,
+        title: String,
+        items: List<FlowUpdateItem>,
+        tagIds: List<Long>,
+        characterIds: List<Long>
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        if (characterIds.isEmpty()) return@launch
+        val (payload, newPaths) = buildFlowPayloadWithVideos(items)
+        val oldPaths = extractFlowVideoPaths(resource.sceneJson)
+        repo.updateResource(resource.copy(title = title, sceneJson = payload))
+        deleteEncryptedPaths(oldPaths.filterNot { it in newPaths })
+        updateResourceTags(resource.id, tagIds)
+        updateResourceCharacters(resource.id, characterIds)
+    }
+
     fun updateResourceTags(resourceId: Long, tagIds: List<Long>) =
         viewModelScope.launch { repo.updateResourceTags(resourceId, tagIds) }
 
@@ -236,7 +376,12 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch { repo.updateResourceCharacters(resourceId, characterIds) }
 
     fun deleteResource(resource: ResourceEntity) = viewModelScope.launch(Dispatchers.IO) {
-        fileManager.deleteEncryptedFile(resource.contentUriOrPath)
+        val paths = when (resource.type) {
+            ResourceType.VIDEO -> parseMediaPaths(resource.contentUriOrPath)
+            ResourceType.FLOW -> extractFlowVideoPaths(resource.sceneJson)
+            else -> emptyList()
+        }
+        deleteEncryptedPaths(paths)
         repo.deleteResource(resource)
     }
 
@@ -290,6 +435,117 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             runCatching { if (temp.exists()) temp.delete() }
         }
         result
+    }
+
+    private fun deleteEncryptedPaths(paths: List<String>) {
+        paths.forEach { fileManager.deleteEncryptedFile(it) }
+    }
+
+    private fun parseMediaPaths(raw: String?): List<String> {
+        if (raw.isNullOrBlank()) return emptyList()
+        val trimmed = raw.trim()
+        if (trimmed.startsWith("[")) {
+            return runCatching {
+                val arr = org.json.JSONArray(trimmed)
+                List(arr.length()) { index -> arr.getString(index) }
+            }.getOrDefault(listOf(raw))
+        }
+        return listOf(raw)
+    }
+
+    private fun extractFlowVideoPaths(flowJson: String?): List<String> {
+        if (flowJson.isNullOrBlank()) return emptyList()
+        return runCatching {
+            val array = org.json.JSONArray(flowJson)
+            buildList {
+                for (i in 0 until array.length()) {
+                    val obj = array.optJSONObject(i) ?: continue
+                    if (obj.optString("type") != ResourceType.VIDEO.name) continue
+                    val videos = obj.optJSONArray("videos") ?: continue
+                    for (j in 0 until videos.length()) {
+                        val path = videos.optString(j)
+                        if (path.isNotBlank()) add(path)
+                    }
+                }
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    private suspend fun resolveVideoItems(items: List<VideoUpdateItem>): List<String> {
+        val resolver = getApplication<Application>().contentResolver
+        val result = mutableListOf<String>()
+        items.forEachIndexed { index, item ->
+            item.path?.let {
+                result.add(it)
+                return@forEachIndexed
+            }
+            val uri = item.uri ?: return@forEachIndexed
+            val extension = resolveMediaExtension(uri)
+            val targetName = buildEncryptedName(ResourceType.VIDEO, extension, index)
+            val input = runCatching { resolver.openInputStream(uri) }
+                .getOrNull()
+                ?: return@forEachIndexed
+            val encryptedFile = runCatching { input.use { fileManager.encryptToFile(it, targetName) } }
+                .getOrNull()
+                ?: return@forEachIndexed
+            result.add(encryptedFile.absolutePath)
+        }
+        return result
+    }
+
+    private suspend fun encryptMediaGroup(type: ResourceType, uris: List<Uri>): List<String> {
+        if (uris.isEmpty()) return emptyList()
+        val resolver = getApplication<Application>().contentResolver
+        val encryptedPaths = mutableListOf<String>()
+        uris.forEachIndexed { index, uri ->
+            val extension = resolveMediaExtension(uri)
+            val targetName = buildEncryptedName(type, extension, index)
+            val input = runCatching { resolver.openInputStream(uri) }.getOrNull() ?: return@forEachIndexed
+            val encryptedFile = runCatching { input.use { fileManager.encryptToFile(it, targetName) } }
+                .getOrNull()
+                ?: return@forEachIndexed
+            encryptedPaths.add(encryptedFile.absolutePath)
+        }
+        return encryptedPaths
+    }
+
+    private suspend fun encodeImageItems(items: List<ImageUpdateItem>): List<String> {
+        return items.mapNotNull { item ->
+            item.base64 ?: item.uri?.let { uri ->
+                ImageCompression.encodeToBase64(getApplication(), uri).ifBlank { null }
+            }
+        }
+    }
+
+    private suspend fun buildFlowPayloadWithVideos(items: List<FlowUpdateItem>): Pair<String, List<String>> {
+        val array = org.json.JSONArray()
+        val videoPaths = mutableListOf<String>()
+        items.forEach { item ->
+            val obj = org.json.JSONObject()
+            obj.put("type", item.type.name)
+            when (item.type) {
+                ResourceType.TEXT -> obj.put("text", item.text.orEmpty())
+                ResourceType.SCENE -> {
+                    val messages = org.json.JSONArray()
+                    item.sceneMessages.forEach { message ->
+                        val msg = org.json.JSONObject()
+                        msg.put("speaker", message.speaker)
+                        msg.put("text", message.content)
+                        messages.put(msg)
+                    }
+                    obj.put("messages", messages)
+                }
+                ResourceType.IMAGE -> obj.put("images", org.json.JSONArray(encodeImageItems(item.images)))
+                ResourceType.VIDEO -> {
+                    val paths = resolveVideoItems(item.videos)
+                    videoPaths.addAll(paths)
+                    obj.put("videos", org.json.JSONArray(paths))
+                }
+                ResourceType.FLOW -> obj.put("text", item.text.orEmpty())
+            }
+            array.put(obj)
+        }
+        return array.toString() to videoPaths
     }
 
     private fun handleDecryptionFailure(path: String, error: Throwable) {

--- a/app/src/main/java/com/example/quotepicker/vm/TagViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/TagViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.quotepicker.data.Repository
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
+import com.example.quotepicker.data.TagCategoryType
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -45,7 +46,7 @@ class TagViewModel(app: Application) : AndroidViewModel(app) {
 
     fun selectCategory(id: Long?) { selectedCategoryId.value = id }
 
-    fun addCategory(name: String) = viewModelScope.launch { repo.addCategory(name) }
+    fun addCategory(name: String, type: TagCategoryType) = viewModelScope.launch { repo.addCategory(name, type) }
     fun updateCategory(category: TagCategoryEntity) = viewModelScope.launch { repo.updateCategory(category) }
     fun deleteCategory(category: TagCategoryEntity) = viewModelScope.launch { repo.deleteCategory(category) }
 


### PR DESCRIPTION
### Motivation
- Separate tag categories into role (character) and resource buckets and restrict tag use so roles only use character tags while resources use resource tags. 
- Replace old resource types with five managed types (流程/Flow, 文本/Text, 图片/Image, 视频/Video, 情景/Scene) and introduce a composite "flow" resource for multi-step content (text/scene/image/video). 
- Allow full editing of all resource content (text, dialogues, images, videos) and ensure stored media is encrypted so app-stored resources are not discoverable as normal files on the device.

### Description
- Data/model: added `ResourceType.FLOW` and `TagCategoryType { CHARACTER, RESOURCE }`, added `type` to `TagCategoryEntity`, updated Room converters and bumped DB version to `3` to persist category type; updated DAOs and `Repository` to support category types and typed orphan categories. 
- ViewModels/logic: filtered tags and categories by type in `ResourceViewModel` and `CharacterViewModel`, introduced new DTOs (`FlowUpdateItem`, `ImageUpdateItem`, `VideoUpdateItem`, `SceneMessageDraft`) and implemented creation/update/delete flows for `FLOW`, `TEXT`, `IMAGE`, `VIDEO`, and `SCENE` resources in `ResourceViewModel` (including encrypting media, building flow payloads, resolving/encrypting video items, deleting stale encrypted files). 
- UI: overhauled `ResourceScreen` to expose creation menu for `创建流程`/`创建文本`/`创建情景`/`上传图片组`/`上传视频组`, added flow step editor (`FlowStepDialog`) and speaker-restricted scene dialogs, expanded `ResourceEditScreen` to edit all content (text, scene dialogues, append/remove/reorder images & videos, edit flow steps), and updated `ResourcePreviewScreen` to render flow steps and handle decrypted media previews. 
- Tag UI: `TagScreen` now groups categories into "角色标签" and "资源标签", added `CategoryDialog` to create categories with a selected `TagCategoryType`, and updated tag pickers to show only resource tags where appropriate. 
- Encrypted media handling: reused `EncryptedFileManager` to encrypt media when saving and to write decrypted temporary previews for playback; added logic to delete encrypted files when resources are removed or videos are replaced. 

### Testing
- No automated tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696da2908080832bb3a8ee2cb6dd0c0d)