### PR TITLE
Store uploaded images as files, add media manager and improve preview UI

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -7,7 +7,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
@@ -51,6 +52,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,7 +74,9 @@ import com.example.quotepicker.vm.FlowUpdateItem
 import com.example.quotepicker.vm.ImageUpdateItem
 import com.example.quotepicker.vm.ResourceViewModel
 import com.example.quotepicker.vm.SceneMessageDraft
+import com.example.quotepicker.vm.StoredMediaItem
 import com.example.quotepicker.vm.VideoUpdateItem
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -87,6 +91,19 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     var deleteTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var filterTagDialog by remember { mutableStateOf(false) }
     var filterCharacterDialog by remember { mutableStateOf(false) }
+    var manageDialog by remember { mutableStateOf(false) }
+    var manageItems by remember { mutableStateOf<List<StoredMediaItem>>(emptyList()) }
+    var restoreTarget by remember { mutableStateOf<StoredMediaItem?>(null) }
+    val coroutineScope = rememberCoroutineScope()
+    val restorePicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
+        val target = restoreTarget
+        if (uri != null && target != null) {
+            coroutineScope.launch {
+                vm.restoreMediaToDirectory(target.path, target.type, uri)
+            }
+        }
+        restoreTarget = null
+    }
 
     createMode?.let { mode ->
         ResourceCreateScreen(
@@ -131,6 +148,12 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                 actions = {
                     IconButton(onClick = { filterTagDialog = true }) {
                         Icon(Icons.Default.Edit, contentDescription = "筛选标签")
+                    }
+                    IconButton(onClick = {
+                        manageItems = vm.listStoredMedia()
+                        manageDialog = true
+                    }) {
+                        Icon(Icons.Default.Settings, contentDescription = "管理资源")
                     }
                 }
             )
@@ -224,6 +247,53 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             onConfirm = { vm.updateCharacterFilter(it) },
             onDismiss = { filterCharacterDialog = false }
         )
+    }
+
+    if (manageDialog) {
+        ModalBottomSheet(onDismissRequest = { manageDialog = false }) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Text("本地存储文件", style = MaterialTheme.typography.titleMedium)
+                Text("长按文件可选择目录恢复", style = MaterialTheme.typography.labelSmall)
+                if (manageItems.isEmpty()) {
+                    Text("暂无文件", style = MaterialTheme.typography.labelMedium)
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        manageItems.forEach { item ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .combinedClickable(
+                                        onClick = {},
+                                        onLongClick = {
+                                            restoreTarget = item
+                                            restorePicker.launch(null)
+                                        }
+                                    )
+                                    .padding(vertical = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Column(modifier = Modifier.weight(1f)) {
+                                    Text(
+                                        text = if (item.type == ResourceType.IMAGE) "图片" else "视频",
+                                        style = MaterialTheme.typography.labelMedium
+                                    )
+                                    Text(
+                                        text = item.path,
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     bottomSheetTarget?.let { target ->
@@ -438,8 +508,14 @@ private fun ResourceCreateScreen(
     var editFlowIndex by remember { mutableStateOf<Int?>(null) }
 
     val context = LocalContext.current
-    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) {
-        imageUris = it
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+        imageUris = uris
+        uris.forEach { uri ->
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+        }
     }
     val videoPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
         videoUris = uris
@@ -613,7 +689,7 @@ private fun ResourceCreateScreen(
                     )
                 }
                 CreateMode.ImageGroup -> {
-                    TextButton(onClick = { imagePicker.launch("image/*") }) {
+                    TextButton(onClick = { imagePicker.launch(arrayOf("image/*")) }) {
                         Icon(Icons.Default.Image, contentDescription = null)
                         Spacer(Modifier.width(8.dp))
                         Text("选择图片")
@@ -797,7 +873,9 @@ private fun ResourceEditScreen(
     var textContent by remember { mutableStateOf(resource.resource.quoteText.orEmpty()) }
     var description by remember { mutableStateOf(resource.resource.quoteText.orEmpty()) }
     var sceneMessages by remember { mutableStateOf(parseSceneMessages(resource.resource.sceneJson)) }
-    var imageItems by remember { mutableStateOf(parseImageItems(resource.resource.quoteImageBase64)) }
+    var imageItems by remember {
+        mutableStateOf(parseImageItems(resource.resource.contentUriOrPath, resource.resource.quoteImageBase64))
+    }
     var videoItems by remember { mutableStateOf(parseVideoItems(resource.resource.contentUriOrPath)) }
     var flowItems by remember { mutableStateOf(parseFlowItems(resource.resource.sceneJson)) }
     var showSceneDialog by remember { mutableStateOf(false) }
@@ -806,9 +884,15 @@ private fun ResourceEditScreen(
     var editFlowIndex by remember { mutableStateOf<Int?>(null) }
 
     val context = LocalContext.current
-    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetMultipleContents()) { uris ->
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
         val updated = imageItems.toMutableList()
-        uris.forEach { uri -> updated.add(ImageUpdateItem(uri = uri)) }
+        uris.forEach { uri ->
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+            updated.add(ImageUpdateItem(uri = uri))
+        }
         imageItems = updated
     }
     val videoPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
@@ -917,7 +1001,7 @@ private fun ResourceEditScreen(
                     )
                 }
                 ResourceType.IMAGE -> {
-                    TextButton(onClick = { imagePicker.launch("image/*") }) {
+                    TextButton(onClick = { imagePicker.launch(arrayOf("image/*")) }) {
                         Icon(Icons.Default.Image, contentDescription = null)
                         Spacer(Modifier.width(8.dp))
                         Text("追加图片")
@@ -1588,22 +1672,31 @@ private fun parseSceneMessages(raw: String?): List<SceneMessageDraft> {
 }
 
 private fun parseImageItems(payload: String?): List<ImageUpdateItem> {
+    return parseImageItems(payload, null)
+}
+
+private fun parseImageItems(pathPayload: String?, base64Payload: String?): List<ImageUpdateItem> {
+    val payload = pathPayload?.takeIf { it.isNotBlank() } ?: base64Payload
     if (payload.isNullOrBlank()) return emptyList()
-    val base64List = runCatching {
-        val array = org.json.JSONArray(payload)
-        buildList {
-            for (i in 0 until array.length()) {
-                val item = array.optString(i)
-                if (item.isNotBlank()) add(item)
-            }
+    val list = parsePathList(payload)
+    return list.map { item ->
+        val uri = Uri.parse(item)
+        if (uri.scheme != null) {
+            ImageUpdateItem(path = item)
+        } else {
+            ImageUpdateItem(base64 = item)
         }
-    }.getOrElse { listOf(payload) }
-    return base64List.map { ImageUpdateItem(base64 = it) }
+    }
 }
 
 private fun parseVideoItems(raw: String?): List<VideoUpdateItem> {
     if (raw.isNullOrBlank()) return emptyList()
-    val list = if (raw.trim().startsWith("[")) {
+    val list = parsePathList(raw)
+    return list.map { VideoUpdateItem(path = it) }
+}
+
+private fun parsePathList(raw: String): List<String> {
+    return if (raw.trim().startsWith("[")) {
         runCatching {
             val array = org.json.JSONArray(raw)
             List(array.length()) { index -> array.getString(index) }
@@ -1611,7 +1704,6 @@ private fun parseVideoItems(raw: String?): List<VideoUpdateItem> {
     } else {
         listOf(raw)
     }
-    return list.map { VideoUpdateItem(path = it) }
 }
 
 private fun flowItemFromResource(resource: ResourceWithTagsCharacters): FlowUpdateItem {
@@ -1633,7 +1725,7 @@ private fun flowItemFromResource(resource: ResourceWithTagsCharacters): FlowUpda
             type = data.type,
             title = data.title,
             resourceId = data.id,
-            images = parseImageItems(data.quoteImageBase64)
+            images = parseImageItems(data.contentUriOrPath, data.quoteImageBase64)
         )
         ResourceType.VIDEO -> FlowUpdateItem(
             type = data.type,
@@ -1654,7 +1746,7 @@ private fun resourceSummary(resource: ResourceWithTagsCharacters): String {
             if (messages.isEmpty()) "" else "对话 ${messages.size} 条"
         }
         ResourceType.IMAGE -> {
-            val images = parseImageItems(data.quoteImageBase64)
+            val images = parseImageItems(data.contentUriOrPath, data.quoteImageBase64)
             if (images.isEmpty()) "" else "图片 ${images.size} 张"
         }
         ResourceType.VIDEO -> {
@@ -1713,7 +1805,14 @@ private fun parseFlowItems(raw: String?): List<FlowUpdateItem> {
                             if (images != null) {
                                 for (j in 0 until images.length()) {
                                     val item = images.optString(j)
-                                    if (item.isNotBlank()) add(ImageUpdateItem(base64 = item))
+                                    if (item.isNotBlank()) {
+                                        val uri = Uri.parse(item)
+                                        if (uri.scheme != null) {
+                                            add(ImageUpdateItem(path = item))
+                                        } else {
+                                            add(ImageUpdateItem(base64 = item))
+                                        }
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -85,7 +85,7 @@ fun ResourcePreviewScreen(
         mediaLoadFailed = false
         flowItems = emptyList()
         if (res.type == ResourceType.IMAGE) {
-            quoteImages = decodeQuoteImages(res.quoteImageBase64, vm)
+            quoteImages = decodeImageSources(res.contentUriOrPath ?: res.quoteImageBase64, vm)
         } else if (res.type == ResourceType.TEXT) {
             quoteImages = decodeQuoteImages(res.quoteImageBase64, vm)
         } else if (res.type == ResourceType.FLOW) {
@@ -131,7 +131,8 @@ fun ResourcePreviewScreen(
                 .padding(inner)
                 .fillMaxSize()
                 .verticalScroll(scrollState)
-                .padding(16.dp),
+                .padding(horizontal = 16.dp, vertical = 16.dp)
+                .padding(bottom = 96.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
             Text(
@@ -301,7 +302,7 @@ private fun MediaPreview(uri: Uri) {
         },
         modifier = Modifier
             .fillMaxWidth()
-            .height(320.dp)
+            .height(420.dp)
             .background(MaterialTheme.colorScheme.surfaceVariant)
     )
 }
@@ -332,6 +333,21 @@ private fun parseMediaPaths(raw: String): List<String> {
         }.getOrDefault(listOf(raw))
     }
     return listOf(raw)
+}
+
+private fun decodeImageSources(payload: String?, vm: ResourceViewModel): List<android.graphics.Bitmap> {
+    if (payload.isNullOrBlank()) return emptyList()
+    val items = parseMediaPaths(payload)
+    return items.mapNotNull { decodeImageSource(it, vm) }
+}
+
+private fun decodeImageSource(item: String, vm: ResourceViewModel): android.graphics.Bitmap? {
+    val uri = Uri.parse(item)
+    return if (uri.scheme != null) {
+        vm.decodeUriToBitmap(uri)
+    } else {
+        vm.decodeBase64ToBitmap(item)
+    }
 }
 
 @Composable
@@ -405,7 +421,7 @@ private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<Flo
                             for (j in 0 until images.length()) {
                                 val item = images.optString(j)
                                 if (item.isNotBlank()) {
-                                    vm.decodeBase64ToBitmap(item)?.let { add(it) }
+                                    decodeImageSource(item, vm)?.let { add(it) }
                                 }
                             }
                         }

--- a/app/src/main/java/com/example/quotepicker/util/ImageCompression.kt
+++ b/app/src/main/java/com/example/quotepicker/util/ImageCompression.kt
@@ -12,23 +12,26 @@ object ImageCompression {
     private const val MAX_EDGE = 1920
 
     fun encodeToBase64(context: Context, uri: Uri): String {
+        val scaled = decodeToBitmap(context, uri) ?: return ""
+        return ByteArrayOutputStream().use { baos ->
+            scaled.compress(Bitmap.CompressFormat.JPEG, 85, baos)
+            Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP)
+        }
+    }
+
+    fun decodeToBitmap(context: Context, uri: Uri): Bitmap? {
         val resolver = context.contentResolver
         val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }
         resolver.openInputStream(uri)?.use { input ->
             BitmapFactory.decodeStream(input, null, bounds)
         }
-        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return ""
+        if (bounds.outWidth <= 0 || bounds.outHeight <= 0) return null
         val sampleSize = calculateInSampleSize(bounds, MAX_EDGE, MAX_EDGE)
         val decodeOptions = BitmapFactory.Options().apply { inSampleSize = sampleSize }
         val bitmap = resolver.openInputStream(uri)?.use { input ->
             BitmapFactory.decodeStream(input, null, decodeOptions)
-        } ?: return ""
-
-        val scaled = scale(bitmap)
-        return ByteArrayOutputStream().use { baos ->
-            scaled.compress(Bitmap.CompressFormat.JPEG, 85, baos)
-            Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP)
-        }
+        } ?: return null
+        return scale(bitmap)
     }
 
     private fun scale(bitmap: Bitmap): Bitmap {

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -42,6 +42,7 @@ data class ResourceUiState(
 )
 
 data class ImageUpdateItem(
+    val path: String? = null,
     val base64: String? = null,
     val uri: Uri? = null
 )
@@ -49,6 +50,11 @@ data class ImageUpdateItem(
 data class VideoUpdateItem(
     val path: String? = null,
     val uri: Uri? = null
+)
+
+data class StoredMediaItem(
+    val path: String,
+    val type: ResourceType
 )
 
 data class SceneMessageDraft(
@@ -130,12 +136,11 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     fun addImageGroup(title: String, imageUris: List<Uri>, tagIds: List<Long>, characterIds: List<Long>) =
         viewModelScope.launch(Dispatchers.IO) {
             if (characterIds.isEmpty()) return@launch
-            val base64List = imageUris.mapNotNull { uri ->
-                ImageCompression.encodeToBase64(getApplication(), uri).ifBlank { null }
-            }
-            val payload = org.json.JSONArray(base64List).toString()
+            val storedPaths = imageUris.mapNotNull { uri -> storeImageToInternal(uri) }
+            if (storedPaths.isEmpty()) return@launch
+            val payload = org.json.JSONArray(storedPaths).toString()
             repo.addResource(
-                ResourceEntity(type = ResourceType.IMAGE, title = title, quoteImageBase64 = payload),
+                ResourceEntity(type = ResourceType.IMAGE, title = title, contentUriOrPath = payload),
                 tagIds,
                 characterIds
             )
@@ -232,8 +237,10 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         characterIds: List<Long>
     ) = viewModelScope.launch(Dispatchers.IO) {
         if (characterIds.isEmpty()) return@launch
-        val payload = org.json.JSONArray(encodeImageItems(items)).toString()
-        repo.updateResource(resource.copy(title = title, quoteImageBase64 = payload))
+        val resolved = resolveImageItems(items)
+        if (resolved.isEmpty()) return@launch
+        val payload = org.json.JSONArray(resolved).toString()
+        repo.updateResource(resource.copy(title = title, contentUriOrPath = payload, quoteImageBase64 = null))
         updateResourceTags(resource.id, tagIds)
         updateResourceCharacters(resource.id, characterIds)
     }
@@ -284,11 +291,11 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         }.filter { it.isNotBlank() }
     }
 
-    private suspend fun encodeImageItems(items: List<ImageUpdateItem>): List<String> {
+    private suspend fun resolveImageItems(items: List<ImageUpdateItem>): List<String> {
         return items.mapNotNull { item ->
-            item.base64 ?: item.uri?.let { uri ->
-                ImageCompression.encodeToBase64(getApplication(), uri).ifBlank { null }
-            }
+            item.path?.ifBlank { null }
+                ?: item.uri?.let { uri -> storeImageToInternal(uri) }
+                ?: item.base64?.let { base64 -> storeBase64ImageToInternal(base64) }
         }
     }
 
@@ -311,7 +318,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                     }
                     obj.put("messages", messages)
                 }
-                ResourceType.IMAGE -> obj.put("images", org.json.JSONArray(encodeImageItems(item.images)))
+                ResourceType.IMAGE -> obj.put("images", org.json.JSONArray(resolveImageItems(item.images)))
                 ResourceType.VIDEO -> obj.put("videos", org.json.JSONArray(resolveVideoItems(item.videos)))
                 ResourceType.FLOW -> obj.put("text", item.text.orEmpty())
             }
@@ -327,6 +334,83 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         }.getOrNull()
     }
 
+    fun decodeUriToBitmap(uri: Uri): Bitmap? {
+        return runCatching {
+            val resolver = getApplication<Application>().contentResolver
+            resolver.openInputStream(uri)?.use { input ->
+                BitmapFactory.decodeStream(input)
+            }
+        }.getOrNull()
+    }
+
+    fun listStoredMedia(): List<StoredMediaItem> {
+        val app = getApplication<Application>()
+        val images = File(app.filesDir, "images")
+            .listFiles()
+            ?.sortedByDescending { it.lastModified() }
+            ?.map { StoredMediaItem(path = Uri.fromFile(it).toString(), type = ResourceType.IMAGE) }
+            .orEmpty()
+        val videos = File(app.filesDir, "videos")
+            .listFiles()
+            ?.sortedByDescending { it.lastModified() }
+            ?.map { StoredMediaItem(path = Uri.fromFile(it).toString(), type = ResourceType.VIDEO) }
+            .orEmpty()
+        return images + videos
+    }
+
+    fun restoreMediaToDirectory(path: String, type: ResourceType, directoryUri: Uri): Boolean {
+        val app = getApplication<Application>()
+        val tree = androidx.documentfile.provider.DocumentFile.fromTreeUri(app, directoryUri) ?: return false
+        val sourceUri = Uri.parse(path)
+        val sourcePath = sourceUri.path ?: return false
+        val sourceFile = File(sourcePath)
+        if (!sourceFile.exists()) return false
+        val mime = when (type) {
+            ResourceType.IMAGE -> "image/*"
+            ResourceType.VIDEO -> "video/*"
+            else -> "*/*"
+        }
+        val target = tree.createFile(mime, sourceFile.name) ?: return false
+        val output = app.contentResolver.openOutputStream(target.uri) ?: return false
+        return runCatching {
+            output.use { out ->
+                sourceFile.inputStream().use { input -> input.copyTo(out) }
+            }
+            true
+        }.getOrDefault(false)
+    }
+
+    private fun storeBase64ImageToInternal(base64: String): String? {
+        val bitmap = decodeBase64ToBitmap(base64) ?: return null
+        return storeBitmapToInternal(bitmap)
+    }
+
+    private fun storeImageToInternal(uri: Uri): String? {
+        val bitmap = ImageCompression.decodeToBitmap(getApplication(), uri) ?: return null
+        val stored = storeBitmapToInternal(bitmap)
+        if (stored != null) {
+            deleteSourceUri(uri)
+        }
+        return stored
+    }
+
+    private fun storeBitmapToInternal(bitmap: Bitmap): String? {
+        return runCatching {
+            val dir = File(getApplication<Application>().filesDir, "images").apply { mkdirs() }
+            val target = File(dir, "image_${System.currentTimeMillis()}_${UUID.randomUUID()}.jpg")
+            FileOutputStream(target).use { output ->
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 85, output)
+            }
+            Uri.fromFile(target).toString()
+        }.getOrNull()
+    }
+
+    private fun deleteSourceUri(uri: Uri) {
+        runCatching {
+            getApplication<Application>().contentResolver.delete(uri, null, null)
+        }
+    }
+
     private fun storeVideoToInternal(uri: Uri): String? {
         return runCatching {
             val dir = File(getApplication<Application>().filesDir, "videos").apply { mkdirs() }
@@ -336,6 +420,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                     input.copyTo(output)
                 }
             } ?: return null
+            deleteSourceUri(uri)
             Uri.fromFile(target).toString()
         }.getOrNull()
     }


### PR DESCRIPTION
### Motivation
- Make image uploads behave like videos (store as internal files) to avoid large base64 blobs in the database and reduce crashes when uploading many images.  
- Improve resource preview usability by enlarging video preview and leaving bottom spacing so controls/menus don't occlude content.  
- Provide a management UI to inspect locally stored media paths and allow restoring files back to a chosen directory, and delete original sources after import.

### Description
- Change image handling to store files instead of in-database base64: `addImageGroup` and `updateImageGroup` now write images to `filesDir/images` and save paths in `ResourceEntity.contentUriOrPath` instead of `quoteImageBase64`.  
- Introduce `ImageUpdateItem.path`, `StoredMediaItem`, and resolution helpers in `ResourceViewModel` including `storeImageToInternal`, `storeBitmapToInternal`, `storeBase64ImageToInternal`, `deleteSourceUri`, `listStoredMedia`, and `restoreMediaToDirectory`.  
- Update pickers to use `OpenMultipleDocuments` and take persistable URI permissions (read+write) and delete original selection URIs after importing.  
- Add a media management entry (settings icon) in `ResourceScreen` that opens a bottom sheet listing stored images/videos with full paths and supports long-press to pick a target directory and restore the file.  
- Make preview improvements in `ResourcePreviewScreen`: support loading images from stored paths (fall back to legacy base64), add extra bottom padding to avoid bottom menus overlapping content, and increase video player height from 320dp to 420dp.  
- Add `ImageCompression.decodeToBitmap` and `ResourceViewModel.decodeUriToBitmap`/`decodeBase64ToBitmap` helpers; adjust flow payload builders and parsing functions to accept both stored paths and legacy base64.

### Testing
- No automated tests were run as part of this change.  
- Changes were compiled and committed locally (manual verification recommended on device/emulator for import, preview, management and restore flows).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dd96edaac832bba543d590ad58d01)