### PR TITLE
Improve media storage management and obfuscate stored media files

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -5,6 +5,7 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -18,10 +19,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
@@ -53,14 +57,17 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.draw.clip
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.ResourceType
@@ -78,7 +85,10 @@ import com.example.quotepicker.vm.ResourceViewModel
 import com.example.quotepicker.vm.SceneMessageDraft
 import com.example.quotepicker.vm.StoredMediaItem
 import com.example.quotepicker.vm.VideoUpdateItem
+import java.io.File
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -93,7 +103,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     var deleteTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var filterTagDialog by remember { mutableStateOf(false) }
     var filterCharacterDialog by remember { mutableStateOf(false) }
-    var manageDialog by remember { mutableStateOf(false) }
+    var manageScreen by remember { mutableStateOf(false) }
     var manageItems by remember { mutableStateOf<List<StoredMediaItem>>(emptyList()) }
     var restoreTarget by remember { mutableStateOf<StoredMediaItem?>(null) }
     val coroutineScope = rememberCoroutineScope()
@@ -105,6 +115,22 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             }
         }
         restoreTarget = null
+    }
+
+    if (manageScreen) {
+        ManageStorageScreen(
+            items = manageItems,
+            vm = vm,
+            onBack = { manageScreen = false },
+            onRestore = { item ->
+                restoreTarget = item
+                restorePicker.launch(null)
+            },
+            onRefresh = {
+                manageItems = vm.listStoredMedia()
+            }
+        )
+        return
     }
 
     createMode?.let { mode ->
@@ -153,7 +179,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                     }
                     IconButton(onClick = {
                         manageItems = vm.listStoredMedia()
-                        manageDialog = true
+                        manageScreen = true
                     }) {
                         Icon(Icons.Default.Settings, contentDescription = "管理资源")
                     }
@@ -187,7 +213,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                     horizontalArrangement = Arrangement.spacedBy(12.dp),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    items(ui.resources, key = { it.resource.id }) { res ->
+                    gridItems(ui.resources, key = { it.resource.id }) { res ->
                         ResourceGridCard(
                             title = res.resource.title,
                             typeLabel = typeLabel(res.resource.type),
@@ -251,53 +277,6 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
         )
     }
 
-    if (manageDialog) {
-        ModalBottomSheet(onDismissRequest = { manageDialog = false }) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
-                verticalArrangement = Arrangement.spacedBy(12.dp)
-            ) {
-                Text("本地存储文件", style = MaterialTheme.typography.titleMedium)
-                Text("长按文件可选择目录恢复", style = MaterialTheme.typography.labelSmall)
-                if (manageItems.isEmpty()) {
-                    Text("暂无文件", style = MaterialTheme.typography.labelMedium)
-                } else {
-                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        manageItems.forEach { item ->
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .combinedClickable(
-                                        onClick = {},
-                                        onLongClick = {
-                                            restoreTarget = item
-                                            restorePicker.launch(null)
-                                        }
-                                    )
-                                    .padding(vertical = 6.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        text = if (item.type == ResourceType.IMAGE) "图片" else "视频",
-                                        style = MaterialTheme.typography.labelMedium
-                                    )
-                                    Text(
-                                        text = item.path,
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                                    )
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
     bottomSheetTarget?.let { target ->
         ModalBottomSheet(onDismissRequest = { bottomSheetTarget = null }) {
             Row(
@@ -339,6 +318,119 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             },
             dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text("取消") } }
         )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun ManageStorageScreen(
+    items: List<StoredMediaItem>,
+    vm: ResourceViewModel,
+    onBack: () -> Unit,
+    onRestore: (StoredMediaItem) -> Unit,
+    onRefresh: () -> Unit
+) {
+    val context = LocalContext.current
+    val imagesDir = remember { File(context.filesDir, "images").absolutePath }
+    val videosDir = remember { File(context.filesDir, "videos").absolutePath }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("资源存储") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                    }
+                },
+                actions = {
+                    TextButton(onClick = onRefresh) { Text("刷新") }
+                }
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Text("App 资源存储路径", style = MaterialTheme.typography.titleMedium)
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text("图片目录：$imagesDir", style = MaterialTheme.typography.labelSmall)
+                Text("视频目录：$videosDir", style = MaterialTheme.typography.labelSmall)
+            }
+            Text("长按文件可选择目录恢复", style = MaterialTheme.typography.labelSmall)
+            if (items.isEmpty()) {
+                Text("暂无文件", style = MaterialTheme.typography.labelMedium)
+            } else {
+                LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    items(items, key = { it.path }) { item ->
+                        StorageMediaRow(item = item, vm = vm, onRestore = onRestore)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StorageMediaRow(
+    item: StoredMediaItem,
+    vm: ResourceViewModel,
+    onRestore: (StoredMediaItem) -> Unit
+) {
+    val thumbnail by produceState<android.graphics.Bitmap?>(initialValue = null, item.path) {
+        value = if (item.type == ResourceType.IMAGE) {
+            withContext(Dispatchers.IO) { vm.decodeUriToBitmap(Uri.parse(item.path)) }
+        } else {
+            null
+        }
+    }
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .combinedClickable(
+                onClick = {},
+                onLongClick = { onRestore(item) }
+            )
+            .padding(vertical = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        if (item.type == ResourceType.IMAGE && thumbnail != null) {
+            Image(
+                bitmap = thumbnail!!.asImageBitmap(),
+                contentDescription = "图片预览",
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(MaterialTheme.shapes.small)
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .size(56.dp)
+                    .clip(MaterialTheme.shapes.small),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = if (item.type == ResourceType.IMAGE) Icons.Default.Image else Icons.Default.Videocam,
+                    contentDescription = null
+                )
+            }
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = if (item.type == ResourceType.IMAGE) "图片" else "视频",
+                style = MaterialTheme.typography.labelMedium
+            )
+            Text(
+                text = item.path,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
     }
 }
 
@@ -524,7 +616,7 @@ private fun ResourceCreateScreen(
         uris.forEach { uri ->
             context.contentResolver.takePersistableUriPermission(
                 uri,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
             )
         }
     }
@@ -902,7 +994,7 @@ private fun ResourceEditScreen(
         uris.forEach { uri ->
             context.contentResolver.takePersistableUriPermission(
                 uri,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
             )
             updated.add(VideoUpdateItem(uri = uri))
         }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -7,6 +7,7 @@ import android.net.Uri
 import android.util.Base64
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.documentfile.provider.DocumentFile
 import com.example.quotepicker.data.Repository
 import com.example.quotepicker.data.ResourceEntity
 import com.example.quotepicker.data.ResourceType
@@ -397,7 +398,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     private fun storeBitmapToInternal(bitmap: Bitmap): String? {
         return runCatching {
             val dir = File(getApplication<Application>().filesDir, "images").apply { mkdirs() }
-            val target = File(dir, "image_${System.currentTimeMillis()}_${UUID.randomUUID()}.jpg")
+            val target = File(dir, "media_${System.currentTimeMillis()}_${UUID.randomUUID()}.dat")
             FileOutputStream(target).use { output ->
                 bitmap.compress(Bitmap.CompressFormat.JPEG, 85, output)
             }
@@ -406,15 +407,20 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     private fun deleteSourceUri(uri: Uri) {
-        runCatching {
-            getApplication<Application>().contentResolver.delete(uri, null, null)
+        val app = getApplication<Application>()
+        val deleted = runCatching {
+            val doc = DocumentFile.fromSingleUri(app, uri)
+            doc?.delete() ?: false
+        }.getOrDefault(false)
+        if (!deleted) {
+            runCatching { app.contentResolver.delete(uri, null, null) }
         }
     }
 
     private fun storeVideoToInternal(uri: Uri): String? {
         return runCatching {
             val dir = File(getApplication<Application>().filesDir, "videos").apply { mkdirs() }
-            val target = File(dir, "video_${System.currentTimeMillis()}_${UUID.randomUUID()}.bin")
+            val target = File(dir, "media_${System.currentTimeMillis()}_${UUID.randomUUID()}.dat")
             getApplication<Application>().contentResolver.openInputStream(uri)?.use { input ->
                 FileOutputStream(target).use { output ->
                     input.copyTo(output)


### PR DESCRIPTION
### Motivation
- Users reported that source files were not always removed after upload, the management UI only showed a limited view, and stored files exposed obvious image/video extensions; the changes aim to clean up originals, present a clearer storage management screen with previews, and hide file types by renaming stored files.

### Description
- Replace the previous bottom-sheet file manager with a dedicated `ManageStorageScreen` that shows the app `images` and `videos` storage paths, lists stored files in a `LazyColumn`, and provides small image previews and long-press restore behavior (calls `vm.restoreMediaToDirectory`).
- Request write permission when persisting picked URIs by adding `Intent.FLAG_GRANT_WRITE_URI_PERMISSION` to the image/video pickers in create/edit flows so the app can attempt deletion of the source URIs.
- Obfuscate stored media filenames by writing both images and videos as `media_<timestamp>_<uuid>.dat` instead of visible `.jpg`/`.bin` names to reduce obvious detection.
- Harden source removal by first attempting `DocumentFile.fromSingleUri(...).delete()` and falling back to `contentResolver.delete(...)` when deleting the original picked URIs.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696de5beeaec832b8e204d0d8bb3de33)