### PR TITLE
Fix experimental and clickable imports in ResourceScreen

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -4,10 +4,12 @@ import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -78,7 +80,7 @@ import com.example.quotepicker.vm.StoredMediaItem
 import com.example.quotepicker.vm.VideoUpdateItem
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewModel()) {
     val ui by vm.uiState.collectAsState()


### PR DESCRIPTION
### Motivation
- Resolve unresolved reference to `clickable` and opt into the foundation experimental APIs required by `combinedClickable` in `ResourceScreen.kt` to remove compiler errors/warnings.

### Description
- Add `import androidx.compose.foundation.ExperimentalFoundationApi` and `import androidx.compose.foundation.clickable` to `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`.
- Keep `combinedClickable` import and update the file-level opt-in to `@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)` so experimental foundation APIs are enabled.

### Testing
- No automated tests were run for this change (`not run`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dddb47250832b8500a9f68ebbd3e1)