### PR TITLE
Support motion-photo (JPEG Live) previews and add scrollable resource edit/create screens

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -150,7 +150,11 @@ class Repository private constructor(context: Context) {
         val unique = linkedSetOf<Pair<String, ResourceType>>()
         resources.forEach { resource ->
             when (resource.type) {
-                ResourceType.IMAGE,
+                ResourceType.IMAGE -> {
+                    parseImageMediaPaths(resource.contentUriOrPath).forEach { (path, type) ->
+                        unique.add(path to type)
+                    }
+                }
                 ResourceType.VIDEO -> {
                     parseMediaPaths(resource.contentUriOrPath).forEach { path ->
                         unique.add(path to resource.type)
@@ -179,6 +183,44 @@ class Repository private constructor(context: Context) {
         return listOf(trimmed)
     }
 
+    private fun parseImageMediaPaths(payload: String?): List<Pair<String, ResourceType>> {
+        if (payload.isNullOrBlank()) return emptyList()
+        val trimmed = payload.trim()
+        return if (trimmed.startsWith("[")) {
+            runCatching {
+                val array = JSONArray(trimmed)
+                buildList {
+                    for (i in 0 until array.length()) {
+                        when (val entry = array.get(i)) {
+                            is org.json.JSONObject -> {
+                                val image = entry.optString("image")
+                                val motionVideo = entry.optString("motionVideo")
+                                if (image.isNotBlank()) add(image to ResourceType.IMAGE)
+                                if (motionVideo.isNotBlank()) add(motionVideo to ResourceType.VIDEO)
+                            }
+                            else -> {
+                                val item = entry.toString()
+                                if (item.isNotBlank()) add(item to ResourceType.IMAGE)
+                            }
+                        }
+                    }
+                }
+            }.getOrDefault(emptyList())
+        } else if (trimmed.startsWith("{")) {
+            runCatching {
+                val obj = org.json.JSONObject(trimmed)
+                val image = obj.optString("image")
+                val motionVideo = obj.optString("motionVideo")
+                buildList {
+                    if (image.isNotBlank()) add(image to ResourceType.IMAGE)
+                    if (motionVideo.isNotBlank()) add(motionVideo to ResourceType.VIDEO)
+                }
+            }.getOrDefault(emptyList())
+        } else {
+            listOf(trimmed to ResourceType.IMAGE)
+        }
+    }
+
     private fun parseFlowMediaPaths(payload: String?): List<Pair<String, ResourceType>> {
         if (payload.isNullOrBlank()) return emptyList()
         return runCatching {
@@ -193,7 +235,18 @@ class Repository private constructor(context: Context) {
                         ResourceType.IMAGE -> {
                             val images = obj.optJSONArray("images") ?: JSONArray()
                             for (j in 0 until images.length()) {
-                                add(images.getString(j) to type)
+                                when (val entry = images.get(j)) {
+                                    is org.json.JSONObject -> {
+                                        val image = entry.optString("image")
+                                        val motionVideo = entry.optString("motionVideo")
+                                        if (image.isNotBlank()) add(image to ResourceType.IMAGE)
+                                        if (motionVideo.isNotBlank()) add(motionVideo to ResourceType.VIDEO)
+                                    }
+                                    else -> {
+                                        val item = entry.toString()
+                                        if (item.isNotBlank()) add(item to type)
+                                    }
+                                }
                             }
                         }
                         ResourceType.VIDEO -> {
@@ -249,10 +302,35 @@ class Repository private constructor(context: Context) {
                 val array = JSONArray(trimmed)
                 val updated = JSONArray()
                 for (i in 0 until array.length()) {
-                    val raw = array.getString(i)
-                    updated.put(mapping[raw] ?: raw)
+                    when (val entry = array.get(i)) {
+                        is org.json.JSONObject -> {
+                            val image = entry.optString("image")
+                            val motionVideo = entry.optString("motionVideo")
+                            if (image.isNotBlank()) {
+                                entry.put("image", mapping[image] ?: image)
+                            }
+                            if (motionVideo.isNotBlank()) {
+                                entry.put("motionVideo", mapping[motionVideo] ?: motionVideo)
+                            }
+                            updated.put(entry)
+                        }
+                        else -> {
+                            val raw = entry.toString()
+                            updated.put(mapping[raw] ?: raw)
+                        }
+                    }
                 }
                 updated.toString()
+            }.getOrDefault(payload)
+        }
+        if (trimmed.startsWith("{")) {
+            return runCatching {
+                val obj = org.json.JSONObject(trimmed)
+                val image = obj.optString("image")
+                val motionVideo = obj.optString("motionVideo")
+                if (image.isNotBlank()) obj.put("image", mapping[image] ?: image)
+                if (motionVideo.isNotBlank()) obj.put("motionVideo", mapping[motionVideo] ?: motionVideo)
+                obj.toString()
             }.getOrDefault(payload)
         }
         return mapping[trimmed] ?: payload
@@ -268,8 +346,23 @@ class Repository private constructor(context: Context) {
                     val items = obj.optJSONArray(key) ?: return@forEach
                     val updated = JSONArray()
                     for (j in 0 until items.length()) {
-                        val raw = items.getString(j)
-                        updated.put(mapping[raw] ?: raw)
+                        when (val entry = items.get(j)) {
+                            is org.json.JSONObject -> {
+                                val image = entry.optString("image")
+                                val motionVideo = entry.optString("motionVideo")
+                                if (image.isNotBlank()) {
+                                    entry.put("image", mapping[image] ?: image)
+                                }
+                                if (motionVideo.isNotBlank()) {
+                                    entry.put("motionVideo", mapping[motionVideo] ?: motionVideo)
+                                }
+                                updated.put(entry)
+                            }
+                            else -> {
+                                val raw = entry.toString()
+                                updated.put(mapping[raw] ?: raw)
+                            }
+                        }
                     }
                     obj.put(key, updated)
                 }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items as gridItems
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
@@ -669,6 +671,9 @@ private fun ResourceCreateScreen(
     var editSceneIndex by remember { mutableStateOf<Int?>(null) }
     var showFlowDialog by remember { mutableStateOf(false) }
     var editFlowIndex by remember { mutableStateOf<Int?>(null) }
+    val scrollState = rememberScrollState()
+    val scrollState = rememberScrollState()
+    val scrollState = rememberScrollState()
 
     val context = LocalContext.current
     val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
@@ -775,6 +780,7 @@ private fun ResourceCreateScreen(
             modifier = Modifier
                 .padding(inner)
                 .fillMaxSize()
+                .verticalScroll(scrollState)
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
@@ -1144,6 +1150,7 @@ private fun ResourceEditScreen(
             modifier = Modifier
                 .padding(inner)
                 .fillMaxSize()
+                .verticalScroll(scrollState)
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
@@ -1872,13 +1879,49 @@ private fun parseImageItems(payload: String?): List<ImageUpdateItem> {
 private fun parseImageItems(pathPayload: String?, base64Payload: String?): List<ImageUpdateItem> {
     val payload = pathPayload?.takeIf { it.isNotBlank() } ?: base64Payload
     if (payload.isNullOrBlank()) return emptyList()
-    val list = parsePathList(payload)
-    return list.map { item ->
-        val uri = Uri.parse(item)
+    val trimmed = payload.trim()
+    val parsedList = if (trimmed.startsWith("[")) {
+        runCatching {
+            val array = org.json.JSONArray(trimmed)
+            buildList {
+                for (i in 0 until array.length()) {
+                    when (val entry = array.get(i)) {
+                        is org.json.JSONObject -> {
+                            val image = entry.optString("image")
+                            val motion = entry.optString("motionVideo")
+                            if (image.isNotBlank()) {
+                                add(ImageUpdateItem(path = image, motionVideoPath = motion.ifBlank { null }))
+                            }
+                        }
+                        else -> {
+                            val item = entry.toString()
+                            if (item.isNotBlank()) add(ImageUpdateItem(path = item))
+                        }
+                    }
+                }
+            }
+        }.getOrDefault(emptyList())
+    } else if (trimmed.startsWith("{")) {
+        runCatching {
+            val obj = org.json.JSONObject(trimmed)
+            val image = obj.optString("image")
+            val motion = obj.optString("motionVideo")
+            if (image.isNotBlank()) {
+                listOf(ImageUpdateItem(path = image, motionVideoPath = motion.ifBlank { null }))
+            } else {
+                emptyList()
+            }
+        }.getOrDefault(emptyList())
+    } else {
+        listOf(ImageUpdateItem(path = payload))
+    }
+    return parsedList.map { item ->
+        val raw = item.path ?: item.base64 ?: return@map item
+        val uri = Uri.parse(raw)
         if (uri.scheme != null) {
-            ImageUpdateItem(path = item)
+            item.copy(path = raw, base64 = null)
         } else {
-            ImageUpdateItem(base64 = item)
+            item.copy(base64 = raw, path = null)
         }
     }
 }
@@ -1999,13 +2042,29 @@ private fun parseFlowItems(raw: String?): List<FlowUpdateItem> {
                         val parsed = buildList {
                             if (images != null) {
                                 for (j in 0 until images.length()) {
-                                    val item = images.optString(j)
-                                    if (item.isNotBlank()) {
-                                        val uri = Uri.parse(item)
-                                        if (uri.scheme != null) {
-                                            add(ImageUpdateItem(path = item))
-                                        } else {
-                                            add(ImageUpdateItem(base64 = item))
+                                    when (val entry = images.get(j)) {
+                                        is org.json.JSONObject -> {
+                                            val image = entry.optString("image")
+                                            val motion = entry.optString("motionVideo")
+                                            if (image.isNotBlank()) {
+                                                val uri = Uri.parse(image)
+                                                if (uri.scheme != null) {
+                                                    add(ImageUpdateItem(path = image, motionVideoPath = motion.ifBlank { null }))
+                                                } else {
+                                                    add(ImageUpdateItem(base64 = image, motionVideoPath = motion.ifBlank { null }))
+                                                }
+                                            }
+                                        }
+                                        else -> {
+                                            val item = entry.toString()
+                                            if (item.isNotBlank()) {
+                                                val uri = Uri.parse(item)
+                                                if (uri.scheme != null) {
+                                                    add(ImageUpdateItem(path = item))
+                                                } else {
+                                                    add(ImageUpdateItem(base64 = item))
+                                                }
+                                            }
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -64,12 +64,17 @@ import org.json.JSONArray
 
 private data class SceneMessage(val speaker: String, val content: String)
 
+private data class ImagePreviewItem(
+    val bitmap: android.graphics.Bitmap,
+    val motionVideoUri: Uri? = null
+)
+
 private data class FlowPreviewItem(
     val type: ResourceType,
     val title: String? = null,
     val text: String = "",
     val sceneMessages: List<SceneMessage> = emptyList(),
-    val images: List<android.graphics.Bitmap> = emptyList(),
+    val images: List<ImagePreviewItem> = emptyList(),
     val mediaUris: List<Uri> = emptyList(),
     val mediaFailed: Boolean = false
 )
@@ -81,7 +86,7 @@ fun ResourcePreviewScreen(
     vm: ResourceViewModel,
     onBack: () -> Unit
 ) {
-    var quoteImages by remember { mutableStateOf<List<android.graphics.Bitmap>>(emptyList()) }
+    var quoteImages by remember { mutableStateOf<List<ImagePreviewItem>>(emptyList()) }
     var mediaUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var mediaLoadFailed by remember { mutableStateOf(false) }
     var mediaReloadKey by remember { mutableStateOf(0) }
@@ -354,6 +359,11 @@ private fun MediaPreviewPager(uris: List<Uri>) {
     }
 }
 
+private data class ImagePayloadEntry(
+    val image: String,
+    val motionVideo: String? = null
+)
+
 private fun parseMediaPaths(raw: String): List<String> {
     val trimmed = raw.trim()
     if (trimmed.startsWith("[")) {
@@ -365,10 +375,49 @@ private fun parseMediaPaths(raw: String): List<String> {
     return listOf(raw)
 }
 
-private fun decodeImageSources(payload: String?, vm: ResourceViewModel): List<android.graphics.Bitmap> {
+private fun parseImagePayloadEntries(payload: String): List<ImagePayloadEntry> {
+    val trimmed = payload.trim()
+    return if (trimmed.startsWith("[")) {
+        runCatching {
+            val array = JSONArray(trimmed)
+            buildList {
+                for (i in 0 until array.length()) {
+                    when (val entry = array.get(i)) {
+                        is org.json.JSONObject -> {
+                            val image = entry.optString("image")
+                            val motion = entry.optString("motionVideo")
+                            if (image.isNotBlank()) {
+                                add(ImagePayloadEntry(image, motion.ifBlank { null }))
+                            }
+                        }
+                        else -> {
+                            val item = entry.toString()
+                            if (item.isNotBlank()) add(ImagePayloadEntry(item))
+                        }
+                    }
+                }
+            }
+        }.getOrDefault(emptyList())
+    } else if (trimmed.startsWith("{")) {
+        runCatching {
+            val obj = org.json.JSONObject(trimmed)
+            val image = obj.optString("image")
+            val motion = obj.optString("motionVideo")
+            if (image.isNotBlank()) listOf(ImagePayloadEntry(image, motion.ifBlank { null })) else emptyList()
+        }.getOrDefault(emptyList())
+    } else {
+        listOf(ImagePayloadEntry(trimmed))
+    }
+}
+
+private fun decodeImageSources(payload: String?, vm: ResourceViewModel): List<ImagePreviewItem> {
     if (payload.isNullOrBlank()) return emptyList()
-    val items = parseMediaPaths(payload)
-    return items.mapNotNull { decodeImageSource(it, vm) }
+    val items = parseImagePayloadEntries(payload)
+    return items.mapNotNull { entry ->
+        decodeImageSource(entry.image, vm)?.let { bitmap ->
+            ImagePreviewItem(bitmap = bitmap, motionVideoUri = entry.motionVideo?.let(Uri::parse))
+        }
+    }
 }
 
 private fun decodeImageSource(item: String, vm: ResourceViewModel): android.graphics.Bitmap? {
@@ -450,9 +499,22 @@ private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<Flo
                         val images = obj.optJSONArray("images") ?: JSONArray()
                         val bitmaps = buildList {
                             for (j in 0 until images.length()) {
-                                val item = images.optString(j)
-                                if (item.isNotBlank()) {
-                                    decodeImageSource(item, vm)?.let { add(it) }
+                                when (val entry = images.get(j)) {
+                                    is org.json.JSONObject -> {
+                                        val image = entry.optString("image")
+                                        val motion = entry.optString("motionVideo")
+                                        if (image.isNotBlank()) {
+                                            decodeImageSource(image, vm)?.let {
+                                                add(ImagePreviewItem(it, motion.ifBlank { null }?.let(Uri::parse)))
+                                            }
+                                        }
+                                    }
+                                    else -> {
+                                        val item = entry.toString()
+                                        if (item.isNotBlank()) {
+                                            decodeImageSource(item, vm)?.let { add(ImagePreviewItem(it)) }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -514,38 +576,62 @@ private fun ResourceMetaRow(
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun QuoteImagePager(images: List<android.graphics.Bitmap>) {
+private fun QuoteImagePager(images: List<ImagePreviewItem>) {
     if (images.isEmpty()) return
     var fullScreenImage by remember { mutableStateOf<android.graphics.Bitmap?>(null) }
+    var fullScreenVideo by remember { mutableStateOf<Uri?>(null) }
     if (fullScreenImage != null) {
         FullScreenImageDialog(bitmap = fullScreenImage!!, onDismiss = { fullScreenImage = null })
     }
+    if (fullScreenVideo != null) {
+        FullScreenVideoDialog(uri = fullScreenVideo!!, onDismiss = { fullScreenVideo = null })
+    }
     if (images.size == 1) {
-        Image(
-            bitmap = images.first().asImageBitmap(),
-            contentDescription = null,
-            modifier = Modifier
-                .fillMaxWidth()
-                .clickable { fullScreenImage = images.first() }
-        )
+        val item = images.first()
+        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Image(
+                bitmap = item.bitmap.asImageBitmap(),
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { fullScreenImage = item.bitmap }
+            )
+            if (item.motionVideoUri != null) {
+                TextButton(onClick = { fullScreenVideo = item.motionVideoUri }) {
+                    Text("播放 Live")
+                }
+            }
+        }
         return
     }
     val pagerState = rememberPagerState(pageCount = { images.size })
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         HorizontalPager(state = pagerState, modifier = Modifier.fillMaxWidth()) { page ->
+            val item = images[page]
             Image(
-                bitmap = images[page].asImageBitmap(),
+                bitmap = item.bitmap.asImageBitmap(),
                 contentDescription = null,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .clickable { fullScreenImage = images[page] }
+                    .clickable { fullScreenImage = item.bitmap }
             )
         }
-        Text(
-            text = "${pagerState.currentPage + 1}/${images.size}",
-            style = MaterialTheme.typography.labelSmall,
-            modifier = Modifier.align(Alignment.CenterHorizontally)
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "${pagerState.currentPage + 1}/${images.size}",
+                style = MaterialTheme.typography.labelSmall
+            )
+            val motionUri = images[pagerState.currentPage].motionVideoUri
+            if (motionUri != null) {
+                TextButton(onClick = { fullScreenVideo = motionUri }) {
+                    Text("播放 Live")
+                }
+            }
+        }
     }
 }
 
@@ -658,7 +744,7 @@ private fun FullScreenVideoDialog(uri: Uri, onDismiss: () -> Unit) {
     }
 }
 
-private fun decodeQuoteImages(payload: String?, vm: ResourceViewModel): List<android.graphics.Bitmap> {
+private fun decodeQuoteImages(payload: String?, vm: ResourceViewModel): List<ImagePreviewItem> {
     if (payload.isNullOrBlank()) return emptyList()
     val base64List = runCatching {
         val array = JSONArray(payload)
@@ -670,4 +756,5 @@ private fun decodeQuoteImages(payload: String?, vm: ResourceViewModel): List<and
         }
     }.getOrElse { listOf(payload) }
     return base64List.mapNotNull { vm.decodeBase64ToBitmap(it) }
+        .map { ImagePreviewItem(it) }
 }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
 import android.util.Base64
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
@@ -45,12 +47,19 @@ data class ResourceUiState(
 data class ImageUpdateItem(
     val path: String? = null,
     val base64: String? = null,
-    val uri: Uri? = null
+    val uri: Uri? = null,
+    val motionVideoPath: String? = null,
+    val motionVideoUri: Uri? = null
 )
 
 data class VideoUpdateItem(
     val path: String? = null,
     val uri: Uri? = null
+)
+
+data class StoredImageResult(
+    val imagePath: String,
+    val motionVideoPath: String? = null
 )
 
 data class StoredMediaItem(
@@ -138,6 +147,15 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch(Dispatchers.IO) {
             if (characterIds.isEmpty()) return@launch
             val storedPaths = imageUris.mapNotNull { uri -> storeImageToInternal(uri) }
+                .map { stored ->
+                    if (stored.motionVideoPath != null) {
+                        org.json.JSONObject()
+                            .put("image", stored.imagePath)
+                            .put("motionVideo", stored.motionVideoPath)
+                    } else {
+                        stored.imagePath
+                    }
+                }
             if (storedPaths.isEmpty()) return@launch
             val payload = org.json.JSONArray(storedPaths).toString()
             repo.addResource(
@@ -292,11 +310,22 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         }.filter { it.isNotBlank() }
     }
 
-    private suspend fun resolveImageItems(items: List<ImageUpdateItem>): List<String> {
+    private suspend fun resolveImageItems(items: List<ImageUpdateItem>): List<Any> {
         return items.mapNotNull { item ->
-            item.path?.ifBlank { null }
+            val stored = item.path?.ifBlank { null }?.let { StoredImageResult(it, item.motionVideoPath) }
                 ?: item.uri?.let { uri -> storeImageToInternal(uri) }
-                ?: item.base64?.let { base64 -> storeBase64ImageToInternal(base64) }
+                ?: item.base64?.let { base64 -> storeBase64ImageToInternal(base64) }?.let { StoredImageResult(it) }
+            val imagePath = stored?.imagePath ?: return@mapNotNull null
+            val motionVideoPath = stored.motionVideoPath
+                ?: item.motionVideoPath?.ifBlank { null }
+                ?: item.motionVideoUri?.let { uri -> storeVideoToInternal(uri, deleteSource = false) }
+            if (motionVideoPath != null) {
+                org.json.JSONObject()
+                    .put("image", imagePath)
+                    .put("motionVideo", motionVideoPath)
+            } else {
+                imagePath
+            }
         }
     }
 
@@ -393,13 +422,14 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         return storeBitmapToInternal(bitmap)
     }
 
-    private fun storeImageToInternal(uri: Uri): String? {
+    private fun storeImageToInternal(uri: Uri): StoredImageResult? {
         val bitmap = ImageCompression.decodeToBitmap(getApplication(), uri) ?: return null
-        val stored = storeBitmapToInternal(bitmap)
-        if (stored != null) {
-            deleteSourceUri(uri)
+        val stored = storeBitmapToInternal(bitmap) ?: return null
+        val motionVideoPath = queryMotionVideoUri(uri)?.let { motionUri ->
+            storeVideoToInternal(motionUri, deleteSource = false)
         }
-        return stored
+        deleteSourceUri(uri)
+        return StoredImageResult(imagePath = stored, motionVideoPath = motionVideoPath)
     }
 
     private fun storeBitmapToInternal(bitmap: Bitmap): String? {
@@ -424,7 +454,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
-    private fun storeVideoToInternal(uri: Uri): String? {
+    private fun storeVideoToInternal(uri: Uri, deleteSource: Boolean = true): String? {
         return runCatching {
             val dir = File(getApplication<Application>().filesDir, "videos").apply { mkdirs() }
             val target = File(dir, "media_${System.currentTimeMillis()}_${UUID.randomUUID()}.dat")
@@ -433,8 +463,27 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                     input.copyTo(output)
                 }
             } ?: return null
-            deleteSourceUri(uri)
+            if (deleteSource) {
+                deleteSourceUri(uri)
+            }
             Uri.fromFile(target).toString()
         }.getOrNull()
+    }
+
+    private fun queryMotionVideoUri(uri: Uri): Uri? {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
+        val resolver = getApplication<Application>().contentResolver
+        val projection = arrayOf(
+            MediaStore.Images.Media.IS_MOTION_PHOTO,
+            MediaStore.Images.Media.MOTION_PHOTO_ASSOCIATED_VIDEO
+        )
+        return resolver.query(uri, projection, null, null, null)?.use { cursor ->
+            if (!cursor.moveToFirst()) return@use null
+            val isMotionIndex = cursor.getColumnIndex(MediaStore.Images.Media.IS_MOTION_PHOTO)
+            val videoIndex = cursor.getColumnIndex(MediaStore.Images.Media.MOTION_PHOTO_ASSOCIATED_VIDEO)
+            val isMotion = isMotionIndex >= 0 && cursor.getInt(isMotionIndex) == 1
+            val videoUri = if (videoIndex >= 0) cursor.getString(videoIndex) else null
+            if (isMotion && !videoUri.isNullOrBlank()) Uri.parse(videoUri) else null
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Allow uploaded JPEG Live / motion-photo images to be previewed with an associated playable Live video and preserve that metadata when importing and storing media.  
- Make the resource edit/create screens vertically scrollable so long forms can be scrolled on smaller screens.

### Description
- Detect and persist motion-photo companion videos when importing images by querying `MediaStore` and storing an associated video alongside the decoded image; `ResourceViewModel` adds `motionVideoPath`/`motionVideoUri` fields and a `StoredImageResult` return type, and `storeVideoToInternal` gains an optional `deleteSource` flag.  
- Support image payload entries that include optional `motionVideo` metadata across resource add/update and flow payloads by encoding/decoding JSON entries of the form `{ "image": <path|base64>, "motionVideo": <path> }` in `ResourceViewModel`, `ResourceScreen`, and `ResourcePreviewScreen`.  
- Preview UI improvements: `ResourcePreviewScreen` introduces `ImagePreviewItem` (bitmap + optional motion video `Uri`), decodes payload entries, and `QuoteImagePager` shows a "播放 Live"/"Play Live" button that opens the companion video in `FullScreenVideoDialog`.  
- Backup/restore and repository path handling updated to include motion-video entries by extending `Repository` parsing/replacing logic (`parseImageMediaPaths`, `replacePathsInPayload`, `replacePathsInSceneJson`) so motion-video paths are collected and remapped during import/restore.  
- Make resource edit/create screens vertically scrollable by adding `rememberScrollState()` and `.verticalScroll(...)` to the column containers in `ResourceScreen` so long content can be scrolled.

### Testing
- No automated tests were executed for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697021911f2c832b84917f7c59898034)