### PR TITLE
Fix missing scroll state in resource editor

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -1049,6 +1049,7 @@ private fun ResourceEditScreen(
     var editSceneIndex by remember { mutableStateOf<Int?>(null) }
     var showFlowDialog by remember { mutableStateOf(false) }
     var editFlowIndex by remember { mutableStateOf<Int?>(null) }
+    val scrollState = rememberScrollState()
 
     val context = LocalContext.current
     val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->


### PR DESCRIPTION
### Motivation
- The resource edit screen used `.verticalScroll(scrollState)` but lacked a local `scrollState` declaration, causing composition/compile issues when editing image/video resources in `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`.

### Description
- Add `val scrollState = rememberScrollState()` inside the `ResourceEditScreen` composable so the existing `.verticalScroll(scrollState)` calls have a valid scroll state.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697027a2e6c0832b8f0dd6f0d4367f25)