### PR TITLE
Format tag labels and randomize bracketed text display

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.CharacterBadge
 import com.example.quotepicker.ui.components.TagBadge
+import com.example.quotepicker.ui.components.rememberFormattedText
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
@@ -126,7 +127,8 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
                     res.resource.title.take(2) == "要点"
             }
             if (introCandidates.size == 1) {
-                Text(introCandidates.first().resource.quoteText.orEmpty())
+                val introText = rememberFormattedText(introCandidates.first().resource.quoteText.orEmpty())
+                Text(introText)
             } else {
                 Text("资源错误")
             }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -78,6 +78,7 @@ import com.example.quotepicker.ui.components.CharacterBadge
 import com.example.quotepicker.ui.components.ResourceGridCard
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.TagBadge
+import com.example.quotepicker.ui.components.rememberFormattedText
 import com.example.quotepicker.ui.components.tagTextColor
 import com.example.quotepicker.vm.FlowUpdateItem
 import com.example.quotepicker.vm.ImageUpdateItem
@@ -813,7 +814,7 @@ private fun ResourceCreateScreen(
                                                 color = MaterialTheme.colorScheme.primary
                                             )
                                             val summary = when (item.type) {
-                                                ResourceType.TEXT -> item.text.orEmpty()
+                                                ResourceType.TEXT -> rememberFormattedText(item.text.orEmpty())
                                                 ResourceType.SCENE -> "对话 ${item.sceneMessages.size} 条"
                                                 ResourceType.IMAGE -> "图片 ${item.images.size} 张"
                                                 ResourceType.VIDEO -> "视频 ${item.videos.size} 个"
@@ -1372,7 +1373,7 @@ private fun ResourceEditScreen(
                                                 color = MaterialTheme.colorScheme.primary
                                             )
                                             val summary = when (item.type) {
-                                                ResourceType.TEXT -> item.text.orEmpty()
+                                                ResourceType.TEXT -> rememberFormattedText(item.text.orEmpty())
                                                 ResourceType.SCENE -> "对话 ${item.sceneMessages.size} 条"
                                                 ResourceType.IMAGE -> "图片 ${item.images.size} 张"
                                                 ResourceType.VIDEO -> "视频 ${item.videos.size} 个"
@@ -1930,10 +1931,11 @@ private fun flowItemFromResource(resource: ResourceWithTagsCharacters): FlowUpda
     }
 }
 
+@Composable
 private fun resourceSummary(resource: ResourceWithTagsCharacters): String {
     val data = resource.resource
     return when (data.type) {
-        ResourceType.TEXT -> data.quoteText.orEmpty()
+        ResourceType.TEXT -> rememberFormattedText(data.quoteText.orEmpty())
         ResourceType.SCENE -> {
             val messages = parseSceneMessages(data.sceneJson)
             if (messages.isEmpty()) "" else "对话 ${messages.size} 条"

--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -52,6 +52,7 @@ import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.ui.components.NameDialog
 import com.example.quotepicker.ui.components.SquareGridItem
+import com.example.quotepicker.ui.components.formatTagLabel
 import com.example.quotepicker.vm.TagViewModel
 import androidx.compose.runtime.collectAsState
 import androidx.compose.foundation.combinedClickable
@@ -173,7 +174,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                             val bg = Color(tag.colorArgb)
                             val textColor = if (bg.luminance() < 0.5f) Color.White else Color.Black
                             SquareGridItem(
-                                title = tag.name,
+                                title = formatTagLabel(tag.name),
                                 backgroundColor = bg,
                                 contentColor = textColor,
                                 onClick = {},
@@ -272,7 +273,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     deleteTag?.let { tag ->
         ConfirmDeleteDialog(
             title = "删除标签",
-            message = "确定删除“${tag.name}”吗？",
+            message = "确定删除“${formatTagLabel(tag.name)}”吗？",
             onConfirm = { vm.deleteTag(tag) },
             onDismiss = { deleteTag = null }
         )

--- a/app/src/main/java/com/example/quotepicker/ui/components/DisplayFormatters.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/DisplayFormatters.kt
@@ -1,0 +1,38 @@
+package com.example.quotepicker.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import java.time.LocalDate
+import java.time.Period
+import java.time.format.DateTimeFormatter
+import kotlin.random.Random
+
+private val birthdayFormatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日")
+private val randomTokenRegex = Regex("【【(.*?)】】")
+
+fun formatTagLabel(name: String, today: LocalDate = LocalDate.now()): String {
+    val birthday = runCatching { LocalDate.parse(name, birthdayFormatter) }.getOrNull() ?: return name
+    val age = if (birthday.isAfter(today)) 0 else Period.between(birthday, today).years
+    return "$name($age)"
+}
+
+fun formatDisplayText(text: String, random: Random = Random.Default): String {
+    if (text.isBlank()) return text
+    val replaced = randomTokenRegex.replace(text) { match ->
+        val options = match.groupValues[1]
+            .split(",")
+            .map { it.trim() }
+            .filter { it.isNotEmpty() }
+        if (options.isEmpty()) {
+            match.value
+        } else {
+            "【${options.random(random)}】"
+        }
+    }
+    return replaced.replace("++", "")
+}
+
+@Composable
+fun rememberFormattedText(text: String): String {
+    return remember(text) { formatDisplayText(text) }
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -192,8 +192,10 @@ fun ResourcePreviewScreen(
                 ) {
                     when (resource.resource.type) {
                         ResourceType.TEXT -> {
-                            if (!resource.resource.quoteText.isNullOrBlank()) {
-                                Text(resource.resource.quoteText.orEmpty())
+                            val quoteText = resource.resource.quoteText.orEmpty()
+                            if (quoteText.isNotBlank()) {
+                                val displayText = rememberFormattedText(quoteText)
+                                Text(displayText)
                             }
                             QuoteImagePager(images = quoteImages)
                         }
@@ -246,7 +248,10 @@ fun ResourcePreviewScreen(
                                                 val title = item.title?.ifBlank { null } ?: typeLabel(item.type)
                                                 Text(title, style = MaterialTheme.typography.titleMedium)
                                                 when (item.type) {
-                                                    ResourceType.TEXT -> Text(item.text)
+                                                    ResourceType.TEXT -> {
+                                                        val displayText = rememberFormattedText(item.text)
+                                                        Text(displayText)
+                                                    }
                                                     ResourceType.SCENE -> {
                                                         item.sceneMessages.forEach { message ->
                                                             SceneBubble(message = message)
@@ -392,7 +397,8 @@ private fun SceneBubble(message: SceneMessage) {
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )
             Spacer(Modifier.height(4.dp))
-            Text(text = message.content)
+            val content = rememberFormattedText(message.content)
+            Text(text = content)
         }
     }
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/TagBadge.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/TagBadge.kt
@@ -24,7 +24,7 @@ fun TagBadge(
             .background(bg, shape = MaterialTheme.shapes.small)
             .padding(horizontal = 10.dp, vertical = 6.dp)
     ) {
-        Text(text = tag.name, color = textColor, style = MaterialTheme.typography.labelSmall)
+        Text(text = formatTagLabel(tag.name), color = textColor, style = MaterialTheme.typography.labelSmall)
     }
 }
 


### PR DESCRIPTION
### Motivation

- Tags that are dates in `yyyy年MM月dd日` format should display the computed age next to the date for clearer UI context. 
- Text content may include special random-choice tokens using `【【...】】`, and the UI should resolve these to a single randomly selected option for display. 

### Description

- Added `app/src/main/java/com/example/quotepicker/ui/components/DisplayFormatters.kt` which implements `formatTagLabel`, `formatDisplayText`, and a composable `rememberFormattedText` that memoizes formatting results and supports random selection from `【【a,b,c】】` tokens and removal of `++` markers. 
- Updated tag UI to use the formatted label by calling `formatTagLabel` in `TagBadge.kt` and in the tag grid and delete confirmation in `TagScreen.kt`. 
- Updated text rendering to use the new formatter: `RandomScreen.kt` uses `rememberFormattedText` for intro text, `ResourcePreviewScreen.kt` uses `rememberFormattedText` for text/flow/scene content, and `ResourceScreen.kt` uses `rememberFormattedText` for flow summaries and resource summaries. 
- Kept formatting deterministic per-text across recompositions by exposing `rememberFormattedText` as a composable wrapper around `formatDisplayText`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f18e8071c832b97a7219ce2b5f92c)