### PR TITLE
Fix resource screen state and motion photo columns

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -672,8 +672,6 @@ private fun ResourceCreateScreen(
     var showFlowDialog by remember { mutableStateOf(false) }
     var editFlowIndex by remember { mutableStateOf<Int?>(null) }
     val scrollState = rememberScrollState()
-    val scrollState = rememberScrollState()
-    val scrollState = rememberScrollState()
 
     val context = LocalContext.current
     val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -474,16 +474,21 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return null
         val resolver = getApplication<Application>().contentResolver
         val projection = arrayOf(
-            MediaStore.Images.Media.IS_MOTION_PHOTO,
-            MediaStore.Images.Media.MOTION_PHOTO_ASSOCIATED_VIDEO
+            COLUMN_IS_MOTION_PHOTO,
+            COLUMN_MOTION_PHOTO_ASSOCIATED_VIDEO
         )
         return resolver.query(uri, projection, null, null, null)?.use { cursor ->
             if (!cursor.moveToFirst()) return@use null
-            val isMotionIndex = cursor.getColumnIndex(MediaStore.Images.Media.IS_MOTION_PHOTO)
-            val videoIndex = cursor.getColumnIndex(MediaStore.Images.Media.MOTION_PHOTO_ASSOCIATED_VIDEO)
+            val isMotionIndex = cursor.getColumnIndex(COLUMN_IS_MOTION_PHOTO)
+            val videoIndex = cursor.getColumnIndex(COLUMN_MOTION_PHOTO_ASSOCIATED_VIDEO)
             val isMotion = isMotionIndex >= 0 && cursor.getInt(isMotionIndex) == 1
             val videoUri = if (videoIndex >= 0) cursor.getString(videoIndex) else null
             if (isMotion && !videoUri.isNullOrBlank()) Uri.parse(videoUri) else null
         }
+    }
+
+    private companion object {
+        const val COLUMN_IS_MOTION_PHOTO = "is_motion_photo"
+        const val COLUMN_MOTION_PHOTO_ASSOCIATED_VIDEO = "motion_photo_associated_video"
     }
 }


### PR DESCRIPTION
### Motivation

- Remove duplicated state declarations that caused redeclaration/conflict in the resource creation screen.
- Use explicit string column names for motion-photo fields to avoid unresolved/SDK-dependent `MediaStore` constants.

### Description

- Removed duplicate `val scrollState = rememberScrollState()` declarations in `ResourceCreateScreen` in `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`.
- Replaced `MediaStore.Images.Media.IS_MOTION_PHOTO` and `MediaStore.Images.Media.MOTION_PHOTO_ASSOCIATED_VIDEO` with `COLUMN_IS_MOTION_PHOTO` and `COLUMN_MOTION_PHOTO_ASSOCIATED_VIDEO` in `app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt`.
- Added a `private companion object` in `ResourceViewModel` defining `COLUMN_IS_MOTION_PHOTO = "is_motion_photo"` and `COLUMN_MOTION_PHOTO_ASSOCIATED_VIDEO = "motion_photo_associated_video"`.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69702669729c832bb0b870c373ef9976)