### PR TITLE
Fix intro preview lookup and include media in backups

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
+++ b/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
@@ -10,13 +10,14 @@ data class BackupSnapshot(
     val resources: List<ResourceEntity>,
     val resourceTagRefs: List<ResourceTagCrossRef>,
     val characterTagRefs: List<CharacterTagCrossRef>,
-    val resourceCharacterRefs: List<ResourceCharacterCrossRef>
+    val resourceCharacterRefs: List<ResourceCharacterCrossRef>,
+    val media: List<MediaBackupItem> = emptyList()
 ) {
     fun toJsonString(): String = toJson().toString()
 
     fun toJson(): JSONObject {
         return JSONObject().apply {
-            put("version", 1)
+            put("version", 2)
             put("categories", JSONArray(categories.map(::categoryToJson)))
             put("tags", JSONArray(tags.map(::tagToJson)))
             put("characters", JSONArray(characters.map(::characterToJson)))
@@ -24,6 +25,7 @@ data class BackupSnapshot(
             put("resourceTagRefs", JSONArray(resourceTagRefs.map(::resourceTagToJson)))
             put("characterTagRefs", JSONArray(characterTagRefs.map(::characterTagToJson)))
             put("resourceCharacterRefs", JSONArray(resourceCharacterRefs.map(::resourceCharacterToJson)))
+            put("media", JSONArray(media.map(::mediaToJson)))
         }
     }
 
@@ -37,11 +39,18 @@ data class BackupSnapshot(
                 resources = parseArray(obj, "resources", ::resourceFromJson),
                 resourceTagRefs = parseArray(obj, "resourceTagRefs", ::resourceTagFromJson),
                 characterTagRefs = parseArray(obj, "characterTagRefs", ::characterTagFromJson),
-                resourceCharacterRefs = parseArray(obj, "resourceCharacterRefs", ::resourceCharacterFromJson)
+                resourceCharacterRefs = parseArray(obj, "resourceCharacterRefs", ::resourceCharacterFromJson),
+                media = parseArray(obj, "media", ::mediaFromJson)
             )
         }
     }
 }
+
+data class MediaBackupItem(
+    val originalPath: String,
+    val type: ResourceType,
+    val base64: String
+)
 
 private fun categoryToJson(category: TagCategoryEntity): JSONObject =
     JSONObject()
@@ -94,6 +103,12 @@ private fun resourceCharacterToJson(ref: ResourceCharacterCrossRef): JSONObject 
     JSONObject()
         .put("resourceId", ref.resourceId)
         .put("characterId", ref.characterId)
+
+private fun mediaToJson(item: MediaBackupItem): JSONObject =
+    JSONObject()
+        .put("path", item.originalPath)
+        .put("type", item.type.name)
+        .put("base64", item.base64)
 
 private fun categoryFromJson(obj: JSONObject): TagCategoryEntity =
     TagCategoryEntity(
@@ -152,6 +167,13 @@ private fun resourceCharacterFromJson(obj: JSONObject): ResourceCharacterCrossRe
     ResourceCharacterCrossRef(
         resourceId = obj.getLong("resourceId"),
         characterId = obj.getLong("characterId")
+    )
+
+private fun mediaFromJson(obj: JSONObject): MediaBackupItem =
+    MediaBackupItem(
+        originalPath = obj.getString("path"),
+        type = ResourceType.valueOf(obj.getString("type")),
+        base64 = obj.getString("base64")
     )
 
 private fun <T> parseArray(

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -1,9 +1,14 @@
 package com.example.quotepicker.data
 
 import android.content.Context
+import android.net.Uri
+import android.util.Base64
+import java.io.File
+import org.json.JSONArray
 import kotlinx.coroutines.flow.Flow
 
 class Repository private constructor(context: Context) {
+    private val appContext = context.applicationContext
     private val db = AppDatabase.get(context)
     private val categoryDao = db.tagCategoryDao()
     private val tagDao = db.tagDao()
@@ -21,18 +26,43 @@ class Repository private constructor(context: Context) {
     fun observeResources(): Flow<List<ResourceEntity>> = resourceDao.observeResources()
     fun observeResourcesWithRelations(): Flow<List<ResourceWithTagsCharacters>> = resourceDao.observeResourcesWithRelations()
 
-    suspend fun exportSnapshot(): BackupSnapshot =
-        BackupSnapshot(
+    suspend fun exportSnapshot(): BackupSnapshot {
+        val resources = resourceDao.listAll()
+        val mediaItems = collectMediaPaths(resources).mapNotNull { (path, type) ->
+            readMedia(path)?.let { bytes ->
+                MediaBackupItem(
+                    originalPath = path,
+                    type = type,
+                    base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
+                )
+            }
+        }
+        return BackupSnapshot(
             categories = categoryDao.listAll(),
             tags = tagDao.listAll(),
             characters = characterDao.listAll(),
-            resources = resourceDao.listAll(),
+            resources = resources,
             resourceTagRefs = crossRefDao.listResourceTags(),
             characterTagRefs = crossRefDao.listCharacterTags(),
-            resourceCharacterRefs = crossRefDao.listResourceCharacters()
+            resourceCharacterRefs = crossRefDao.listResourceCharacters(),
+            media = mediaItems
         )
+    }
 
     suspend fun replaceSnapshot(snapshot: BackupSnapshot) {
+        val mediaMapping = restoreMedia(snapshot.media)
+        val restoredResources = snapshot.resources.map { resource ->
+            when (resource.type) {
+                ResourceType.IMAGE,
+                ResourceType.VIDEO -> resource.copy(
+                    contentUriOrPath = replacePathsInPayload(resource.contentUriOrPath, mediaMapping)
+                )
+                ResourceType.FLOW -> resource.copy(
+                    sceneJson = replacePathsInSceneJson(resource.sceneJson, mediaMapping)
+                )
+                else -> resource
+            }
+        }
         crossRefDao.deleteAllResourceTags()
         crossRefDao.deleteAllCharacterTags()
         crossRefDao.deleteAllResourceCharacters()
@@ -43,7 +73,7 @@ class Repository private constructor(context: Context) {
         if (snapshot.categories.isNotEmpty()) categoryDao.insertAll(snapshot.categories)
         if (snapshot.tags.isNotEmpty()) tagDao.insertAll(snapshot.tags)
         if (snapshot.characters.isNotEmpty()) characterDao.insertAll(snapshot.characters)
-        if (snapshot.resources.isNotEmpty()) resourceDao.insertAll(snapshot.resources)
+        if (restoredResources.isNotEmpty()) resourceDao.insertAll(restoredResources)
         if (snapshot.resourceTagRefs.isNotEmpty()) crossRefDao.insertResourceTags(snapshot.resourceTagRefs)
         if (snapshot.characterTagRefs.isNotEmpty()) crossRefDao.insertCharacterTags(snapshot.characterTagRefs)
         if (snapshot.resourceCharacterRefs.isNotEmpty()) crossRefDao.insertResourceCharacters(snapshot.resourceCharacterRefs)
@@ -115,6 +145,138 @@ class Repository private constructor(context: Context) {
 
     suspend fun resourceIdsForCharacter(characterId: Long) = crossRefDao.resourceIdsForCharacter(characterId)
     suspend fun resourceIdsForTags(tagIds: List<Long>) = crossRefDao.resourceIdsForTags(tagIds)
+
+    private fun collectMediaPaths(resources: List<ResourceEntity>): List<Pair<String, ResourceType>> {
+        val unique = linkedSetOf<Pair<String, ResourceType>>()
+        resources.forEach { resource ->
+            when (resource.type) {
+                ResourceType.IMAGE,
+                ResourceType.VIDEO -> {
+                    parseMediaPaths(resource.contentUriOrPath).forEach { path ->
+                        unique.add(path to resource.type)
+                    }
+                }
+                ResourceType.FLOW -> {
+                    parseFlowMediaPaths(resource.sceneJson).forEach { (path, type) ->
+                        unique.add(path to type)
+                    }
+                }
+                else -> Unit
+            }
+        }
+        return unique.toList()
+    }
+
+    private fun parseMediaPaths(payload: String?): List<String> {
+        if (payload.isNullOrBlank()) return emptyList()
+        val trimmed = payload.trim()
+        if (trimmed.startsWith("[")) {
+            return runCatching {
+                val array = JSONArray(trimmed)
+                List(array.length()) { index -> array.getString(index) }
+            }.getOrDefault(emptyList())
+        }
+        return listOf(trimmed)
+    }
+
+    private fun parseFlowMediaPaths(payload: String?): List<Pair<String, ResourceType>> {
+        if (payload.isNullOrBlank()) return emptyList()
+        return runCatching {
+            val array = JSONArray(payload)
+            buildList {
+                for (i in 0 until array.length()) {
+                    val obj = array.optJSONObject(i) ?: continue
+                    val type = runCatching {
+                        ResourceType.valueOf(obj.getString("type"))
+                    }.getOrNull() ?: continue
+                    when (type) {
+                        ResourceType.IMAGE -> {
+                            val images = obj.optJSONArray("images") ?: JSONArray()
+                            for (j in 0 until images.length()) {
+                                add(images.getString(j) to type)
+                            }
+                        }
+                        ResourceType.VIDEO -> {
+                            val videos = obj.optJSONArray("videos") ?: JSONArray()
+                            for (j in 0 until videos.length()) {
+                                add(videos.getString(j) to type)
+                            }
+                        }
+                        else -> Unit
+                    }
+                }
+            }
+        }.getOrDefault(emptyList())
+    }
+
+    private fun readMedia(path: String): ByteArray? {
+        val uri = Uri.parse(path)
+        return runCatching {
+            if (uri.scheme == "file") {
+                val filePath = uri.path ?: return@runCatching null
+                File(filePath).takeIf { it.exists() }?.readBytes()
+            } else {
+                appContext.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            }
+        }.getOrNull()
+    }
+
+    private fun restoreMedia(items: List<MediaBackupItem>): Map<String, String> {
+        if (items.isEmpty()) return emptyMap()
+        val mapping = mutableMapOf<String, String>()
+        items.forEach { item ->
+            val bytes = runCatching { Base64.decode(item.base64, Base64.DEFAULT) }.getOrNull() ?: return@forEach
+            val folder = when (item.type) {
+                ResourceType.IMAGE -> "images"
+                ResourceType.VIDEO -> "videos"
+                else -> "media"
+            }
+            val dir = File(appContext.filesDir, folder).apply { mkdirs() }
+            val target = File(dir, "media_import_${System.currentTimeMillis()}_${item.originalPath.hashCode()}.dat")
+            runCatching {
+                target.writeBytes(bytes)
+                mapping[item.originalPath] = Uri.fromFile(target).toString()
+            }
+        }
+        return mapping
+    }
+
+    private fun replacePathsInPayload(payload: String?, mapping: Map<String, String>): String? {
+        if (payload.isNullOrBlank() || mapping.isEmpty()) return payload
+        val trimmed = payload.trim()
+        if (trimmed.startsWith("[")) {
+            return runCatching {
+                val array = JSONArray(trimmed)
+                val updated = JSONArray()
+                for (i in 0 until array.length()) {
+                    val raw = array.getString(i)
+                    updated.put(mapping[raw] ?: raw)
+                }
+                updated.toString()
+            }.getOrDefault(payload)
+        }
+        return mapping[trimmed] ?: payload
+    }
+
+    private fun replacePathsInSceneJson(payload: String?, mapping: Map<String, String>): String? {
+        if (payload.isNullOrBlank() || mapping.isEmpty()) return payload
+        return runCatching {
+            val array = JSONArray(payload)
+            for (i in 0 until array.length()) {
+                val obj = array.optJSONObject(i) ?: continue
+                listOf("images", "videos").forEach { key ->
+                    val items = obj.optJSONArray(key) ?: return@forEach
+                    val updated = JSONArray()
+                    for (j in 0 until items.length()) {
+                        val raw = items.getString(j)
+                        updated.put(mapping[raw] ?: raw)
+                    }
+                    obj.put(key, updated)
+                }
+            }
+            array.toString()
+        }.getOrDefault(payload)
+    }
 
     companion object {
         const val ORPHAN_CATEGORY_NAME = "未分类"

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.CharacterBadge
 import com.example.quotepicker.ui.components.TagBadge
+import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.vm.RandomViewModel
@@ -120,8 +121,15 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
             }
         }
         if (showIntro && ui.selectedCharacter != null) {
-            val focus = ui.selectedCharacter!!.name.take(2)
-            Text("${focus}为要点")
+            val introCandidates = ui.characterResources.filter { res ->
+                res.resource.type == ResourceType.TEXT &&
+                    res.resource.title.take(2) == "要点"
+            }
+            if (introCandidates.size == 1) {
+                Text(introCandidates.first().resource.quoteText.orEmpty())
+            } else {
+                Text("资源错误")
+            }
         }
     }
 

--- a/app/src/main/java/com/example/quotepicker/vm/RandomViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/RandomViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.launch
 data class RandomUiState(
     val characters: List<CharacterEntity> = emptyList(),
     val resources: List<ResourceWithTagsCharacters> = emptyList(),
+    val characterResources: List<ResourceWithTagsCharacters> = emptyList(),
     val categories: List<TagCategoryEntity> = emptyList(),
     val tags: List<TagEntity> = emptyList(),
     val selectedTagIds: Set<Long> = emptySet(),
@@ -79,6 +80,7 @@ class RandomViewModel(app: Application) : AndroidViewModel(app) {
         RandomUiState(
             characters = inputs.characters,
             resources = filteredResources,
+            characterResources = matchingResources,
             categories = resourceCategories,
             tags = resourceTags,
             selectedTagIds = tagIds,


### PR DESCRIPTION
### Motivation
- Make the "显示介绍" behavior show the actual character intro text stored as a resource titled with the marker "要点" instead of deriving it from the character name. 
- Ensure backup/export and import/restore include uploaded media files (images and videos) so that resources referencing stored files remain valid after restore.

### Description
- Add `characterResources` to `RandomUiState` and populate it in `RandomViewModel` so the UI can inspect resources that belong to the selected character.  
- Change `RandomScreen` to look up text resources whose title starts with `"要点"` among the current character's resources and display its `quoteText` when exactly one match exists, otherwise show `"资源错误"`.  
- Extend `BackupSnapshot` to version `2` by adding `MediaBackupItem` and JSON serialization/deserialization for media entries.  
- Update `Repository` export/import to collect media bytes for image/video resources (and media referenced inside `FLOW` items), encode them as Base64 into the backup, restore media files into the app files directory on import, and remap resource payload paths (including arrays and scene JSON) to the restored file URIs.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ece7915e8832b9c749075e6309420)