### PR TITLE
Show image thumbnails in editor and add swipeable tabs to character detail

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -12,6 +12,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
@@ -30,6 +34,8 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material3.MaterialTheme
@@ -43,6 +49,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -62,6 +69,7 @@ import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.SquareGridItem
 import com.example.quotepicker.vm.CharacterViewModel
 import com.example.quotepicker.vm.ResourceViewModel
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -84,6 +92,8 @@ fun CharacterScreen(
     var selectedTagIds by remember { mutableStateOf(setOf<Long>()) }
     var selectedType by remember { mutableStateOf<ResourceType?>(null) }
     var previewTarget by remember { mutableStateOf<com.example.quotepicker.data.ResourceWithTagsCharacters?>(null) }
+    val pagerState = rememberPagerState(pageCount = { 2 })
+    val pagerScope = rememberCoroutineScope()
     val importPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri != null) {
             vm.importSnapshot(uri)
@@ -167,18 +177,6 @@ fun CharacterScreen(
                 }
             } else {
                 val char = selected!!.character
-                TagSummarySection(
-                    categories = ui.categories,
-                    tags = selected!!.tags,
-                    onEdit = { showTagPicker = true }
-                )
-                Spacer(Modifier.height(12.dp))
-                CharacterResourceFilterBar(
-                    selectedType = selectedType,
-                    selectedTagIds = selectedTagIds,
-                    onTypeChange = { selectedType = it },
-                    onTagDialog = { filterTagDialog = true }
-                )
                 val filteredResources = resources.filter {
                     it.characters.any { c -> c.id == char.id }
                 }.filter { res ->
@@ -186,25 +184,66 @@ fun CharacterScreen(
                     val tagMatch = if (selectedTagIds.isEmpty()) true else res.tags.any { selectedTagIds.contains(it.id) }
                     typeMatch && tagMatch
                 }
-                if (filteredResources.isEmpty()) {
-                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                        Text("暂无资源")
+                TabRow(selectedTabIndex = pagerState.currentPage) {
+                    listOf("标签", "资源").forEachIndexed { index, title ->
+                        Tab(
+                            selected = pagerState.currentPage == index,
+                            onClick = { pagerScope.launch { pagerState.animateScrollToPage(index) } },
+                            text = { Text(title) }
+                        )
                     }
-                } else {
-                    LazyVerticalGrid(
-                        columns = GridCells.Fixed(3),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
-                        horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
-                    ) {
-                        items(filteredResources, key = { it.resource.id }) { resource ->
-                            ResourceGridCard(
-                                title = resource.resource.title,
-                                typeLabel = typeLabel(resource.resource.type),
-                                tags = resource.tags,
-                                onClick = { previewTarget = resource },
-                                onLongClick = {}
-                            )
+                }
+                HorizontalPager(
+                    state = pagerState,
+                    modifier = Modifier.fillMaxSize()
+                ) { page ->
+                    when (page) {
+                        0 -> {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .verticalScroll(rememberScrollState())
+                            ) {
+                                TagSummarySection(
+                                    categories = ui.categories,
+                                    tags = selected!!.tags,
+                                    onEdit = { showTagPicker = true }
+                                )
+                            }
+                        }
+                        1 -> {
+                            Column(Modifier.fillMaxSize()) {
+                                Spacer(Modifier.height(12.dp))
+                                CharacterResourceFilterBar(
+                                    selectedType = selectedType,
+                                    selectedTagIds = selectedTagIds,
+                                    onTypeChange = { selectedType = it },
+                                    onTagDialog = { filterTagDialog = true }
+                                )
+                                if (filteredResources.isEmpty()) {
+                                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                                        Text("暂无资源")
+                                    }
+                                } else {
+                                    LazyVerticalGrid(
+                                        columns = GridCells.Fixed(3),
+                                        contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                                        modifier = Modifier.weight(1f)
+                                    ) {
+                                        items(filteredResources, key = { it.resource.id }) { resource ->
+                                            ResourceGridCard(
+                                                title = resource.resource.title,
+                                                typeLabel = typeLabel(resource.resource.type),
+                                                tags = resource.tags,
+                                                onClick = { previewTarget = resource },
+                                                onLongClick = {}
+                                            )
+                                        }
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -1172,13 +1172,44 @@ private fun ResourceEditScreen(
                         Text("暂无图片", style = MaterialTheme.typography.labelSmall)
                     } else {
                         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                            imageItems.forEachIndexed { index, _ ->
+                            imageItems.forEachIndexed { index, item ->
+                                val thumbnail by produceState<android.graphics.Bitmap?>(initialValue = null, item) {
+                                    value = withContext(Dispatchers.IO) {
+                                        when {
+                                            item.base64 != null -> vm.decodeBase64ToBitmap(item.base64)
+                                            item.uri != null -> vm.decodeUriToBitmap(item.uri)
+                                            item.path != null -> vm.decodeUriToBitmap(Uri.parse(item.path))
+                                            else -> null
+                                        }
+                                    }
+                                }
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
-                                    Text(text = "图片 ${index + 1}")
+                                    if (thumbnail != null) {
+                                        Image(
+                                            bitmap = thumbnail!!.asImageBitmap(),
+                                            contentDescription = "图片预览",
+                                            modifier = Modifier
+                                                .size(48.dp)
+                                                .clip(MaterialTheme.shapes.small)
+                                        )
+                                    } else {
+                                        Box(
+                                            modifier = Modifier
+                                                .size(48.dp)
+                                                .clip(MaterialTheme.shapes.small),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(Icons.Default.Image, contentDescription = null)
+                                        }
+                                    }
+                                    Spacer(Modifier.width(12.dp))
+                                    Text(
+                                        text = "图片 ${index + 1}",
+                                        modifier = Modifier.weight(1f)
+                                    )
                                     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                                         IconButton(onClick = {
                                             if (index > 0) {


### PR DESCRIPTION
### Motivation
- 在编辑图片顺序时提供小预览图以便更直观地调整图片顺序（类似资源管理的预览）。
- 在角色详情页将“标签/资源”分开，通过左右滑动和标签栏在两页之间切换以改善导航体验。

### Description
- 在 `ResourceScreen.kt` 的资源编辑界面中为每个 `imageItems` 条目添加了缩略图预览，使用 `produceState` + `withContext(Dispatchers.IO)` 调用 `vm.decodeBase64ToBitmap` / `vm.decodeUriToBitmap` 来生成 `Bitmap`，并在行首显示 `Image`（48dp）或占位图标，同时保留上下移动与删除按钮。 
- 在 `CharacterScreen.kt` 中引入了 `TabRow` 与 `HorizontalPager`，增加了 `rememberPagerState` 与 `rememberCoroutineScope`，将标签摘要放到第一页并将资源筛选与资源网格放到第二页以支持左右滑动切换，标签页支持垂直滚动以容纳较多内容。 
- 修改涉及文件：`app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt` 与 `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt`。

### Testing
- 未执行任何自动化测试（没有运行单元测试或仪器化测试）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eea4e59c8832b956b78c83b2a1590)