### PR TITLE
Opt in to ExperimentalFoundationApi for StorageMediaRow

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -375,6 +375,7 @@ private fun ManageStorageScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun StorageMediaRow(
     item: StoredMediaItem,


### PR DESCRIPTION
### Motivation
- `StorageMediaRow` uses the experimental `combinedClickable` API and needs an opt-in to avoid compilation warnings or errors.

### Description
- Add `@OptIn(ExperimentalFoundationApi::class)` above the `StorageMediaRow` composable in `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt` to acknowledge usage of the experimental API.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dec4d55cc832bbf0aa5c822a4b385)