### PR TITLE
Select existing resources for flow steps; add CharacterBadge and tag filtering for Random

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -4,12 +4,18 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.Refresh
@@ -25,13 +31,19 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
+import com.example.quotepicker.ui.components.CharacterBadge
+import com.example.quotepicker.ui.components.TagBadge
+import com.example.quotepicker.data.TagCategoryEntity
+import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.vm.RandomViewModel
 import com.example.quotepicker.vm.ResourceViewModel
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(), resourceVm: ResourceViewModel = viewModel()) {
     val ui by vm.uiState.collectAsState()
     var showPreview by remember { mutableStateOf(false) }
+    var showTagDialog by remember { mutableStateOf(false) }
 
     if (showPreview && ui.selectedResource != null) {
         ResourcePreviewScreen(
@@ -48,7 +60,27 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
             Spacer(Modifier.width(8.dp))
             Text("随机角色")
         }
-        Text(ui.selectedCharacter?.name ?: "未选择角色")
+        if (ui.selectedCharacter == null) {
+            Text("未选择角色")
+        } else {
+            CharacterBadge(name = ui.selectedCharacter!!.name)
+        }
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                TextButton(onClick = { showTagDialog = true }) {
+                    Text("资源标签筛选(${ui.selectedTagIds.size})")
+                }
+            }
+            if (ui.selectedTagIds.isEmpty()) {
+                Text("未选择标签")
+            } else {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    ui.tags.filter { ui.selectedTagIds.contains(it.id) }.forEach { tag ->
+                        TagBadge(tag = tag)
+                    }
+                }
+            }
+        }
         Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
             Button(onClick = { vm.randomResource() }, enabled = ui.selectedCharacter != null) {
                 Icon(Icons.Default.Casino, contentDescription = null)
@@ -79,4 +111,108 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
             }
         }
     }
+
+    if (showTagDialog) {
+        TagPickerDialog(
+            categories = ui.categories,
+            tags = ui.tags,
+            selectedIds = ui.selectedTagIds,
+            onConfirm = vm::updateTagFilter,
+            onDismiss = { showTagDialog = false }
+        )
+    }
+}
+
+@Composable
+private fun TagPickerDialog(
+    categories: List<TagCategoryEntity>,
+    tags: List<TagEntity>,
+    selectedIds: Set<Long>,
+    onConfirm: (Set<Long>) -> Unit,
+    onDismiss: () -> Unit
+) {
+    var selected by remember { mutableStateOf(selectedIds.toMutableSet()) }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("资源标签筛选") },
+        text = {
+            TagSelectionSection(
+                categories = categories,
+                tags = tags,
+                selected = selected,
+                onChange = { selected = it.toMutableSet() }
+            )
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(selected); onDismiss() }) { Text("确定") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun TagSelectionSection(
+    categories: List<TagCategoryEntity>,
+    tags: List<TagEntity>,
+    selected: Set<Long>,
+    onChange: (Set<Long>) -> Unit
+) {
+    val grouped = tags.groupBy { it.categoryId }
+    val knownCategoryIds = categories.map { it.id }.toSet()
+    val uncategorized = tags.filter { it.categoryId !in knownCategoryIds }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        categories.forEach { category ->
+            val items = grouped[category.id].orEmpty()
+            if (items.isNotEmpty()) {
+                Text(category.name)
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items.forEach { tag ->
+                        TagFilterChip(
+                            tag = tag,
+                            selected = selected,
+                            onChange = onChange
+                        )
+                    }
+                }
+            }
+        }
+        if (uncategorized.isNotEmpty()) {
+            Text("未分类")
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                uncategorized.forEach { tag ->
+                    TagFilterChip(
+                        tag = tag,
+                        selected = selected,
+                        onChange = onChange
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TagFilterChip(
+    tag: TagEntity,
+    selected: Set<Long>,
+    onChange: (Set<Long>) -> Unit
+) {
+    val isSelected = selected.contains(tag.id)
+    FilterChip(
+        selected = isSelected,
+        onClick = {
+            val updated = selected.toMutableSet()
+            if (isSelected) updated.remove(tag.id) else updated.add(tag.id)
+            onChange(updated)
+        },
+        label = { Text(tag.name) },
+        colors = FilterChipDefaults.filterChipColors()
+    )
 }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -7,6 +7,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -62,6 +63,7 @@ import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
+import com.example.quotepicker.ui.components.CharacterBadge
 import com.example.quotepicker.ui.components.ResourceGridCard
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.TagBadge
@@ -76,6 +78,7 @@ import com.example.quotepicker.vm.VideoUpdateItem
 @Composable
 fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewModel()) {
     val ui by vm.uiState.collectAsState()
+    val allResources by vm.allResources.collectAsState()
     var showAddMenu by remember { mutableStateOf(false) }
     var createMode by remember { mutableStateOf<CreateMode?>(null) }
     var previewTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
@@ -91,6 +94,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             categories = ui.categories,
             tags = ui.tags,
             characters = ui.characters,
+            availableResources = allResources,
             vm = vm,
             onBack = { createMode = null }
         )
@@ -103,6 +107,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             categories = ui.categories,
             tags = ui.tags,
             characters = ui.characters,
+            availableResources = allResources,
             vm = vm,
             onBack = { editTarget = null }
         )
@@ -412,6 +417,7 @@ private fun ResourceCreateScreen(
     categories: List<TagCategoryEntity>,
     tags: List<TagEntity>,
     characters: List<CharacterEntity>,
+    availableResources: List<ResourceWithTagsCharacters>,
     vm: ResourceViewModel,
     onBack: () -> Unit
 ) {
@@ -471,6 +477,9 @@ private fun ResourceCreateScreen(
 
     val selectedSpeakerNames = remember(selectedCharacters, characters) {
         characters.filter { selectedCharacters.contains(it.id) }.map { it.name }
+    }
+    val flowResources = remember(availableResources) {
+        availableResources.filter { it.resource.type != ResourceType.FLOW }
     }
 
     Scaffold(
@@ -561,7 +570,7 @@ private fun ResourceCreateScreen(
                                             verticalArrangement = Arrangement.spacedBy(4.dp)
                                         ) {
                                             Text(
-                                                text = typeLabel(item.type),
+                                                text = item.title?.ifBlank { null } ?: typeLabel(item.type),
                                                 style = MaterialTheme.typography.labelMedium,
                                                 color = MaterialTheme.colorScheme.primary
                                             )
@@ -750,6 +759,7 @@ private fun ResourceCreateScreen(
         FlowStepDialog(
             allowedSpeakers = selectedSpeakerNames,
             initialItem = editFlowIndex?.let { flowItems.getOrNull(it) },
+            availableResources = flowResources,
             onConfirm = { item ->
                 val updated = flowItems.toMutableList()
                 if (editFlowIndex != null) {
@@ -776,6 +786,7 @@ private fun ResourceEditScreen(
     categories: List<TagCategoryEntity>,
     tags: List<TagEntity>,
     characters: List<CharacterEntity>,
+    availableResources: List<ResourceWithTagsCharacters>,
     vm: ResourceViewModel,
     onBack: () -> Unit
 ) {
@@ -815,6 +826,9 @@ private fun ResourceEditScreen(
 
     val selectedSpeakerNames = remember(selectedCharacters, characters) {
         characters.filter { selectedCharacters.contains(it.id) }.map { it.name }
+    }
+    val flowResources = remember(availableResources) {
+        availableResources.filter { it.resource.type != ResourceType.FLOW }
     }
 
     val canSave = title.isNotBlank() && selectedCharacters.isNotEmpty() && when (resource.resource.type) {
@@ -1185,8 +1199,8 @@ private fun ResourceEditScreen(
     }
     if (showFlowDialog) {
         FlowStepDialog(
-            allowedSpeakers = selectedSpeakerNames,
             initialItem = editFlowIndex?.let { flowItems.getOrNull(it) },
+            availableResources = flowResources,
             onConfirm = { item ->
                 val updated = flowItems.toMutableList()
                 if (editFlowIndex != null) {
@@ -1251,7 +1265,7 @@ private fun ResourceCharacterPickerRow(
         } else {
             FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
                 selectedCharacters.forEach { character ->
-                    AssistChip(onClick = {}, label = { Text(character.name) })
+                    CharacterBadge(name = character.name)
                 }
             }
         }
@@ -1473,44 +1487,24 @@ private fun SceneMessageDialog(
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 private fun FlowStepDialog(
-    allowedSpeakers: List<String>,
     initialItem: FlowUpdateItem?,
+    availableResources: List<ResourceWithTagsCharacters>,
     onConfirm: (FlowUpdateItem) -> Unit,
     onDismiss: () -> Unit
 ) {
     var selectedType by remember { mutableStateOf(initialItem?.type ?: ResourceType.TEXT) }
-    var text by remember { mutableStateOf(initialItem?.text.orEmpty()) }
-    var sceneMessages by remember { mutableStateOf(initialItem?.sceneMessages ?: emptyList()) }
-    var imageItems by remember { mutableStateOf(initialItem?.images ?: emptyList()) }
-    var videoItems by remember { mutableStateOf(initialItem?.videos ?: emptyList()) }
-    var showSceneDialog by remember { mutableStateOf(false) }
-    var editSceneIndex by remember { mutableStateOf<Int?>(null) }
+    val initialResourceId = remember(initialItem, availableResources) {
+        initialItem?.resourceId
+            ?: availableResources.firstOrNull {
+                it.resource.title == initialItem?.title && it.resource.type == initialItem?.type
+            }?.resource?.id
+    }
+    var selectedResourceId by remember(initialResourceId) { mutableStateOf(initialResourceId) }
 
-    val context = LocalContext.current
-    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
-        val updated = imageItems.toMutableList()
-        uris.forEach { uri -> updated.add(ImageUpdateItem(uri = uri)) }
-        imageItems = updated
+    val resourcesOfType = remember(selectedType, availableResources) {
+        availableResources.filter { it.resource.type == selectedType }
     }
-    val videoPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
-        val updated = videoItems.toMutableList()
-        uris.forEach { uri ->
-            context.contentResolver.takePersistableUriPermission(
-                uri,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION
-            )
-            updated.add(VideoUpdateItem(uri = uri))
-        }
-        videoItems = updated
-    }
-
-    val canSubmit = when (selectedType) {
-        ResourceType.TEXT -> text.isNotBlank()
-        ResourceType.SCENE -> sceneMessages.isNotEmpty() && allowedSpeakers.isNotEmpty()
-        ResourceType.IMAGE -> imageItems.isNotEmpty()
-        ResourceType.VIDEO -> videoItems.isNotEmpty()
-        else -> false
-    }
+    val selectedResource = resourcesOfType.firstOrNull { it.resource.id == selectedResourceId }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -1525,187 +1519,56 @@ private fun FlowStepDialog(
                     listOf(ResourceType.TEXT, ResourceType.SCENE, ResourceType.IMAGE, ResourceType.VIDEO).forEach { type ->
                         FilterChip(
                             selected = selectedType == type,
-                            onClick = { selectedType = type },
+                            onClick = {
+                                selectedType = type
+                                selectedResourceId = null
+                            },
                             label = { Text(typeLabel(type)) }
                         )
                     }
                 }
-                when (selectedType) {
-                    ResourceType.TEXT -> {
-                        OutlinedTextField(
-                            value = text,
-                            onValueChange = { text = it },
-                            label = { Text("文本内容") },
-                            modifier = Modifier.fillMaxWidth()
-                        )
-                    }
-                    ResourceType.SCENE -> {
-                        TextButton(onClick = { showSceneDialog = true }, enabled = allowedSpeakers.isNotEmpty()) {
-                            Icon(Icons.Default.Chat, contentDescription = null)
-                            Spacer(Modifier.width(8.dp))
-                            Text("添加对话")
-                        }
-                        if (sceneMessages.isEmpty()) {
-                            Text("暂无对话", style = MaterialTheme.typography.labelSmall)
-                        } else {
-                            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                sceneMessages.forEachIndexed { index, message ->
-                                    androidx.compose.material3.OutlinedCard {
-                                        Row(
-                                            modifier = Modifier
-                                                .fillMaxWidth()
-                                                .padding(12.dp),
-                                            horizontalArrangement = Arrangement.SpaceBetween,
-                                            verticalAlignment = Alignment.CenterVertically
-                                        ) {
-                                            Column(
-                                                modifier = Modifier.weight(1f),
-                                                verticalArrangement = Arrangement.spacedBy(4.dp)
-                                            ) {
-                                                Text(
-                                                    text = message.speaker.ifBlank { "角色" },
-                                                    style = MaterialTheme.typography.labelMedium,
-                                                    color = MaterialTheme.colorScheme.primary
-                                                )
-                                                Text(text = message.content)
-                                            }
-                                            Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
-                                                IconButton(onClick = {
-                                                    editSceneIndex = index
-                                                    showSceneDialog = true
-                                                }) {
-                                                    Icon(Icons.Default.Edit, contentDescription = "编辑")
-                                                }
-                                                IconButton(onClick = {
-                                                    sceneMessages = sceneMessages.toMutableList().also { it.removeAt(index) }
-                                                }) {
-                                                    Icon(Icons.Default.Delete, contentDescription = "删除")
-                                                }
-                                            }
-                                        }
+                Text("选择资源")
+                if (resourcesOfType.isEmpty()) {
+                    Text("暂无可用资源", style = MaterialTheme.typography.labelSmall)
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        resourcesOfType.forEach { res ->
+                            val isSelected = selectedResourceId == res.resource.id
+                            androidx.compose.material3.OutlinedCard(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .clickable { selectedResourceId = res.resource.id }
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(12.dp),
+                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                ) {
+                                    Text(
+                                        text = res.resource.title,
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface
+                                    )
+                                    val summary = resourceSummary(res)
+                                    if (summary.isNotBlank()) {
+                                        Text(summary, style = MaterialTheme.typography.bodySmall)
                                     }
                                 }
                             }
                         }
                     }
-                    ResourceType.IMAGE -> {
-                        TextButton(onClick = { imagePicker.launch("image/*") }) {
-                            Icon(Icons.Default.Image, contentDescription = null)
-                            Spacer(Modifier.width(8.dp))
-                            Text("选择图片")
-                        }
-                        if (imageItems.isEmpty()) {
-                            Text("未选择图片")
-                        } else {
-                            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                                Text("已选择 ${imageItems.size} 张图片")
-                                imageItems.forEachIndexed { index, _ ->
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.SpaceBetween,
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        Text("图片 ${index + 1}")
-                                        IconButton(onClick = {
-                                            imageItems = imageItems.toMutableList().also { it.removeAt(index) }
-                                        }) {
-                                            Icon(Icons.Default.Delete, contentDescription = "删除")
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    ResourceType.VIDEO -> {
-                        TextButton(onClick = { videoPicker.launch(arrayOf("video/*")) }) {
-                            Icon(Icons.Default.Videocam, contentDescription = null)
-                            Spacer(Modifier.width(8.dp))
-                            Text("选择视频")
-                        }
-                        if (videoItems.isEmpty()) {
-                            Text("未选择视频")
-                        } else {
-                            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                                Text("已选择 ${videoItems.size} 个视频")
-                                videoItems.forEachIndexed { index, _ ->
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.SpaceBetween,
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        Text("视频 ${index + 1}")
-                                        IconButton(onClick = {
-                                            videoItems = videoItems.toMutableList().also { it.removeAt(index) }
-                                        }) {
-                                            Icon(Icons.Default.Delete, contentDescription = "删除")
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    else -> {}
                 }
             }
         },
         confirmButton = {
             TextButton(
-                onClick = {
-                    onConfirm(
-                        FlowUpdateItem(
-                            type = selectedType,
-                            text = text,
-                            sceneMessages = sceneMessages,
-                            images = imageItems,
-                            videos = videoItems
-                        )
-                    )
-                },
-                enabled = canSubmit
+                onClick = { selectedResource?.let { onConfirm(flowItemFromResource(it)) } },
+                enabled = selectedResource != null
             ) { Text("确定") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )
-
-    if (showSceneDialog) {
-        SceneMessageDialog(
-            title = if (editSceneIndex == null) "添加对话" else "编辑对话",
-            allowedSpeakers = allowedSpeakers,
-            initialSpeaker = editSceneIndex?.let { sceneMessages.getOrNull(it)?.speaker }.orEmpty(),
-            initialContent = editSceneIndex?.let { sceneMessages.getOrNull(it)?.content }.orEmpty(),
-            onConfirm = { speaker, content ->
-                if (speaker.isBlank() && content.isBlank()) {
-                    showSceneDialog = false
-                    editSceneIndex = null
-                } else {
-                    val updated = sceneMessages.toMutableList()
-                    if (editSceneIndex != null) {
-                        updated[editSceneIndex!!] = SceneMessageDraft(speaker.trim(), content.trim())
-                    } else {
-                        updated.add(SceneMessageDraft(speaker.trim(), content.trim()))
-                    }
-                    sceneMessages = updated
-                    showSceneDialog = false
-                    editSceneIndex = null
-                }
-            },
-            onAddAnother = if (editSceneIndex == null) {
-                { speaker, content ->
-                    if (speaker.isNotBlank() || content.isNotBlank()) {
-                        val updated = sceneMessages.toMutableList()
-                        updated.add(SceneMessageDraft(speaker.trim(), content.trim()))
-                        sceneMessages = updated
-                    }
-                }
-            } else {
-                null
-            },
-            onDismiss = {
-                showSceneDialog = false
-                editSceneIndex = null
-            }
-        )
-    }
 }
 
 private fun parseSceneMessages(raw: String?): List<SceneMessageDraft> {
@@ -1752,6 +1615,57 @@ private fun parseVideoItems(raw: String?): List<VideoUpdateItem> {
     return list.map { VideoUpdateItem(path = it) }
 }
 
+private fun flowItemFromResource(resource: ResourceWithTagsCharacters): FlowUpdateItem {
+    val data = resource.resource
+    return when (data.type) {
+        ResourceType.TEXT -> FlowUpdateItem(
+            type = data.type,
+            title = data.title,
+            resourceId = data.id,
+            text = data.quoteText.orEmpty()
+        )
+        ResourceType.SCENE -> FlowUpdateItem(
+            type = data.type,
+            title = data.title,
+            resourceId = data.id,
+            sceneMessages = parseSceneMessages(data.sceneJson)
+        )
+        ResourceType.IMAGE -> FlowUpdateItem(
+            type = data.type,
+            title = data.title,
+            resourceId = data.id,
+            images = parseImageItems(data.quoteImageBase64)
+        )
+        ResourceType.VIDEO -> FlowUpdateItem(
+            type = data.type,
+            title = data.title,
+            resourceId = data.id,
+            videos = parseVideoItems(data.contentUriOrPath)
+        )
+        else -> FlowUpdateItem(type = data.type, title = data.title, resourceId = data.id)
+    }
+}
+
+private fun resourceSummary(resource: ResourceWithTagsCharacters): String {
+    val data = resource.resource
+    return when (data.type) {
+        ResourceType.TEXT -> data.quoteText.orEmpty()
+        ResourceType.SCENE -> {
+            val messages = parseSceneMessages(data.sceneJson)
+            if (messages.isEmpty()) "" else "对话 ${messages.size} 条"
+        }
+        ResourceType.IMAGE -> {
+            val images = parseImageItems(data.quoteImageBase64)
+            if (images.isEmpty()) "" else "图片 ${images.size} 张"
+        }
+        ResourceType.VIDEO -> {
+            val videos = parseVideoItems(data.contentUriOrPath)
+            if (videos.isEmpty()) "" else "视频 ${videos.size} 个"
+        }
+        else -> ""
+    }
+}
+
 private fun parseFlowItems(raw: String?): List<FlowUpdateItem> {
     if (raw.isNullOrBlank()) return emptyList()
     return runCatching {
@@ -1760,9 +1674,16 @@ private fun parseFlowItems(raw: String?): List<FlowUpdateItem> {
             for (i in 0 until array.length()) {
                 val obj = array.optJSONObject(i) ?: continue
                 val type = runCatching { ResourceType.valueOf(obj.optString("type")) }.getOrNull() ?: continue
+                val title = obj.optString("title").ifBlank { null }
+                val resourceId = obj.optLong("resourceId", -1L).takeIf { it > 0 }
                 when (type) {
                     ResourceType.TEXT -> add(
-                        FlowUpdateItem(type = type, text = obj.optString("text"))
+                        FlowUpdateItem(
+                            type = type,
+                            title = title,
+                            resourceId = resourceId,
+                            text = obj.optString("text")
+                        )
                     )
                     ResourceType.SCENE -> {
                         val messages = obj.optJSONArray("messages")
@@ -1778,7 +1699,14 @@ private fun parseFlowItems(raw: String?): List<FlowUpdateItem> {
                                 }
                             }
                         }
-                        add(FlowUpdateItem(type = type, sceneMessages = parsed))
+                        add(
+                            FlowUpdateItem(
+                                type = type,
+                                title = title,
+                                resourceId = resourceId,
+                                sceneMessages = parsed
+                            )
+                        )
                     }
                     ResourceType.IMAGE -> {
                         val images = obj.optJSONArray("images")
@@ -1790,7 +1718,14 @@ private fun parseFlowItems(raw: String?): List<FlowUpdateItem> {
                                 }
                             }
                         }
-                        add(FlowUpdateItem(type = type, images = parsed))
+                        add(
+                            FlowUpdateItem(
+                                type = type,
+                                title = title,
+                                resourceId = resourceId,
+                                images = parsed
+                            )
+                        )
                     }
                     ResourceType.VIDEO -> {
                         val videos = obj.optJSONArray("videos")
@@ -1802,7 +1737,14 @@ private fun parseFlowItems(raw: String?): List<FlowUpdateItem> {
                                 }
                             }
                         }
-                        add(FlowUpdateItem(type = type, videos = parsed))
+                        add(
+                            FlowUpdateItem(
+                                type = type,
+                                title = title,
+                                resourceId = resourceId,
+                                videos = parsed
+                            )
+                        )
                     }
                     else -> {}
                 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/CharacterBadge.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/CharacterBadge.kt
@@ -1,0 +1,24 @@
+package com.example.quotepicker.ui.components
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun CharacterBadge(
+    name: String,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .border(1.dp, MaterialTheme.colorScheme.outline, shape = MaterialTheme.shapes.small)
+            .padding(horizontal = 10.dp, vertical = 6.dp)
+    ) {
+        Text(text = name, style = MaterialTheme.typography.labelSmall)
+    }
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
-import androidx.compose.material3.AssistChip
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -56,6 +55,7 @@ private data class SceneMessage(val speaker: String, val content: String)
 
 private data class FlowPreviewItem(
     val type: ResourceType,
+    val title: String? = null,
     val text: String = "",
     val sceneMessages: List<SceneMessage> = emptyList(),
     val images: List<android.graphics.Bitmap> = emptyList(),
@@ -138,32 +138,34 @@ fun ResourcePreviewScreen(
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold
             )
-            ResourceMetaRow(label = "标签") {
-                if (resource.tags.isNotEmpty()) {
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
-                    ) {
-                        resource.tags.forEach { tag ->
-                            TagBadge(tag = tag)
+            if (resource.resource.type != ResourceType.FLOW) {
+                ResourceMetaRow(label = "标签") {
+                    if (resource.tags.isNotEmpty()) {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            resource.tags.forEach { tag ->
+                                TagBadge(tag = tag)
+                            }
                         }
+                    } else {
+                        Text("无标签", style = MaterialTheme.typography.labelSmall)
                     }
-                } else {
-                    Text("无标签", style = MaterialTheme.typography.labelSmall)
                 }
-            }
-            ResourceMetaRow(label = "角色") {
-                if (resource.characters.isNotEmpty()) {
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                        verticalArrangement = Arrangement.spacedBy(6.dp)
-                    ) {
-                        resource.characters.forEach { character ->
-                            AssistChip(onClick = {}, label = { Text(character.name) })
+                ResourceMetaRow(label = "角色") {
+                    if (resource.characters.isNotEmpty()) {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(6.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                        ) {
+                            resource.characters.forEach { character ->
+                                CharacterBadge(name = character.name)
+                            }
                         }
+                    } else {
+                        Text("未选择角色", style = MaterialTheme.typography.labelSmall)
                     }
-                } else {
-                    Text("未选择角色", style = MaterialTheme.typography.labelSmall)
                 }
             }
 
@@ -221,7 +223,7 @@ fun ResourcePreviewScreen(
                                 Text("流程内容为空")
                             } else {
                                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                    flowItems.forEachIndexed { index, item ->
+                                    flowItems.forEach { item ->
                                         Card(modifier = Modifier.fillMaxWidth()) {
                                             Column(
                                                 modifier = Modifier
@@ -229,7 +231,8 @@ fun ResourcePreviewScreen(
                                                     .padding(12.dp),
                                                 verticalArrangement = Arrangement.spacedBy(8.dp)
                                             ) {
-                                                Text("步骤 ${index + 1} - ${typeLabel(item.type)}")
+                                                val title = item.title?.ifBlank { null } ?: typeLabel(item.type)
+                                                Text(title, style = MaterialTheme.typography.titleMedium)
                                                 when (item.type) {
                                                     ResourceType.TEXT -> Text(item.text)
                                                     ResourceType.SCENE -> {
@@ -376,9 +379,10 @@ private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<Flo
             for (i in 0 until array.length()) {
                 val obj = array.optJSONObject(i) ?: continue
                 val type = runCatching { ResourceType.valueOf(obj.optString("type")) }.getOrNull() ?: continue
+                val title = obj.optString("title").ifBlank { null }
                 when (type) {
                     ResourceType.TEXT -> add(
-                        FlowPreviewItem(type = type, text = obj.optString("text"))
+                        FlowPreviewItem(type = type, title = title, text = obj.optString("text"))
                     )
                     ResourceType.SCENE -> {
                         val messages = obj.optJSONArray("messages") ?: JSONArray()
@@ -392,7 +396,7 @@ private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<Flo
                                 }
                             }
                         }
-                        add(FlowPreviewItem(type = type, sceneMessages = parsed))
+                        add(FlowPreviewItem(type = type, title = title, sceneMessages = parsed))
                     }
                     ResourceType.IMAGE -> {
                         val images = obj.optJSONArray("images") ?: JSONArray()
@@ -404,7 +408,7 @@ private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<Flo
                                 }
                             }
                         }
-                        add(FlowPreviewItem(type = type, images = bitmaps))
+                        add(FlowPreviewItem(type = type, title = title, images = bitmaps))
                     }
                     ResourceType.VIDEO -> {
                         val videos = obj.optJSONArray("videos") ?: JSONArray()
@@ -421,7 +425,7 @@ private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<Flo
                         if (uriList.isEmpty() && videos.length() > 0) {
                             failed = true
                         }
-                        add(FlowPreviewItem(type = type, mediaUris = uriList, mediaFailed = failed))
+                        add(FlowPreviewItem(type = type, title = title, mediaUris = uriList, mediaFailed = failed))
                     }
                     else -> {}
                 }

--- a/app/src/main/java/com/example/quotepicker/vm/RandomViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/RandomViewModel.kt
@@ -6,6 +6,9 @@ import androidx.lifecycle.viewModelScope
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.Repository
 import com.example.quotepicker.data.ResourceWithTagsCharacters
+import com.example.quotepicker.data.TagCategoryEntity
+import com.example.quotepicker.data.TagCategoryType
+import com.example.quotepicker.data.TagEntity
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -16,6 +19,9 @@ import kotlinx.coroutines.launch
 data class RandomUiState(
     val characters: List<CharacterEntity> = emptyList(),
     val resources: List<ResourceWithTagsCharacters> = emptyList(),
+    val categories: List<TagCategoryEntity> = emptyList(),
+    val tags: List<TagEntity> = emptyList(),
+    val selectedTagIds: Set<Long> = emptySet(),
     val selectedCharacter: CharacterEntity? = null,
     val selectedResource: ResourceWithTagsCharacters? = null
 )
@@ -24,23 +30,38 @@ class RandomViewModel(app: Application) : AndroidViewModel(app) {
     private val repo = Repository.get(app)
     private val selectedCharacterId = MutableStateFlow<Long?>(null)
     private val selectedResourceId = MutableStateFlow<Long?>(null)
+    private val selectedTagIds = MutableStateFlow<Set<Long>>(emptySet())
 
     val uiState: StateFlow<RandomUiState> = combine(
         repo.observeCharacters(),
         repo.observeResourcesWithRelations(),
+        repo.observeCategories(),
+        repo.observeAllTags(),
         selectedCharacterId,
-        selectedResourceId
-    ) { characters, resources, charId, resId ->
+        selectedResourceId,
+        selectedTagIds
+    ) { characters, resources, categories, tags, charId, resId, tagIds ->
         val selectedCharacter = characters.firstOrNull { it.id == charId }
         val matchingResources = if (selectedCharacter == null) {
             emptyList()
         } else {
             resources.filter { res -> res.characters.any { it.id == selectedCharacter.id } }
         }
-        val selectedResource = matchingResources.firstOrNull { it.resource.id == resId }
+        val filteredResources = if (tagIds.isEmpty()) {
+            matchingResources
+        } else {
+            matchingResources.filter { res -> res.tags.any { tagIds.contains(it.id) } }
+        }
+        val selectedResource = filteredResources.firstOrNull { it.resource.id == resId }
+        val resourceCategories = categories.filter { it.type == TagCategoryType.RESOURCE }
+        val categoryIds = resourceCategories.map { it.id }.toSet()
+        val resourceTags = tags.filter { it.categoryId in categoryIds }
         RandomUiState(
             characters = characters,
-            resources = matchingResources,
+            resources = filteredResources,
+            categories = resourceCategories,
+            tags = resourceTags,
+            selectedTagIds = tagIds,
             selectedCharacter = selectedCharacter,
             selectedResource = selectedResource
         )
@@ -73,5 +94,10 @@ class RandomViewModel(app: Application) : AndroidViewModel(app) {
     fun reset() {
         selectedCharacterId.value = null
         selectedResourceId.value = null
+        selectedTagIds.value = emptySet()
+    }
+
+    fun updateTagFilter(tagIds: Set<Long>) {
+        selectedTagIds.value = tagIds
     }
 }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -58,6 +58,8 @@ data class SceneMessageDraft(
 
 data class FlowUpdateItem(
     val type: ResourceType,
+    val title: String? = null,
+    val resourceId: Long? = null,
     val text: String? = null,
     val sceneMessages: List<SceneMessageDraft> = emptyList(),
     val images: List<ImageUpdateItem> = emptyList(),
@@ -295,6 +297,8 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         items.forEach { item ->
             val obj = org.json.JSONObject()
             obj.put("type", item.type.name)
+            item.title?.takeIf { it.isNotBlank() }?.let { obj.put("title", it) }
+            item.resourceId?.let { obj.put("resourceId", it) }
             when (item.type) {
                 ResourceType.TEXT -> obj.put("text", item.text.orEmpty())
                 ResourceType.SCENE -> {


### PR DESCRIPTION
### Motivation

- Allow creating flow steps by picking existing resources instead of only adding inline content so flow previews can show resource titles and contents. 
- Make role display consistent with tags by using a compact outlined role badge instead of chip-like buttons. 
- Support filtering random resource picks by resource tags so the random flow can be constrained by tag selection. 

### Description

- Added a new `CharacterBadge` composable (`app/src/main/java/.../ui/components/CharacterBadge.kt`) and replaced several `AssistChip` usages with `CharacterBadge` in `ResourcePreviewScreen`, `ResourceScreen` and `RandomScreen`. 
- Reworked flow step creation UI: `FlowStepDialog` now lets the user pick an existing resource by type, and the create/edit flow logic uses `flowItemFromResource`/`resourceSummary` helpers to build `FlowUpdateItem` from a selected `ResourceWithTagsCharacters`. 
- Persisted resource references and titles in flow payloads by including `title` and `resourceId` in `FlowUpdateItem` and writing them into the JSON via `ResourceViewModel::buildFlowPayloadWithVideos`. 
- Plumbed the available resource list (`allResources`) into create/edit screens so dialogs can list existing resources, and updated parsing/serialization in `parseFlowItems`/preview to honor optional `title`/`resourceId`. 
- Added tag-based filtering to the random flow by extending `RandomViewModel` to expose `categories`/`tags` and a `selectedTagIds` filter, plus `RandomScreen` UI to pick tag filters and show selected tags. 

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc6b9b1f0832b8a5a49ba6587d96c)