### PR TITLE
Fix RandomViewModel combine logic, remove invalid FlowStepDialog arg, enlarge video preview

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -757,7 +757,6 @@ private fun ResourceCreateScreen(
     }
     if (showFlowDialog) {
         FlowStepDialog(
-            allowedSpeakers = selectedSpeakerNames,
             initialItem = editFlowIndex?.let { flowItems.getOrNull(it) },
             availableResources = flowResources,
             onConfirm = { item ->

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -300,7 +301,7 @@ private fun MediaPreview(uri: Uri) {
         },
         modifier = Modifier
             .fillMaxWidth()
-            .height(240.dp)
+            .height(320.dp)
             .background(MaterialTheme.colorScheme.surfaceVariant)
     )
 }

--- a/app/src/main/java/com/example/quotepicker/vm/RandomViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/RandomViewModel.kt
@@ -26,26 +26,46 @@ data class RandomUiState(
     val selectedResource: ResourceWithTagsCharacters? = null
 )
 
+private data class RandomInputs(
+    val characters: List<CharacterEntity>,
+    val resources: List<ResourceWithTagsCharacters>,
+    val categories: List<TagCategoryEntity>,
+    val tags: List<TagEntity>,
+    val selectedCharacterId: Long?
+)
+
 class RandomViewModel(app: Application) : AndroidViewModel(app) {
     private val repo = Repository.get(app)
     private val selectedCharacterId = MutableStateFlow<Long?>(null)
     private val selectedResourceId = MutableStateFlow<Long?>(null)
     private val selectedTagIds = MutableStateFlow<Set<Long>>(emptySet())
 
-    val uiState: StateFlow<RandomUiState> = combine(
+    private val baseInputs = combine(
         repo.observeCharacters(),
         repo.observeResourcesWithRelations(),
         repo.observeCategories(),
         repo.observeAllTags(),
-        selectedCharacterId,
+        selectedCharacterId
+    ) { characters, resources, categories, tags, charId ->
+        RandomInputs(
+            characters = characters,
+            resources = resources,
+            categories = categories,
+            tags = tags,
+            selectedCharacterId = charId
+        )
+    }
+
+    val uiState: StateFlow<RandomUiState> = combine(
+        baseInputs,
         selectedResourceId,
         selectedTagIds
-    ) { characters, resources, categories, tags, charId, resId, tagIds ->
-        val selectedCharacter = characters.firstOrNull { it.id == charId }
+    ) { inputs, resId, tagIds ->
+        val selectedCharacter = inputs.characters.firstOrNull { it.id == inputs.selectedCharacterId }
         val matchingResources = if (selectedCharacter == null) {
             emptyList()
         } else {
-            resources.filter { res -> res.characters.any { it.id == selectedCharacter.id } }
+            inputs.resources.filter { res -> res.characters.any { it.id == selectedCharacter.id } }
         }
         val filteredResources = if (tagIds.isEmpty()) {
             matchingResources
@@ -53,11 +73,11 @@ class RandomViewModel(app: Application) : AndroidViewModel(app) {
             matchingResources.filter { res -> res.tags.any { tagIds.contains(it.id) } }
         }
         val selectedResource = filteredResources.firstOrNull { it.resource.id == resId }
-        val resourceCategories = categories.filter { it.type == TagCategoryType.RESOURCE }
+        val resourceCategories = inputs.categories.filter { it.type == TagCategoryType.RESOURCE }
         val categoryIds = resourceCategories.map { it.id }.toSet()
-        val resourceTags = tags.filter { it.categoryId in categoryIds }
+        val resourceTags = inputs.tags.filter { it.categoryId in categoryIds }
         RandomUiState(
-            characters = characters,
+            characters = inputs.characters,
             resources = filteredResources,
             categories = resourceCategories,
             tags = resourceTags,


### PR DESCRIPTION
### Motivation

- Ensure the random selection UI composes and filters resources reliably by grouping source inputs before downstream filtering. 
- Remove an invalid parameter passed to the flow step dialog which could cause a mismatch/compile issue. 
- Make the in-app video preview larger for better usability per UI feedback and add a missing import used by the preview UI. 

### Description

- Introduced a `RandomInputs` data class and a `baseInputs` combined flow in `app/src/main/java/com/example/quotepicker/vm/RandomViewModel.kt`, and rewired `uiState` to combine `baseInputs` with `selectedResourceId` and `selectedTagIds` so filtering operates on a stable grouped input set. 
- Removed the `allowedSpeakers` argument when calling `FlowStepDialog` in `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt` to match the dialog signature. 
- Enlarged the video preview height from `240.dp` to `320.dp` and added the missing `AssistChip` import in `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`. 

### Testing

- No automated tests were run for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dcb157510832b8ebd185ceeeb944d)