### PR TITLE
Add fullscreen preview for images and videos

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -6,6 +6,7 @@ import android.widget.MediaController
 import android.widget.VideoView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +25,7 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -32,6 +34,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -42,10 +45,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.ui.components.TagBadge
@@ -311,15 +317,30 @@ private fun MediaPreview(uri: Uri) {
 @Composable
 private fun MediaPreviewPager(uris: List<Uri>) {
     val pagerState = rememberPagerState(pageCount = { uris.size })
+    var fullScreenUri by remember { mutableStateOf<Uri?>(null) }
+    if (fullScreenUri != null) {
+        FullScreenVideoDialog(uri = fullScreenUri!!, onDismiss = { fullScreenUri = null })
+    }
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         HorizontalPager(state = pagerState) { page ->
             MediaPreview(uri = uris[page])
         }
-        if (uris.size > 1) {
-            Text(
-                text = "视频 ${pagerState.currentPage + 1}/${uris.size}",
-                style = MaterialTheme.typography.labelSmall
-            )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(modifier = Modifier.weight(1f)) {
+                if (uris.size > 1) {
+                    Text(
+                        text = "视频 ${pagerState.currentPage + 1}/${uris.size}",
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                }
+            }
+            TextButton(onClick = { fullScreenUri = uris[pagerState.currentPage] }) {
+                Text("全屏播放")
+            }
         }
     }
 }
@@ -485,11 +506,17 @@ private fun ResourceMetaRow(
 @Composable
 private fun QuoteImagePager(images: List<android.graphics.Bitmap>) {
     if (images.isEmpty()) return
+    var fullScreenImage by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
+    if (fullScreenImage != null) {
+        FullScreenImageDialog(bitmap = fullScreenImage!!, onDismiss = { fullScreenImage = null })
+    }
     if (images.size == 1) {
         Image(
             bitmap = images.first().asImageBitmap(),
             contentDescription = null,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { fullScreenImage = images.first() }
         )
         return
     }
@@ -499,7 +526,9 @@ private fun QuoteImagePager(images: List<android.graphics.Bitmap>) {
             Image(
                 bitmap = images[page].asImageBitmap(),
                 contentDescription = null,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { fullScreenImage = images[page] }
             )
         }
         Text(
@@ -507,6 +536,77 @@ private fun QuoteImagePager(images: List<android.graphics.Bitmap>) {
             style = MaterialTheme.typography.labelSmall,
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )
+    }
+}
+
+@Composable
+private fun FullScreenImageDialog(bitmap: android.graphics.Bitmap, onDismiss: () -> Unit) {
+    Dialog(onDismissRequest = onDismiss) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .clickable(onClick = onDismiss)
+        ) {
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxSize()
+            )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.TopEnd)
+            ) {
+                Icon(Icons.Default.Close, contentDescription = "关闭", tint = Color.White)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FullScreenVideoDialog(uri: Uri, onDismiss: () -> Unit) {
+    Dialog(onDismissRequest = onDismiss) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+        ) {
+            val viewHolder = remember { mutableStateOf<VideoView?>(null) }
+            DisposableEffect(Unit) {
+                onDispose {
+                    viewHolder.value?.stopPlayback()
+                }
+            }
+            AndroidView(
+                factory = { context ->
+                    VideoView(context).apply {
+                        val controller = MediaController(context)
+                        controller.setAnchorView(this)
+                        setMediaController(controller)
+                        setVideoURI(uri)
+                        tag = uri
+                        setOnPreparedListener { mediaPlayer ->
+                            mediaPlayer.start()
+                        }
+                        viewHolder.value = this
+                    }
+                },
+                update = { view ->
+                    if (view.tag != uri) {
+                        view.tag = uri
+                        view.setVideoURI(uri)
+                    }
+                },
+                modifier = Modifier.fillMaxSize()
+            )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.TopEnd)
+            ) {
+                Icon(Icons.Default.Close, contentDescription = "关闭", tint = Color.White)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Provide a way to view images in fullscreen on tap and allow videos to be played in fullscreen, matching the preview UX expectations for image/video resources.

### Description
- Added `FullScreenImageDialog` and `FullScreenVideoDialog` composables and required imports to `ResourcePreviewScreen.kt`.
- Wired image fullscreen into `QuoteImagePager` by adding `clickable` handlers to images and a state-backed fullscreen bitmap (`fullScreenImage`).
- Wired video fullscreen into `MediaPreviewPager` by adding a `TextButton` to open the currently visible video in `FullScreenVideoDialog` and a state-backed `fullScreenUri`; preserved video lifecycle with `DisposableEffect` and `stopPlayback()`.
- Kept existing inline previews intact and ensured the same fullscreen behavior works for Flow items that use the same pagers.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696df5b32354832ba2a846449719cf20)