### PR TITLE
Add backup import/export (snapshot) and RandomScreen intro button

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
+++ b/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
@@ -1,0 +1,170 @@
+package com.example.quotepicker.data
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+data class BackupSnapshot(
+    val categories: List<TagCategoryEntity>,
+    val tags: List<TagEntity>,
+    val characters: List<CharacterEntity>,
+    val resources: List<ResourceEntity>,
+    val resourceTagRefs: List<ResourceTagCrossRef>,
+    val characterTagRefs: List<CharacterTagCrossRef>,
+    val resourceCharacterRefs: List<ResourceCharacterCrossRef>
+) {
+    fun toJsonString(): String = toJson().toString()
+
+    fun toJson(): JSONObject {
+        return JSONObject().apply {
+            put("version", 1)
+            put("categories", JSONArray(categories.map(::categoryToJson)))
+            put("tags", JSONArray(tags.map(::tagToJson)))
+            put("characters", JSONArray(characters.map(::characterToJson)))
+            put("resources", JSONArray(resources.map(::resourceToJson)))
+            put("resourceTagRefs", JSONArray(resourceTagRefs.map(::resourceTagToJson)))
+            put("characterTagRefs", JSONArray(characterTagRefs.map(::characterTagToJson)))
+            put("resourceCharacterRefs", JSONArray(resourceCharacterRefs.map(::resourceCharacterToJson)))
+        }
+    }
+
+    companion object {
+        fun fromJson(json: String): BackupSnapshot {
+            val obj = JSONObject(json)
+            return BackupSnapshot(
+                categories = parseArray(obj, "categories", ::categoryFromJson),
+                tags = parseArray(obj, "tags", ::tagFromJson),
+                characters = parseArray(obj, "characters", ::characterFromJson),
+                resources = parseArray(obj, "resources", ::resourceFromJson),
+                resourceTagRefs = parseArray(obj, "resourceTagRefs", ::resourceTagFromJson),
+                characterTagRefs = parseArray(obj, "characterTagRefs", ::characterTagFromJson),
+                resourceCharacterRefs = parseArray(obj, "resourceCharacterRefs", ::resourceCharacterFromJson)
+            )
+        }
+    }
+}
+
+private fun categoryToJson(category: TagCategoryEntity): JSONObject =
+    JSONObject()
+        .put("id", category.id)
+        .put("type", category.type.name)
+        .put("name", category.name)
+        .put("createdAt", category.createdAt)
+        .put("updatedAt", category.updatedAt)
+
+private fun tagToJson(tag: TagEntity): JSONObject =
+    JSONObject()
+        .put("id", tag.id)
+        .put("categoryId", tag.categoryId)
+        .put("name", tag.name)
+        .put("colorArgb", tag.colorArgb)
+        .put("createdAt", tag.createdAt)
+        .put("updatedAt", tag.updatedAt)
+
+private fun characterToJson(character: CharacterEntity): JSONObject =
+    JSONObject()
+        .put("id", character.id)
+        .put("name", character.name)
+        .put("description", character.description)
+        .put("createdAt", character.createdAt)
+        .put("updatedAt", character.updatedAt)
+
+private fun resourceToJson(resource: ResourceEntity): JSONObject =
+    JSONObject()
+        .put("id", resource.id)
+        .put("type", resource.type.name)
+        .put("title", resource.title)
+        .put("contentUriOrPath", resource.contentUriOrPath)
+        .put("quoteText", resource.quoteText)
+        .put("quoteImageBase64", resource.quoteImageBase64)
+        .put("sceneJson", resource.sceneJson)
+        .put("createdAt", resource.createdAt)
+        .put("updatedAt", resource.updatedAt)
+
+private fun resourceTagToJson(ref: ResourceTagCrossRef): JSONObject =
+    JSONObject()
+        .put("resourceId", ref.resourceId)
+        .put("tagId", ref.tagId)
+
+private fun characterTagToJson(ref: CharacterTagCrossRef): JSONObject =
+    JSONObject()
+        .put("characterId", ref.characterId)
+        .put("tagId", ref.tagId)
+
+private fun resourceCharacterToJson(ref: ResourceCharacterCrossRef): JSONObject =
+    JSONObject()
+        .put("resourceId", ref.resourceId)
+        .put("characterId", ref.characterId)
+
+private fun categoryFromJson(obj: JSONObject): TagCategoryEntity =
+    TagCategoryEntity(
+        id = obj.getLong("id"),
+        type = TagCategoryType.valueOf(obj.getString("type")),
+        name = obj.getString("name"),
+        createdAt = obj.getLong("createdAt"),
+        updatedAt = obj.getLong("updatedAt")
+    )
+
+private fun tagFromJson(obj: JSONObject): TagEntity =
+    TagEntity(
+        id = obj.getLong("id"),
+        categoryId = obj.getLong("categoryId"),
+        name = obj.getString("name"),
+        colorArgb = obj.getInt("colorArgb"),
+        createdAt = obj.getLong("createdAt"),
+        updatedAt = obj.getLong("updatedAt")
+    )
+
+private fun characterFromJson(obj: JSONObject): CharacterEntity =
+    CharacterEntity(
+        id = obj.getLong("id"),
+        name = obj.getString("name"),
+        description = readNullableString(obj, "description"),
+        createdAt = obj.getLong("createdAt"),
+        updatedAt = obj.getLong("updatedAt")
+    )
+
+private fun resourceFromJson(obj: JSONObject): ResourceEntity =
+    ResourceEntity(
+        id = obj.getLong("id"),
+        type = ResourceType.valueOf(obj.getString("type")),
+        title = obj.getString("title"),
+        contentUriOrPath = readNullableString(obj, "contentUriOrPath"),
+        quoteText = readNullableString(obj, "quoteText"),
+        quoteImageBase64 = readNullableString(obj, "quoteImageBase64"),
+        sceneJson = readNullableString(obj, "sceneJson"),
+        createdAt = obj.getLong("createdAt"),
+        updatedAt = obj.getLong("updatedAt")
+    )
+
+private fun resourceTagFromJson(obj: JSONObject): ResourceTagCrossRef =
+    ResourceTagCrossRef(
+        resourceId = obj.getLong("resourceId"),
+        tagId = obj.getLong("tagId")
+    )
+
+private fun characterTagFromJson(obj: JSONObject): CharacterTagCrossRef =
+    CharacterTagCrossRef(
+        characterId = obj.getLong("characterId"),
+        tagId = obj.getLong("tagId")
+    )
+
+private fun resourceCharacterFromJson(obj: JSONObject): ResourceCharacterCrossRef =
+    ResourceCharacterCrossRef(
+        resourceId = obj.getLong("resourceId"),
+        characterId = obj.getLong("characterId")
+    )
+
+private fun <T> parseArray(
+    obj: JSONObject,
+    key: String,
+    mapper: (JSONObject) -> T
+): List<T> {
+    val array = obj.optJSONArray(key) ?: JSONArray()
+    return List(array.length()) { index ->
+        mapper(array.getJSONObject(index))
+    }
+}
+
+private fun readNullableString(obj: JSONObject, key: String): String? {
+    return if (obj.has(key) && !obj.isNull(key)) obj.getString(key) else null
+}

--- a/app/src/main/java/com/example/quotepicker/data/Dao.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Dao.kt
@@ -13,6 +13,9 @@ interface TagCategoryDao {
     @Query("SELECT * FROM tag_categories ORDER BY name COLLATE NOCASE ASC")
     fun observeCategories(): Flow<List<TagCategoryEntity>>
 
+    @Query("SELECT * FROM tag_categories ORDER BY name COLLATE NOCASE ASC")
+    suspend fun listAll(): List<TagCategoryEntity>
+
     @Query("SELECT * FROM tag_categories WHERE type = :type ORDER BY name COLLATE NOCASE ASC")
     fun observeCategoriesByType(type: TagCategoryType): Flow<List<TagCategoryEntity>>
 
@@ -22,11 +25,17 @@ interface TagCategoryDao {
     @Insert
     suspend fun insert(category: TagCategoryEntity): Long
 
+    @Insert
+    suspend fun insertAll(categories: List<TagCategoryEntity>)
+
     @Update
     suspend fun update(category: TagCategoryEntity)
 
     @Delete
     suspend fun delete(category: TagCategoryEntity)
+
+    @Query("DELETE FROM tag_categories")
+    suspend fun deleteAll()
 }
 
 @Dao
@@ -37,8 +46,14 @@ interface TagDao {
     @Query("SELECT * FROM tags ORDER BY name COLLATE NOCASE ASC")
     fun observeAllTags(): Flow<List<TagEntity>>
 
+    @Query("SELECT * FROM tags ORDER BY name COLLATE NOCASE ASC")
+    suspend fun listAll(): List<TagEntity>
+
     @Insert
     suspend fun insert(tag: TagEntity): Long
+
+    @Insert
+    suspend fun insertAll(tags: List<TagEntity>)
 
     @Update
     suspend fun update(tag: TagEntity)
@@ -48,6 +63,9 @@ interface TagDao {
 
     @Query("UPDATE tags SET categoryId = :newCategoryId WHERE categoryId = :oldCategoryId")
     suspend fun reassignCategory(oldCategoryId: Long, newCategoryId: Long)
+
+    @Query("DELETE FROM tags")
+    suspend fun deleteAll()
 }
 
 @Dao
@@ -59,14 +77,23 @@ interface CharacterDao {
     @Query("SELECT * FROM characters ORDER BY name COLLATE NOCASE ASC")
     fun observeCharactersWithTags(): Flow<List<CharacterWithTags>>
 
+    @Query("SELECT * FROM characters ORDER BY name COLLATE NOCASE ASC")
+    suspend fun listAll(): List<CharacterEntity>
+
     @Insert
     suspend fun insert(character: CharacterEntity): Long
+
+    @Insert
+    suspend fun insertAll(characters: List<CharacterEntity>)
 
     @Update
     suspend fun update(character: CharacterEntity)
 
     @Delete
     suspend fun delete(character: CharacterEntity)
+
+    @Query("DELETE FROM characters")
+    suspend fun deleteAll()
 }
 
 @Dao
@@ -78,14 +105,23 @@ interface ResourceDao {
     @Query("SELECT * FROM resources ORDER BY createdAt DESC")
     fun observeResourcesWithRelations(): Flow<List<ResourceWithTagsCharacters>>
 
+    @Query("SELECT * FROM resources ORDER BY createdAt DESC")
+    suspend fun listAll(): List<ResourceEntity>
+
     @Insert
     suspend fun insert(resource: ResourceEntity): Long
+
+    @Insert
+    suspend fun insertAll(resources: List<ResourceEntity>)
 
     @Update
     suspend fun update(resource: ResourceEntity)
 
     @Delete
     suspend fun delete(resource: ResourceEntity)
+
+    @Query("DELETE FROM resources")
+    suspend fun deleteAll()
 }
 
 @Dao
@@ -98,6 +134,15 @@ interface CrossRefDao {
 
     @Insert
     suspend fun insertResourceCharacters(refs: List<ResourceCharacterCrossRef>)
+
+    @Query("SELECT * FROM resource_tag_cross_ref")
+    suspend fun listResourceTags(): List<ResourceTagCrossRef>
+
+    @Query("SELECT * FROM character_tag_cross_ref")
+    suspend fun listCharacterTags(): List<CharacterTagCrossRef>
+
+    @Query("SELECT * FROM resource_character_cross_ref")
+    suspend fun listResourceCharacters(): List<ResourceCharacterCrossRef>
 
     @Query("DELETE FROM resource_tag_cross_ref WHERE resourceId = :resourceId")
     suspend fun clearResourceTags(resourceId: Long)
@@ -113,4 +158,13 @@ interface CrossRefDao {
 
     @Query("SELECT resourceId FROM resource_tag_cross_ref WHERE tagId IN (:tagIds)")
     suspend fun resourceIdsForTags(tagIds: List<Long>): List<Long>
+
+    @Query("DELETE FROM resource_tag_cross_ref")
+    suspend fun deleteAllResourceTags()
+
+    @Query("DELETE FROM character_tag_cross_ref")
+    suspend fun deleteAllCharacterTags()
+
+    @Query("DELETE FROM resource_character_cross_ref")
+    suspend fun deleteAllResourceCharacters()
 }

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -21,6 +21,34 @@ class Repository private constructor(context: Context) {
     fun observeResources(): Flow<List<ResourceEntity>> = resourceDao.observeResources()
     fun observeResourcesWithRelations(): Flow<List<ResourceWithTagsCharacters>> = resourceDao.observeResourcesWithRelations()
 
+    suspend fun exportSnapshot(): BackupSnapshot =
+        BackupSnapshot(
+            categories = categoryDao.listAll(),
+            tags = tagDao.listAll(),
+            characters = characterDao.listAll(),
+            resources = resourceDao.listAll(),
+            resourceTagRefs = crossRefDao.listResourceTags(),
+            characterTagRefs = crossRefDao.listCharacterTags(),
+            resourceCharacterRefs = crossRefDao.listResourceCharacters()
+        )
+
+    suspend fun replaceSnapshot(snapshot: BackupSnapshot) {
+        crossRefDao.deleteAllResourceTags()
+        crossRefDao.deleteAllCharacterTags()
+        crossRefDao.deleteAllResourceCharacters()
+        resourceDao.deleteAll()
+        characterDao.deleteAll()
+        tagDao.deleteAll()
+        categoryDao.deleteAll()
+        if (snapshot.categories.isNotEmpty()) categoryDao.insertAll(snapshot.categories)
+        if (snapshot.tags.isNotEmpty()) tagDao.insertAll(snapshot.tags)
+        if (snapshot.characters.isNotEmpty()) characterDao.insertAll(snapshot.characters)
+        if (snapshot.resources.isNotEmpty()) resourceDao.insertAll(snapshot.resources)
+        if (snapshot.resourceTagRefs.isNotEmpty()) crossRefDao.insertResourceTags(snapshot.resourceTagRefs)
+        if (snapshot.characterTagRefs.isNotEmpty()) crossRefDao.insertCharacterTags(snapshot.characterTagRefs)
+        if (snapshot.resourceCharacterRefs.isNotEmpty()) crossRefDao.insertResourceCharacters(snapshot.resourceCharacterRefs)
+    }
+
     suspend fun addCategory(name: String, type: TagCategoryType) =
         categoryDao.insert(TagCategoryEntity(name = name, type = type))
 

--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -15,6 +15,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
@@ -82,6 +84,16 @@ fun CharacterScreen(
     var selectedTagIds by remember { mutableStateOf(setOf<Long>()) }
     var selectedType by remember { mutableStateOf<ResourceType?>(null) }
     var previewTarget by remember { mutableStateOf<com.example.quotepicker.data.ResourceWithTagsCharacters?>(null) }
+    val importPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        if (uri != null) {
+            vm.importSnapshot(uri)
+        }
+    }
+    val exportPicker = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
+        if (uri != null) {
+            vm.exportSnapshot(uri)
+        }
+    }
 
     LaunchedEffect(selectedId) {
         selectedTagIds = emptySet()
@@ -106,6 +118,18 @@ fun CharacterScreen(
                     if (selected != null) {
                         IconButton(onClick = { selectedId = null }) {
                             Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                        }
+                    }
+                },
+                actions = {
+                    if (selected == null) {
+                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            TextButton(onClick = { importPicker.launch(arrayOf("application/json")) }) {
+                                Text("导入")
+                            }
+                            TextButton(onClick = { exportPicker.launch("quote_backup.json") }) {
+                                Text("导出")
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -44,6 +44,7 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
     val ui by vm.uiState.collectAsState()
     var showPreview by remember { mutableStateOf(false) }
     var showTagDialog by remember { mutableStateOf(false) }
+    var showIntro by remember { mutableStateOf(false) }
 
     if (showPreview && ui.selectedResource != null) {
         ResourcePreviewScreen(
@@ -55,10 +56,18 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
     }
 
     Column(modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        Button(onClick = { vm.randomCharacter() }) {
-            Icon(Icons.Default.Casino, contentDescription = null)
-            Spacer(Modifier.width(8.dp))
-            Text("随机角色")
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = {
+                vm.randomCharacter()
+                showIntro = false
+            }) {
+                Icon(Icons.Default.Casino, contentDescription = null)
+                Spacer(Modifier.width(8.dp))
+                Text("随机角色")
+            }
+            Button(onClick = { showIntro = true }, enabled = ui.selectedCharacter != null) {
+                Text("显示介绍")
+            }
         }
         if (ui.selectedCharacter == null) {
             Text("未选择角色")
@@ -109,6 +118,10 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
                 Spacer(Modifier.width(8.dp))
                 Text("预览")
             }
+        }
+        if (showIntro && ui.selectedCharacter != null) {
+            val focus = ui.selectedCharacter!!.name.take(2)
+            Text("${focus}为要点")
         }
     }
 

--- a/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
@@ -1,14 +1,18 @@
 package com.example.quotepicker.vm
 
 import android.app.Application
+import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.quotepicker.data.BackupSnapshot
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.CharacterWithTags
 import com.example.quotepicker.data.Repository
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
+import java.nio.charset.Charset
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -40,4 +44,21 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
     fun deleteCharacter(character: CharacterEntity) = viewModelScope.launch { repo.deleteCharacter(character) }
     fun updateCharacterTags(characterId: Long, tagIds: List<Long>) =
         viewModelScope.launch { repo.updateCharacterTags(characterId, tagIds) }
+
+    fun exportSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
+        val snapshot = repo.exportSnapshot()
+        val payload = snapshot.toJsonString()
+        val resolver = getApplication<Application>().contentResolver
+        resolver.openOutputStream(uri)?.use { output ->
+            output.write(payload.toByteArray(Charset.forName("UTF-8")))
+        }
+    }
+
+    fun importSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
+        val resolver = getApplication<Application>().contentResolver
+        val payload = resolver.openInputStream(uri)?.bufferedReader(Charset.forName("UTF-8"))?.use { it.readText() }
+            ?: return@launch
+        val snapshot = BackupSnapshot.fromJson(payload)
+        repo.replaceSnapshot(snapshot)
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide a simple way to export and import the entire app data (categories, tags, characters, resources and cross refs) so users can transfer data across devices via a file package.
- Add a small UX shortcut on the random page to show a concise character intro/focus text after a character is picked.

### Description
- Add a new data class `BackupSnapshot` with JSON `toJson()`/`fromJson()` helpers to serialize/deserialize the full DB snapshot in `app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt`.
- Extend DAOs with `listAll`, `insertAll`, and `deleteAll` methods plus cross-ref listing and delete helpers to support bulk export/import in `app/src/main/java/com/example/quotepicker/data/Dao.kt`.
- Add repository methods `exportSnapshot()` and `replaceSnapshot()` that produce/consume a `BackupSnapshot` and perform bulk persistence in `app/src/main/java/com/example/quotepicker/data/Repository.kt`.
- Wire import/export to the UI and VM: add `exportSnapshot`/`importSnapshot` methods in `CharacterViewModel`, add import/export action buttons and document pickers in `CharacterScreen` (using `ActivityResultContracts`) to read/write JSON backup files, and add the `显示介绍` button and brief intro text to `RandomScreen` to show the first two characters as a focus line.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ec9cbfe9c832bb8f645b53a34681a)