### PR TITLE
Show video thumbnails and switch backups to zip package with media payloads

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
+++ b/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
@@ -17,7 +17,7 @@ data class BackupSnapshot(
 
     fun toJson(): JSONObject {
         return JSONObject().apply {
-            put("version", 2)
+            put("version", 3)
             put("categories", JSONArray(categories.map(::categoryToJson)))
             put("tags", JSONArray(tags.map(::tagToJson)))
             put("characters", JSONArray(characters.map(::characterToJson)))
@@ -49,7 +49,8 @@ data class BackupSnapshot(
 data class MediaBackupItem(
     val originalPath: String,
     val type: ResourceType,
-    val base64: String
+    val base64: String? = null,
+    val fileName: String? = null
 )
 
 private fun categoryToJson(category: TagCategoryEntity): JSONObject =
@@ -105,10 +106,12 @@ private fun resourceCharacterToJson(ref: ResourceCharacterCrossRef): JSONObject 
         .put("characterId", ref.characterId)
 
 private fun mediaToJson(item: MediaBackupItem): JSONObject =
-    JSONObject()
-        .put("path", item.originalPath)
-        .put("type", item.type.name)
-        .put("base64", item.base64)
+    JSONObject().apply {
+        put("path", item.originalPath)
+        put("type", item.type.name)
+        item.base64?.let { put("base64", it) }
+        item.fileName?.let { put("fileName", it) }
+    }
 
 private fun categoryFromJson(obj: JSONObject): TagCategoryEntity =
     TagCategoryEntity(
@@ -173,7 +176,8 @@ private fun mediaFromJson(obj: JSONObject): MediaBackupItem =
     MediaBackupItem(
         originalPath = obj.getString("path"),
         type = ResourceType.valueOf(obj.getString("type")),
-        base64 = obj.getString("base64")
+        base64 = readNullableString(obj, "base64"),
+        fileName = readNullableString(obj, "fileName")
     )
 
 private fun <T> parseArray(

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -26,18 +26,27 @@ class Repository private constructor(context: Context) {
     fun observeResources(): Flow<List<ResourceEntity>> = resourceDao.observeResources()
     fun observeResourcesWithRelations(): Flow<List<ResourceWithTagsCharacters>> = resourceDao.observeResourcesWithRelations()
 
-    suspend fun exportSnapshot(): BackupSnapshot {
+    data class ExportPackage(
+        val snapshot: BackupSnapshot,
+        val mediaPayloads: Map<String, ByteArray>
+    )
+
+    suspend fun exportSnapshot(): BackupSnapshot = exportSnapshotPackage().snapshot
+
+    suspend fun exportSnapshotPackage(): ExportPackage {
         val resources = resourceDao.listAll()
+        val mediaPayloads = linkedMapOf<String, ByteArray>()
         val mediaItems = collectMediaPaths(resources).mapNotNull { (path, type) ->
-            readMedia(path)?.let { bytes ->
-                MediaBackupItem(
-                    originalPath = path,
-                    type = type,
-                    base64 = Base64.encodeToString(bytes, Base64.NO_WRAP)
-                )
-            }
+            val bytes = readMedia(path) ?: return@mapNotNull null
+            val fileName = "media_${mediaPayloads.size}_${path.hashCode()}.dat"
+            mediaPayloads[fileName] = bytes
+            MediaBackupItem(
+                originalPath = path,
+                type = type,
+                fileName = fileName
+            )
         }
-        return BackupSnapshot(
+        val snapshot = BackupSnapshot(
             categories = categoryDao.listAll(),
             tags = tagDao.listAll(),
             characters = characterDao.listAll(),
@@ -47,10 +56,11 @@ class Repository private constructor(context: Context) {
             resourceCharacterRefs = crossRefDao.listResourceCharacters(),
             media = mediaItems
         )
+        return ExportPackage(snapshot = snapshot, mediaPayloads = mediaPayloads)
     }
 
-    suspend fun replaceSnapshot(snapshot: BackupSnapshot) {
-        val mediaMapping = restoreMedia(snapshot.media)
+    suspend fun replaceSnapshot(snapshot: BackupSnapshot, mediaPayloads: Map<String, ByteArray> = emptyMap()) {
+        val mediaMapping = restoreMedia(snapshot.media, mediaPayloads)
         val restoredResources = snapshot.resources.map { resource ->
             when (resource.type) {
                 ResourceType.IMAGE,
@@ -274,11 +284,18 @@ class Repository private constructor(context: Context) {
         }.getOrNull()
     }
 
-    private fun restoreMedia(items: List<MediaBackupItem>): Map<String, String> {
+    private fun restoreMedia(
+        items: List<MediaBackupItem>,
+        mediaPayloads: Map<String, ByteArray>
+    ): Map<String, String> {
         if (items.isEmpty()) return emptyMap()
         val mapping = mutableMapOf<String, String>()
         items.forEach { item ->
-            val bytes = runCatching { Base64.decode(item.base64, Base64.DEFAULT) }.getOrNull() ?: return@forEach
+            val bytes = when {
+                item.base64 != null -> runCatching { Base64.decode(item.base64, Base64.DEFAULT) }.getOrNull()
+                item.fileName != null -> mediaPayloads[item.fileName]
+                else -> null
+            } ?: return@forEach
             val folder = when (item.type) {
                 ResourceType.IMAGE -> "images"
                 ResourceType.VIDEO -> "videos"

--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -101,7 +101,7 @@ fun CharacterScreen(
             vm.importSnapshot(uri)
         }
     }
-    val exportPicker = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
+    val exportPicker = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
         if (uri != null) {
             vm.exportSnapshot(uri)
         }
@@ -136,10 +136,10 @@ fun CharacterScreen(
                 actions = {
                     if (selected == null) {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            TextButton(onClick = { importPicker.launch(arrayOf("application/json")) }) {
+                            TextButton(onClick = { importPicker.launch(arrayOf("application/zip", "application/json", "application/octet-stream")) }) {
                                 Text("导入")
                             }
-                            TextButton(onClick = { exportPicker.launch("quote_backup.json") }) {
+                            TextButton(onClick = { exportPicker.launch("quote_backup.zip") }) {
                                 Text("导出")
                             }
                         }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -453,10 +453,12 @@ private fun StorageMediaRow(
     onLongPress: (StoredMediaItem) -> Unit
 ) {
     val thumbnail by produceState<android.graphics.Bitmap?>(initialValue = null, item.path) {
-        value = if (item.type == ResourceType.IMAGE) {
-            withContext(Dispatchers.IO) { vm.decodeUriToBitmap(Uri.parse(item.path)) }
-        } else {
-            null
+        value = withContext(Dispatchers.IO) {
+            when (item.type) {
+                ResourceType.IMAGE -> vm.decodeUriToBitmap(Uri.parse(item.path))
+                ResourceType.VIDEO -> vm.decodeVideoFrame(Uri.parse(item.path))
+                else -> null
+            }
         }
     }
     Row(
@@ -470,10 +472,10 @@ private fun StorageMediaRow(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {
-        if (item.type == ResourceType.IMAGE && thumbnail != null) {
+        if (thumbnail != null) {
             Image(
                 bitmap = thumbnail!!.asImageBitmap(),
-                contentDescription = "图片预览",
+                contentDescription = if (item.type == ResourceType.IMAGE) "图片预览" else "视频预览",
                 modifier = Modifier
                     .size(56.dp)
                     .clip(MaterialTheme.shapes.small)
@@ -1260,13 +1262,37 @@ private fun ResourceEditScreen(
                     } else {
                         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                             videoItems.forEachIndexed { index, item ->
+                                val previewUri = item.uri ?: item.path?.let { Uri.parse(it) }
+                                val thumbnail by produceState<android.graphics.Bitmap?>(initialValue = null, item) {
+                                    value = previewUri?.let { uri ->
+                                        withContext(Dispatchers.IO) { vm.decodeVideoFrame(uri) }
+                                    }
+                                }
                                 Row(
                                     modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.SpaceBetween,
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
+                                    if (thumbnail != null) {
+                                        Image(
+                                            bitmap = thumbnail!!.asImageBitmap(),
+                                            contentDescription = "视频预览",
+                                            modifier = Modifier
+                                                .size(48.dp)
+                                                .clip(MaterialTheme.shapes.small)
+                                        )
+                                    } else {
+                                        Box(
+                                            modifier = Modifier
+                                                .size(48.dp)
+                                                .clip(MaterialTheme.shapes.small),
+                                            contentAlignment = Alignment.Center
+                                        ) {
+                                            Icon(Icons.Default.Videocam, contentDescription = null)
+                                        }
+                                    }
+                                    Spacer(Modifier.width(12.dp))
                                     val label = item.path?.let { "视频 ${index + 1}" } ?: "新视频 ${index + 1}"
-                                    Text(text = label)
+                                    Text(text = label, modifier = Modifier.weight(1f))
                                     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                                         IconButton(onClick = {
                                             if (index > 0) {

--- a/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
@@ -11,7 +11,11 @@ import com.example.quotepicker.data.Repository
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
+import java.io.ByteArrayInputStream
 import java.nio.charset.Charset
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -46,19 +50,58 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch { repo.updateCharacterTags(characterId, tagIds) }
 
     fun exportSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
-        val snapshot = repo.exportSnapshot()
-        val payload = snapshot.toJsonString()
         val resolver = getApplication<Application>().contentResolver
+        val exportPackage = repo.exportSnapshotPackage()
         resolver.openOutputStream(uri)?.use { output ->
-            output.write(payload.toByteArray(Charset.forName("UTF-8")))
+            ZipOutputStream(output).use { zip ->
+                zip.putNextEntry(ZipEntry(BACKUP_JSON_NAME))
+                zip.write(exportPackage.snapshot.toJsonString().toByteArray(Charset.forName("UTF-8")))
+                zip.closeEntry()
+                exportPackage.mediaPayloads.forEach { (fileName, bytes) ->
+                    zip.putNextEntry(ZipEntry("media/$fileName"))
+                    zip.write(bytes)
+                    zip.closeEntry()
+                }
+            }
         }
     }
 
     fun importSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
         val resolver = getApplication<Application>().contentResolver
-        val payload = resolver.openInputStream(uri)?.bufferedReader(Charset.forName("UTF-8"))?.use { it.readText() }
-            ?: return@launch
-        val snapshot = BackupSnapshot.fromJson(payload)
-        repo.replaceSnapshot(snapshot)
+        val bytes = resolver.openInputStream(uri)?.use { it.readBytes() } ?: return@launch
+        var snapshot: BackupSnapshot? = null
+        val mediaPayloads = mutableMapOf<String, ByteArray>()
+        if (bytes.size >= 2 && bytes[0] == ZIP_MAGIC_P && bytes[1] == ZIP_MAGIC_K) {
+            ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+                var entry = zip.nextEntry
+                var payload: String? = null
+                while (entry != null) {
+                    when {
+                        entry.name == BACKUP_JSON_NAME -> {
+                            payload = zip.readBytes().toString(Charset.forName("UTF-8"))
+                        }
+                        entry.name.startsWith("media/") -> {
+                            val fileName = entry.name.removePrefix("media/")
+                            mediaPayloads[fileName] = zip.readBytes()
+                        }
+                    }
+                    zip.closeEntry()
+                    entry = zip.nextEntry
+                }
+                if (!payload.isNullOrBlank()) {
+                    snapshot = BackupSnapshot.fromJson(payload)
+                }
+            }
+        } else {
+            val payload = bytes.toString(Charset.forName("UTF-8"))
+            snapshot = BackupSnapshot.fromJson(payload)
+        }
+        snapshot?.let { repo.replaceSnapshot(it, mediaPayloads) }
+    }
+
+    private companion object {
+        const val BACKUP_JSON_NAME = "backup.json"
+        const val ZIP_MAGIC_P: Byte = 0x50
+        const val ZIP_MAGIC_K: Byte = 0x4B
     }
 }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -3,6 +3,7 @@ package com.example.quotepicker.vm
 import android.app.Application
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
@@ -369,6 +370,19 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             val resolver = getApplication<Application>().contentResolver
             resolver.openInputStream(uri)?.use { input ->
                 BitmapFactory.decodeStream(input)
+            }
+        }.getOrNull()
+    }
+
+    fun decodeVideoFrame(uri: Uri): Bitmap? {
+        val app = getApplication<Application>()
+        return runCatching {
+            val retriever = MediaMetadataRetriever()
+            try {
+                retriever.setDataSource(app, uri)
+                retriever.getFrameAtTime(0)
+            } finally {
+                retriever.release()
             }
         }.getOrNull()
     }


### PR DESCRIPTION
### Motivation
- Improve recognizability of stored videos by showing small visual previews alongside images in lists and editors. 
- Make backup export/import robust for full-device restores by packaging media payloads together with metadata instead of relying solely on inline base64 JSON. 
- Preserve compatibility with existing JSON backups while enabling a more reliable zip-based package for large exports.

### Description
- Add `decodeVideoFrame` to `ResourceViewModel` and use `MediaMetadataRetriever` to extract a frame for video thumbnails, and wire it into UI preview locations (`ResourceScreen.kt`).
- Show thumbnails for videos in storage management rows and in the video list of the resource edit screen by decoding frames and rendering them as small `Image` previews (`ResourceScreen.kt`).
- Extend `BackupSnapshot` schema to version `3` and make `MediaBackupItem` include optional `base64` and `fileName` fields to support both inline base64 media and external media files (`BackupSnapshot.kt`).
- Replace previous base64-only export with a package exporter `Repository.exportSnapshotPackage()` that returns an `ExportPackage(snapshot, mediaPayloads)` and add `exportSnapshot()` compatibility wrapper; `replaceSnapshot` now accepts an optional `mediaPayloads` map and restores media from either `base64` or provided file bytes (`Repository.kt`).
- Implement zip-based export/import in `CharacterViewModel`: exports write `backup.json` plus a `media/` folder into a zip and imports accept either a zip package (preferred) or legacy JSON payloads, assembling `mediaPayloads` and passing them to `Repository.replaceSnapshot` (`CharacterViewModel.kt`).
- Update the UI to create/download a `.zip` backup and accept multiple MIME types on import (`CharacterScreen.kt`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697066be6b0c832b964c7132835bafbe)