### PR TITLE
Add bottom padding to resource forms and loop video previews

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -779,7 +779,8 @@ private fun ResourceCreateScreen(
                 .padding(inner)
                 .fillMaxSize()
                 .verticalScroll(scrollState)
-                .padding(16.dp),
+                .padding(16.dp)
+                .padding(bottom = 96.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             OutlinedTextField(
@@ -1150,7 +1151,8 @@ private fun ResourceEditScreen(
                 .padding(inner)
                 .fillMaxSize()
                 .verticalScroll(scrollState)
-                .padding(16.dp),
+                .padding(16.dp)
+                .padding(bottom = 96.dp),
             verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Text(text = typeLabel(resource.resource.type), style = MaterialTheme.typography.labelMedium)

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -307,6 +307,9 @@ private fun MediaPreview(uri: Uri) {
                     Log.d("MediaPreview", "Video prepared uri=$uri duration=${mediaPlayer.duration}")
                     mediaPlayer.start()
                 }
+                setOnCompletionListener {
+                    it.start()
+                }
                 setOnErrorListener { _, what, extra ->
                     Log.e("MediaPreview", "Video error uri=$uri what=$what extra=$extra")
                     false
@@ -698,6 +701,9 @@ private fun FullScreenVideoDialog(uri: Uri, onDismiss: () -> Unit) {
                                     0f
                                 }
                             mediaPlayer.start()
+                        }
+                        setOnCompletionListener {
+                            it.start()
                         }
                         viewHolder.value = this
                     }


### PR DESCRIPTION
### Motivation
- Prevent form content from being obscured by bottom navigation/actions in resource create/edit screens by adding extra bottom spacing to the scrollable column.
- Make video previews more usable by automatically replaying videos when playback ends in both inline and full-screen preview modes.

### Description
- Added `Modifier.padding(bottom = 96.dp)` to the scrollable form columns in `ResourceCreateScreen` and `ResourceEditScreen` in `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt` so content clears navigation controls.
- Enabled looping of video previews by adding `setOnCompletionListener { it.start() }` to the `VideoView` instances in `MediaPreview` and `FullScreenVideoDialog` in `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69703326a4c4832bacdbaa8127f7e2d5)