### PR TITLE
Make fullscreen dialogs fill screen and preserve media aspect ratio; add video orientation toggle

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -6,6 +6,7 @@ import android.widget.MediaController
 import android.widget.VideoView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -24,7 +26,9 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Card
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,6 +36,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -42,10 +47,15 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.ui.components.TagBadge
@@ -311,15 +321,30 @@ private fun MediaPreview(uri: Uri) {
 @Composable
 private fun MediaPreviewPager(uris: List<Uri>) {
     val pagerState = rememberPagerState(pageCount = { uris.size })
+    var fullScreenUri by remember { mutableStateOf<Uri?>(null) }
+    if (fullScreenUri != null) {
+        FullScreenVideoDialog(uri = fullScreenUri!!, onDismiss = { fullScreenUri = null })
+    }
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         HorizontalPager(state = pagerState) { page ->
             MediaPreview(uri = uris[page])
         }
-        if (uris.size > 1) {
-            Text(
-                text = "视频 ${pagerState.currentPage + 1}/${uris.size}",
-                style = MaterialTheme.typography.labelSmall
-            )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(modifier = Modifier.weight(1f)) {
+                if (uris.size > 1) {
+                    Text(
+                        text = "视频 ${pagerState.currentPage + 1}/${uris.size}",
+                        style = MaterialTheme.typography.labelSmall
+                    )
+                }
+            }
+            TextButton(onClick = { fullScreenUri = uris[pagerState.currentPage] }) {
+                Text("全屏播放")
+            }
         }
     }
 }
@@ -485,11 +510,17 @@ private fun ResourceMetaRow(
 @Composable
 private fun QuoteImagePager(images: List<android.graphics.Bitmap>) {
     if (images.isEmpty()) return
+    var fullScreenImage by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
+    if (fullScreenImage != null) {
+        FullScreenImageDialog(bitmap = fullScreenImage!!, onDismiss = { fullScreenImage = null })
+    }
     if (images.size == 1) {
         Image(
             bitmap = images.first().asImageBitmap(),
             contentDescription = null,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier
+                .fillMaxWidth()
+                .clickable { fullScreenImage = images.first() }
         )
         return
     }
@@ -499,7 +530,9 @@ private fun QuoteImagePager(images: List<android.graphics.Bitmap>) {
             Image(
                 bitmap = images[page].asImageBitmap(),
                 contentDescription = null,
-                modifier = Modifier.fillMaxWidth()
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { fullScreenImage = images[page] }
             )
         }
         Text(
@@ -507,6 +540,115 @@ private fun QuoteImagePager(images: List<android.graphics.Bitmap>) {
             style = MaterialTheme.typography.labelSmall,
             modifier = Modifier.align(Alignment.CenterHorizontally)
         )
+    }
+}
+
+@Composable
+private fun FullScreenImageDialog(bitmap: android.graphics.Bitmap, onDismiss: () -> Unit) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+                .clickable(onClick = onDismiss)
+        ) {
+            Image(
+                bitmap = bitmap.asImageBitmap(),
+                contentDescription = null,
+                contentScale = ContentScale.Fit,
+                modifier = Modifier.fillMaxSize()
+            )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.align(Alignment.TopEnd)
+            ) {
+                Icon(Icons.Default.Close, contentDescription = "关闭", tint = Color.White)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FullScreenVideoDialog(uri: Uri, onDismiss: () -> Unit) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        var landscape by remember { mutableStateOf(false) }
+        var aspectRatio by remember { mutableStateOf(0f) }
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+        ) {
+            val viewHolder = remember { mutableStateOf<VideoView?>(null) }
+            DisposableEffect(Unit) {
+                onDispose {
+                    viewHolder.value?.stopPlayback()
+                }
+            }
+            AndroidView(
+                factory = { context ->
+                    VideoView(context).apply {
+                        val controller = MediaController(context)
+                        controller.setAnchorView(this)
+                        setMediaController(controller)
+                        setVideoURI(uri)
+                        tag = uri
+                        setOnPreparedListener { mediaPlayer ->
+                            aspectRatio =
+                                if (mediaPlayer.videoHeight > 0) {
+                                    mediaPlayer.videoWidth.toFloat() / mediaPlayer.videoHeight.toFloat()
+                                } else {
+                                    0f
+                                }
+                            mediaPlayer.start()
+                        }
+                        viewHolder.value = this
+                    }
+                },
+                update = { view ->
+                    if (view.tag != uri) {
+                        view.tag = uri
+                        view.setVideoURI(uri)
+                    }
+                },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .then(
+                        if (aspectRatio > 0f) {
+                            Modifier
+                                .align(Alignment.Center)
+                                .aspectRatio(aspectRatio)
+                        } else {
+                            Modifier
+                        }
+                    )
+                    .graphicsLayer {
+                        rotationZ = if (landscape) 90f else 0f
+                    }
+            )
+            Row(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(top = 4.dp, end = 4.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(
+                    onClick = { landscape = !landscape },
+                    colors = ButtonDefaults.textButtonColors(contentColor = Color.White)
+                ) {
+                    Text(if (landscape) "竖屏" else "横屏")
+                }
+                IconButton(onClick = onDismiss) {
+                    Icon(Icons.Default.Close, contentDescription = "关闭", tint = Color.White)
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation
- Ensure fullscreen dialogs truly cover the whole screen by disabling the platform default dialog width and prevent image/video distortion while filling the dialog area.
- Provide a user control to toggle video orientation in the fullscreen player without breaking aspect ratio.

### Description
- Use `DialogProperties(usePlatformDefaultWidth = false)` for fullscreen dialogs and add `FullScreenImageDialog` and `FullScreenVideoDialog` implementations in `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`.
- Change image scaling in fullscreen to `ContentScale.Fit` and open images in fullscreen via `fullScreenImage` state and clickable image handlers using `QuoteImagePager`.
- Preserve video aspect ratio by computing `aspectRatio` from the media player and applying `.aspectRatio(aspectRatio)` while keeping a rotation toggle (`landscape`) that rotates the `AndroidView` with `graphicsLayer` and a `TextButton` to switch orientation; wire fullscreen video via `fullScreenUri` in `MediaPreviewPager`.
- Ensure video lifecycle is handled by calling `stopPlayback()` in a `DisposableEffect` when the fullscreen dialog is dismissed, and add necessary imports and UI affordances (close buttons and a `全屏播放` button).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696df5b32354832ba2a846449719cf20)