### PR TITLE
Make character dialogs scrollable and opt in to pager API

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -10,8 +10,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
@@ -71,7 +73,7 @@ import com.example.quotepicker.vm.CharacterViewModel
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun CharacterScreen(
     modifier: Modifier = Modifier,
@@ -345,7 +347,13 @@ private fun CharacterEditDialog(
         onDismissRequest = onDismiss,
         title = { Text("编辑角色") },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 240.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
@@ -520,7 +528,13 @@ private fun TagSelectionSection(
     val grouped = tags.groupBy { it.categoryId }
     val knownCategoryIds = categories.map { it.id }.toSet()
     val uncategorized = tags.filter { it.categoryId !in knownCategoryIds }
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .heightIn(max = 360.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
         Text(label)
         categories.forEach { category ->
             val items = grouped[category.id].orEmpty()


### PR DESCRIPTION
### Motivation
- Dialog contents in the character details and tag picker could be clipped when there are many items because they lacked scrolling and height limits.
- The pager usage required opting into the experimental foundation pager API to avoid API mismatch warnings.

### Description
- Opted in to `ExperimentalFoundationApi` alongside `ExperimentalMaterial3Api` in `CharacterScreen.kt` and added the corresponding import. 
- Added `heightIn` limits and `verticalScroll(rememberScrollState())` to the `CharacterEditDialog` content so the edit dialog scrolls when its content is tall and is constrained to a reasonable max height. 
- Added `heightIn` limits and `verticalScroll(rememberScrollState())` to the `TagSelectionSection` so long tag lists are scrollable and do not overflow the dialog. 
- Changes are all in `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt` and preserve existing behaviors while preventing clipped dialog content.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ef6d73044832b899806fe82118ca2)