### PR TITLE
Store imported videos inside app private storage

### DIFF
--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -16,6 +16,9 @@ import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.util.ImageCompression
+import java.io.File
+import java.io.FileOutputStream
+import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -154,9 +157,9 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     fun addVideoGroup(title: String, uris: List<Uri>, tagIds: List<Long>, characterIds: List<Long>) =
         viewModelScope.launch(Dispatchers.IO) {
             if (characterIds.isEmpty()) return@launch
-            val uriStrings = uris.mapNotNull { uri -> uri.toString().ifBlank { null } }
-            if (uriStrings.isEmpty()) return@launch
-            val payload = org.json.JSONArray(uriStrings).toString()
+            val storedUris = uris.mapNotNull { uri -> storeVideoToInternal(uri) }
+            if (storedUris.isEmpty()) return@launch
+            val payload = org.json.JSONArray(storedUris).toString()
             repo.addResource(
                 ResourceEntity(
                     type = ResourceType.VIDEO,
@@ -275,7 +278,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
 
     private suspend fun resolveVideoItems(items: List<VideoUpdateItem>): List<String> {
         return items.mapNotNull { item ->
-            item.path ?: item.uri?.toString()
+            item.path?.ifBlank { null } ?: item.uri?.let { uri -> storeVideoToInternal(uri) }
         }.filter { it.isNotBlank() }
     }
 
@@ -317,6 +320,19 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         return runCatching {
             val bytes = Base64.decode(b64, Base64.DEFAULT)
             BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+        }.getOrNull()
+    }
+
+    private fun storeVideoToInternal(uri: Uri): String? {
+        return runCatching {
+            val dir = File(getApplication<Application>().filesDir, "videos").apply { mkdirs() }
+            val target = File(dir, "video_${System.currentTimeMillis()}_${UUID.randomUUID()}.bin")
+            getApplication<Application>().contentResolver.openInputStream(uri)?.use { input ->
+                FileOutputStream(target).use { output ->
+                    input.copyTo(output)
+                }
+            } ?: return null
+            Uri.fromFile(target).toString()
         }.getOrNull()
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure imported videos remain available to the app after the original file is removed and prevent the system from treating them as media files by keeping copies in app-private storage.

### Description

- Copy imported videos into `filesDir/videos` using a new helper `storeVideoToInternal`, writing randomized filenames with a `.bin` suffix and returning a `file://` URI string.
- Update `addVideoGroup` to store provided `Uri`s via `storeVideoToInternal` and save the resulting stored URIs as the `contentUriOrPath` JSON payload.
- Update `resolveVideoItems` (used for `updateVideoGroup` and `Flow` video items) to reuse `path` when present or migrate `uri` entries via `storeVideoToInternal` before saving.
- Add imports for `File`, `FileOutputStream`, and `UUID` and keep the rest of the video/image payload logic unchanged in `app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc1c8baac832bb598e2f43eed473e)