### PR TITLE
Opt in to ExperimentalLayoutApi for SceneMessageDialog

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -1397,6 +1397,7 @@ private fun TagFilterChip(
     )
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun SceneMessageDialog(
     title: String,


### PR DESCRIPTION
### Motivation
- `FlowRow` used inside `SceneMessageDialog` depends on the experimental `ExperimentalLayoutApi`, which required an explicit opt-in to avoid experimental API compile issues.

### Description
- Add `@OptIn(ExperimentalLayoutApi::class)` annotation to the `SceneMessageDialog` composable to permit use of `FlowRow` without experimental API errors by opting into the API.

### Testing
- No automated tests or CI runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696db46b3eb4832b8b1dfe456c04417f)