### PR TITLE
Add preview event parsing/runner, dialog scrolling, and ordering controls

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -555,7 +555,13 @@ private fun TagSelectionSection(
                                 if (isSelected) newSet.remove(tag.id) else newSet.add(tag.id)
                                 onChange(newSet)
                             },
-                            label = { Text(tag.name) },
+                            label = {
+                                Text(
+                                    text = tag.name,
+                                    maxLines = 1,
+                                    overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                )
+                            },
                             colors = FilterChipDefaults.filterChipColors(
                                 containerColor = tagColor.copy(alpha = 0.2f),
                                 selectedContainerColor = tagColor,
@@ -584,7 +590,13 @@ private fun TagSelectionSection(
                             if (isSelected) newSet.remove(tag.id) else newSet.add(tag.id)
                             onChange(newSet)
                         },
-                        label = { Text(tag.name) },
+                        label = {
+                            Text(
+                                text = tag.name,
+                                maxLines = 1,
+                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                            )
+                        },
                         colors = FilterChipDefaults.filterChipColors(
                             containerColor = tagColor.copy(alpha = 0.2f),
                             selectedContainerColor = tagColor,

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -1,14 +1,20 @@
 package com.example.quotepicker.ui
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -28,12 +34,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.CharacterBadge
 import com.example.quotepicker.ui.components.TagBadge
-import com.example.quotepicker.ui.components.rememberFormattedText
+import com.example.quotepicker.ui.components.PreviewTextBlock
+import com.example.quotepicker.ui.components.rememberEventSequenceRunner
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
@@ -47,6 +56,7 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
     var showPreview by remember { mutableStateOf(false) }
     var showTagDialog by remember { mutableStateOf(false) }
     var showIntro by remember { mutableStateOf(false) }
+    val eventRunner = rememberEventSequenceRunner()
 
     if (showPreview && ui.selectedResource != null) {
         ResourcePreviewScreen(
@@ -57,80 +67,107 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
         return
     }
 
-    Column(modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
-        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-            Button(onClick = {
-                vm.randomCharacter()
-                showIntro = false
-            }) {
-                Icon(Icons.Default.Casino, contentDescription = null)
-                Spacer(Modifier.width(8.dp))
-                Text("随机角色")
-            }
-            Button(onClick = { showIntro = true }, enabled = ui.selectedCharacter != null) {
-                Text("显示介绍")
-            }
-        }
-        if (ui.selectedCharacter == null) {
-            Text("未选择角色")
-        } else {
-            CharacterBadge(name = ui.selectedCharacter!!.name)
-        }
-        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    Box(modifier = modifier.fillMaxSize()) {
+        Column(
+            Modifier
+                .padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
             Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                TextButton(onClick = { showTagDialog = true }) {
-                    Text("资源标签筛选(${ui.selectedTagIds.size})")
+                Button(onClick = {
+                    vm.randomCharacter()
+                    showIntro = false
+                }) {
+                    Icon(Icons.Default.Casino, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("随机角色")
+                }
+                Button(onClick = { showIntro = true }, enabled = ui.selectedCharacter != null) {
+                    Text("显示介绍")
                 }
             }
-            if (ui.selectedTagIds.isEmpty()) {
-                Text("未选择标签")
+            if (ui.selectedCharacter == null) {
+                Text("未选择角色")
             } else {
-                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                    ui.tags.filter { ui.selectedTagIds.contains(it.id) }.forEach { tag ->
-                        TagBadge(tag = tag)
+                CharacterBadge(name = ui.selectedCharacter!!.name)
+            }
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    TextButton(onClick = { showTagDialog = true }) {
+                        Text("资源标签筛选(${ui.selectedTagIds.size})")
+                    }
+                }
+                if (ui.selectedTagIds.isEmpty()) {
+                    Text("未选择标签")
+                } else {
+                    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        ui.tags.filter { ui.selectedTagIds.contains(it.id) }.forEach { tag ->
+                            TagBadge(tag = tag)
+                        }
                     }
                 }
             }
-        }
-        Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-            Button(onClick = { vm.randomResource() }, enabled = ui.selectedCharacter != null) {
-                Icon(Icons.Default.Casino, contentDescription = null)
-                Spacer(Modifier.width(8.dp))
-                Text("随机资源")
+            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                Button(onClick = { vm.randomResource() }, enabled = ui.selectedCharacter != null) {
+                    Icon(Icons.Default.Casino, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("随机资源")
+                }
+                Button(onClick = { vm.nextResource() }, enabled = ui.selectedCharacter != null) {
+                    Icon(Icons.Default.SkipNext, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("下一个")
+                }
+                Button(onClick = { vm.reset() }) {
+                    Icon(Icons.Default.Refresh, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("重置")
+                }
             }
-            Button(onClick = { vm.nextResource() }, enabled = ui.selectedCharacter != null) {
-                Icon(Icons.Default.SkipNext, contentDescription = null)
-                Spacer(Modifier.width(8.dp))
-                Text("下一个")
-            }
-            Button(onClick = { vm.reset() }) {
-                Icon(Icons.Default.Refresh, contentDescription = null)
-                Spacer(Modifier.width(8.dp))
-                Text("重置")
-            }
-        }
-        Spacer(Modifier.height(8.dp))
-        val res = ui.selectedResource
-        if (res == null) {
-            Text("暂无资源")
-        } else {
-            Text("当前资源：${res.resource.title}")
-            Button(onClick = { showPreview = true }) {
-                Icon(Icons.Default.Visibility, contentDescription = null)
-                Spacer(Modifier.width(8.dp))
-                Text("预览")
-            }
-        }
-        if (showIntro && ui.selectedCharacter != null) {
-            val introCandidates = ui.characterResources.filter { res ->
-                res.resource.type == ResourceType.TEXT &&
-                    res.resource.title.take(2) == "要点"
-            }
-            if (introCandidates.size == 1) {
-                val introText = rememberFormattedText(introCandidates.first().resource.quoteText.orEmpty())
-                Text(introText)
+            Spacer(Modifier.height(8.dp))
+            val res = ui.selectedResource
+            if (res == null) {
+                Text("暂无资源")
             } else {
-                Text("资源错误")
+                Text("当前资源：${res.resource.title}")
+                Button(onClick = { showPreview = true }) {
+                    Icon(Icons.Default.Visibility, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("预览")
+                }
+            }
+            if (showIntro && ui.selectedCharacter != null) {
+                val introCandidates = ui.characterResources.filter { res ->
+                    res.resource.type == ResourceType.TEXT &&
+                        res.resource.title.take(2) == "要点"
+                }
+                if (introCandidates.size == 1) {
+                    val introText = introCandidates.first().resource.quoteText.orEmpty()
+                    PreviewTextBlock(
+                        text = introText,
+                        onEventSequence = { eventRunner.start(it) }
+                    )
+                } else {
+                    Text("资源错误")
+                }
+            }
+        }
+        if (eventRunner.overlayText != null) {
+            androidx.compose.material3.Card(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .padding(top = 24.dp),
+                colors = androidx.compose.material3.CardDefaults.cardColors(
+                    containerColor = androidx.compose.material3.MaterialTheme.colorScheme.surfaceVariant
+                )
+            ) {
+                Text(
+                    text = eventRunner.overlayText.orEmpty(),
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                    style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
+                    color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
+                )
             }
         }
     }
@@ -159,12 +196,20 @@ private fun TagPickerDialog(
         onDismissRequest = onDismiss,
         title = { Text("资源标签筛选") },
         text = {
-            TagSelectionSection(
-                categories = categories,
-                tags = tags,
-                selected = selected,
-                onChange = { selected = it.toMutableSet() }
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TagSelectionSection(
+                    categories = categories,
+                    tags = tags,
+                    selected = selected,
+                    onChange = { selected = it.toMutableSet() }
+                )
+            }
         },
         confirmButton = {
             TextButton(onClick = { onConfirm(selected); onDismiss() }) { Text("确定") }
@@ -235,7 +280,13 @@ private fun TagFilterChip(
             if (isSelected) updated.remove(tag.id) else updated.add(tag.id)
             onChange(updated)
         },
-        label = { Text(tag.name) },
+        label = {
+            Text(
+                text = tag.name,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
         colors = FilterChipDefaults.filterChipColors()
     )
 }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -70,6 +71,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.ResourceType
@@ -80,7 +82,6 @@ import com.example.quotepicker.ui.components.CharacterBadge
 import com.example.quotepicker.ui.components.ResourceGridCard
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.TagBadge
-import com.example.quotepicker.ui.components.rememberFormattedText
 import com.example.quotepicker.ui.components.tagTextColor
 import com.example.quotepicker.vm.FlowUpdateItem
 import com.example.quotepicker.vm.ImageUpdateItem
@@ -575,13 +576,21 @@ private fun FilterTagDialog(
         onDismissRequest = onDismiss,
         title = { Text("选择标签筛选") },
         text = {
-            TagSelectionSection(
-                label = "标签",
-                categories = categories,
-                tags = tags,
-                selected = selected,
-                onChange = { selected = it.toMutableSet() }
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TagSelectionSection(
+                    label = "标签",
+                    categories = categories,
+                    tags = tags,
+                    selected = selected,
+                    onChange = { selected = it.toMutableSet() }
+                )
+            }
         },
         confirmButton = {
             TextButton(onClick = {
@@ -606,7 +615,13 @@ private fun FilterCharacterDialog(
         onDismissRequest = onDismiss,
         title = { Text("选择角色筛选") },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
                 Text("角色")
                 FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -615,7 +630,13 @@ private fun FilterCharacterDialog(
                     FilterChip(
                         selected = current == null,
                         onClick = { current = null },
-                        label = { Text("全部角色") },
+                        label = {
+                            Text(
+                                text = "全部角色",
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        },
                         colors = FilterChipDefaults.filterChipColors(
                             containerColor = Color.White,
                             selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -626,7 +647,13 @@ private fun FilterCharacterDialog(
                         FilterChip(
                             selected = current == character.id,
                             onClick = { current = character.id },
-                            label = { Text(character.name) },
+                            label = {
+                                Text(
+                                    text = character.name,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            },
                             colors = FilterChipDefaults.filterChipColors(
                                 containerColor = Color.White,
                                 selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
@@ -821,17 +848,40 @@ private fun ResourceCreateScreen(
                                                 color = MaterialTheme.colorScheme.primary
                                             )
                                             val summary = when (item.type) {
-                                                ResourceType.TEXT -> rememberFormattedText(item.text.orEmpty())
+                                                ResourceType.TEXT -> item.text.orEmpty()
                                                 ResourceType.SCENE -> "对话 ${item.sceneMessages.size} 条"
                                                 ResourceType.IMAGE -> "图片 ${item.images.size} 张"
                                                 ResourceType.VIDEO -> "视频 ${item.videos.size} 个"
                                                 else -> ""
                                             }
                                             if (summary.isNotBlank()) {
-                                                Text(text = summary, style = MaterialTheme.typography.bodySmall)
+                                                Text(
+                                                    text = summary,
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis
+                                                )
                                             }
                                         }
                                         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                            IconButton(onClick = {
+                                                if (index > 0) {
+                                                    flowItems = flowItems.toMutableList().also {
+                                                        it.add(index - 1, it.removeAt(index))
+                                                    }
+                                                }
+                                            }) {
+                                                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上移")
+                                            }
+                                            IconButton(onClick = {
+                                                if (index < flowItems.lastIndex) {
+                                                    flowItems = flowItems.toMutableList().also {
+                                                        it.add(index + 1, it.removeAt(index))
+                                                    }
+                                                }
+                                            }) {
+                                                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下移")
+                                            }
                                             IconButton(onClick = {
                                                 editFlowIndex = index
                                                 showFlowDialog = true
@@ -900,9 +950,31 @@ private fun ResourceCreateScreen(
                                                 style = MaterialTheme.typography.labelMedium,
                                                 color = MaterialTheme.colorScheme.primary
                                             )
-                                            Text(text = message.content)
+                                            Text(
+                                                text = message.content,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis
+                                            )
                                         }
                                         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                            IconButton(onClick = {
+                                                if (index > 0) {
+                                                    sceneMessages = sceneMessages.toMutableList().also {
+                                                        it.add(index - 1, it.removeAt(index))
+                                                    }
+                                                }
+                                            }) {
+                                                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上移")
+                                            }
+                                            IconButton(onClick = {
+                                                if (index < sceneMessages.lastIndex) {
+                                                    sceneMessages = sceneMessages.toMutableList().also {
+                                                        it.add(index + 1, it.removeAt(index))
+                                                    }
+                                                }
+                                            }) {
+                                                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下移")
+                                            }
                                             IconButton(onClick = {
                                                 editSceneIndex = index
                                                 showSceneDialog = true
@@ -1357,9 +1429,31 @@ private fun ResourceEditScreen(
                                                 style = MaterialTheme.typography.labelMedium,
                                                 color = MaterialTheme.colorScheme.primary
                                             )
-                                            Text(text = message.content)
+                                            Text(
+                                                text = message.content,
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis
+                                            )
                                         }
                                         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                            IconButton(onClick = {
+                                                if (index > 0) {
+                                                    sceneMessages = sceneMessages.toMutableList().also {
+                                                        it.add(index - 1, it.removeAt(index))
+                                                    }
+                                                }
+                                            }) {
+                                                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上移")
+                                            }
+                                            IconButton(onClick = {
+                                                if (index < sceneMessages.lastIndex) {
+                                                    sceneMessages = sceneMessages.toMutableList().also {
+                                                        it.add(index + 1, it.removeAt(index))
+                                                    }
+                                                }
+                                            }) {
+                                                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下移")
+                                            }
                                             IconButton(onClick = {
                                                 editSceneIndex = index
                                                 showSceneDialog = true
@@ -1407,17 +1501,40 @@ private fun ResourceEditScreen(
                                                 color = MaterialTheme.colorScheme.primary
                                             )
                                             val summary = when (item.type) {
-                                                ResourceType.TEXT -> rememberFormattedText(item.text.orEmpty())
+                                                ResourceType.TEXT -> item.text.orEmpty()
                                                 ResourceType.SCENE -> "对话 ${item.sceneMessages.size} 条"
                                                 ResourceType.IMAGE -> "图片 ${item.images.size} 张"
                                                 ResourceType.VIDEO -> "视频 ${item.videos.size} 个"
                                                 else -> ""
                                             }
                                             if (summary.isNotBlank()) {
-                                                Text(text = summary, style = MaterialTheme.typography.bodySmall)
+                                                Text(
+                                                    text = summary,
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    maxLines = 1,
+                                                    overflow = TextOverflow.Ellipsis
+                                                )
                                             }
                                         }
                                         Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                            IconButton(onClick = {
+                                                if (index > 0) {
+                                                    flowItems = flowItems.toMutableList().also {
+                                                        it.add(index - 1, it.removeAt(index))
+                                                    }
+                                                }
+                                            }) {
+                                                Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上移")
+                                            }
+                                            IconButton(onClick = {
+                                                if (index < flowItems.lastIndex) {
+                                                    flowItems = flowItems.toMutableList().also {
+                                                        it.add(index + 1, it.removeAt(index))
+                                                    }
+                                                }
+                                            }) {
+                                                Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下移")
+                                            }
                                             IconButton(onClick = {
                                                 editFlowIndex = index
                                                 showFlowDialog = true
@@ -1596,13 +1713,21 @@ private fun TagPickerDialog(
         onDismissRequest = onDismiss,
         title = { Text("选择标签") },
         text = {
-            TagSelectionSection(
-                label = "标签",
-                categories = categories,
-                tags = tags,
-                selected = selected,
-                onChange = { selected = it.toMutableSet() }
-            )
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                TagSelectionSection(
+                    label = "标签",
+                    categories = categories,
+                    tags = tags,
+                    selected = selected,
+                    onChange = { selected = it.toMutableSet() }
+                )
+            }
         },
         confirmButton = { TextButton(onClick = { onConfirm(selected); onDismiss() }) { Text("确定") } },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
@@ -1622,22 +1747,35 @@ private fun CharacterPickerDialog(
         onDismissRequest = onDismiss,
         title = { Text("选择角色") },
         text = {
-            FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                characters.forEach { character ->
-                    val isSelected = selected.contains(character.id)
-                    FilterChip(
-                        selected = isSelected,
-                        onClick = {
-                            if (isSelected) selected.remove(character.id) else selected.add(character.id)
-                            selected = selected.toMutableSet()
-                        },
-                        label = { Text(character.name) },
-                        colors = FilterChipDefaults.filterChipColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant,
-                            selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
-                            selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState())
+            ) {
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    characters.forEach { character ->
+                        val isSelected = selected.contains(character.id)
+                        FilterChip(
+                            selected = isSelected,
+                            onClick = {
+                                if (isSelected) selected.remove(character.id) else selected.add(character.id)
+                                selected = selected.toMutableSet()
+                            },
+                            label = {
+                                Text(
+                                    text = character.name,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            },
+                            colors = FilterChipDefaults.filterChipColors(
+                                containerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                selectedContainerColor = MaterialTheme.colorScheme.primaryContainer,
+                                selectedLabelColor = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
                         )
-                    )
+                    }
                 }
             }
         },
@@ -1712,7 +1850,13 @@ private fun TagFilterChip(
             if (isSelected) newSet.remove(tag.id) else newSet.add(tag.id)
             onChange(newSet)
         },
-        label = { Text(tag.name) },
+        label = {
+            Text(
+                text = tag.name,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
+        },
         colors = FilterChipDefaults.filterChipColors(
             containerColor = tagColor.copy(alpha = 0.2f),
             selectedContainerColor = tagColor,
@@ -1743,7 +1887,13 @@ private fun SceneMessageDialog(
         onDismissRequest = onDismiss,
         title = { Text(title) },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
                 if (allowedSpeakers.isEmpty()) {
                     Text("请先选择角色再添加对话", style = MaterialTheme.typography.labelMedium)
                 } else {
@@ -1821,7 +1971,13 @@ private fun FlowStepDialog(
         onDismissRequest = onDismiss,
         title = { Text("流程步骤") },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 420.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
                 Text("步骤类型")
                 FlowRow(
                     horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -1863,7 +2019,12 @@ private fun FlowStepDialog(
                                     )
                                     val summary = resourceSummary(res)
                                     if (summary.isNotBlank()) {
-                                        Text(summary, style = MaterialTheme.typography.bodySmall)
+                                        Text(
+                                            text = summary,
+                                            style = MaterialTheme.typography.bodySmall,
+                                            maxLines = 1,
+                                            overflow = TextOverflow.Ellipsis
+                                        )
                                     }
                                 }
                             }
@@ -2005,7 +2166,7 @@ private fun flowItemFromResource(resource: ResourceWithTagsCharacters): FlowUpda
 private fun resourceSummary(resource: ResourceWithTagsCharacters): String {
     val data = resource.resource
     return when (data.type) {
-        ResourceType.TEXT -> rememberFormattedText(data.quoteText.orEmpty())
+        ResourceType.TEXT -> data.quoteText.orEmpty()
         ResourceType.SCENE -> {
             val messages = parseSceneMessages(data.sceneJson)
             if (messages.isEmpty()) "" else "对话 ${messages.size} 条"

--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -43,6 +44,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.background
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
@@ -305,7 +308,13 @@ private fun TagDialog(
         onDismissRequest = onDismiss,
         title = { Text(title) },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },
@@ -350,7 +359,13 @@ private fun CategoryDialog(
         onDismissRequest = onDismiss,
         title = { Text(title) },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 360.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
                 OutlinedTextField(
                     value = name,
                     onValueChange = { name = it },

--- a/app/src/main/java/com/example/quotepicker/ui/components/DisplayFormatters.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/DisplayFormatters.kt
@@ -29,7 +29,7 @@ fun formatDisplayText(text: String, random: Random = Random.Default): String {
             "【${options.random(random)}】"
         }
     }
-    return replaced.replace("++", "")
+    return replaced
 }
 
 @Composable

--- a/app/src/main/java/com/example/quotepicker/ui/components/EventSequenceRunner.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/EventSequenceRunner.kt
@@ -1,0 +1,71 @@
+package com.example.quotepicker.ui.components
+
+import android.media.AudioManager
+import android.media.ToneGenerator
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+data class EventSequenceRunner(
+    val overlayText: String?,
+    val start: (EventSequence) -> Unit
+)
+
+@Composable
+fun rememberEventSequenceRunner(): EventSequenceRunner {
+    val coroutineScope = rememberCoroutineScope()
+    var overlayText by remember { mutableStateOf<String?>(null) }
+    var eventJob by remember { mutableStateOf<Job?>(null) }
+    val toneGenerator = remember { ToneGenerator(AudioManager.STREAM_MUSIC, 80) }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            toneGenerator.release()
+        }
+    }
+
+    val startSequence: (EventSequence) -> Unit = { sequence ->
+        eventJob?.cancel()
+        eventJob = coroutineScope.launch {
+            runEventSequence(sequence, toneGenerator) { overlayText = it }
+        }
+    }
+
+    return remember(overlayText) {
+        EventSequenceRunner(
+            overlayText = overlayText,
+            start = startSequence
+        )
+    }
+}
+
+private suspend fun runEventSequence(
+    sequence: EventSequence,
+    toneGenerator: ToneGenerator,
+    onOverlayUpdate: (String?) -> Unit
+) {
+    for (step in sequence.steps) {
+        when (step) {
+            is EventStep.Display -> {
+                onOverlayUpdate(step.text)
+                delay(step.seconds * 1000L)
+            }
+            is EventStep.Countdown -> {
+                val interval = step.intervalMs ?: step.randomRange?.random() ?: 1000L
+                for (count in step.total downTo 1) {
+                    onOverlayUpdate(count.toString())
+                    toneGenerator.startTone(ToneGenerator.TONE_PROP_BEEP, 80)
+                    delay(interval)
+                }
+            }
+        }
+    }
+    onOverlayUpdate(null)
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/PreviewTextBlock.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/PreviewTextBlock.kt
@@ -1,0 +1,135 @@
+package com.example.quotepicker.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import kotlin.random.Random
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+
+sealed interface PreviewSegment {
+    data class TextSegment(val text: String) : PreviewSegment
+    data class EventSegment(val sequence: EventSequence) : PreviewSegment
+}
+
+data class EventSequence(
+    val label: String,
+    val steps: List<EventStep>
+)
+
+sealed interface EventStep {
+    data class Display(val text: String, val seconds: Int) : EventStep
+    data class Countdown(
+        val total: Int,
+        val intervalMs: Long?,
+        val randomRange: LongRange? = null
+    ) : EventStep
+}
+
+private val eventTokenRegex = Regex("\\+\\+(.*?)\\+\\+")
+private val eventStepRegex = Regex("\\[(.*?)]")
+
+fun parsePreviewSegments(text: String, random: Random = Random.Default): List<PreviewSegment> {
+    if (text.isBlank()) return listOf(PreviewSegment.TextSegment(text))
+    val segments = mutableListOf<PreviewSegment>()
+    var lastIndex = 0
+    eventTokenRegex.findAll(text).forEach { match ->
+        if (match.range.first > lastIndex) {
+            val raw = text.substring(lastIndex, match.range.first)
+            if (raw.isNotBlank()) {
+                segments.add(PreviewSegment.TextSegment(formatDisplayText(raw, random)))
+            }
+        }
+        val token = match.groupValues.getOrNull(1).orEmpty()
+        val sequence = parseEventSequence(token)
+        if (sequence != null) {
+            segments.add(PreviewSegment.EventSegment(sequence))
+        } else if (token.isNotBlank()) {
+            segments.add(PreviewSegment.TextSegment(formatDisplayText(token, random)))
+        }
+        lastIndex = match.range.last + 1
+    }
+    if (lastIndex < text.length) {
+        val tail = text.substring(lastIndex)
+        if (tail.isNotBlank()) {
+            segments.add(PreviewSegment.TextSegment(formatDisplayText(tail, random)))
+        }
+    }
+    return if (segments.isEmpty()) listOf(PreviewSegment.TextSegment(formatDisplayText(text, random))) else segments
+}
+
+fun parseEventSequence(raw: String): EventSequence? {
+    val steps = mutableListOf<EventStep>()
+    eventStepRegex.findAll(raw).forEach { match ->
+        val parts = match.groupValues.getOrNull(1)
+            ?.split(",", limit = 2)
+            ?.map { it.trim() }
+            .orEmpty()
+        if (parts.size < 2) return@forEach
+        val first = parts[0]
+        val second = parts[1]
+        val count = first.toIntOrNull()
+        val duration = second.toIntOrNull()
+        if (count != null && (duration != null || second.equals("x", ignoreCase = true))) {
+            val interval = duration?.toLong()
+            val range = if (second.equals("x", ignoreCase = true)) 200L..2000L else null
+            steps.add(EventStep.Countdown(total = count, intervalMs = interval, randomRange = range))
+        } else if (duration != null && first.isNotBlank()) {
+            steps.add(EventStep.Display(text = first, seconds = duration))
+        }
+    }
+    if (steps.isEmpty()) return null
+    val label = (steps.firstOrNull { it is EventStep.Display } as? EventStep.Display)?.text ?: "开始"
+    return EventSequence(label = label, steps = steps)
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun PreviewTextBlock(
+    text: String,
+    onEventSequence: (EventSequence) -> Unit,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = MaterialTheme.typography.bodyMedium
+) {
+    val segments = remember(text) { parsePreviewSegments(text) }
+    SelectionContainer {
+        FlowRow(
+            modifier = modifier,
+            horizontalArrangement = Arrangement.spacedBy(0.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp)
+        ) {
+            segments.forEach { segment ->
+                when (segment) {
+                    is PreviewSegment.TextSegment -> {
+                        if (segment.text.isNotBlank()) {
+                            Text(text = segment.text, style = textStyle)
+                        }
+                    }
+                    is PreviewSegment.EventSegment -> {
+                        val label = "【${segment.sequence.label}】"
+                        Text(
+                            text = label,
+                            modifier = Modifier
+                                .clickable { onEventSequence(segment.sequence) }
+                                .padding(vertical = 2.dp),
+                            color = MaterialTheme.colorScheme.primary,
+                            fontWeight = FontWeight.SemiBold,
+                            textDecoration = TextDecoration.Underline,
+                            style = textStyle
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -45,6 +45,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -93,6 +94,11 @@ fun ResourcePreviewScreen(
     var sceneMessages by remember { mutableStateOf<List<SceneMessage>>(emptyList()) }
     var flowItems by remember { mutableStateOf<List<FlowPreviewItem>>(emptyList()) }
     val scrollState = rememberScrollState()
+    val uiState by vm.uiState.collectAsState()
+    val highlightedSpeaker = uiState.filters.selectedCharacterId?.let { id ->
+        uiState.characters.firstOrNull { it.id == id }?.name
+    }
+    val eventRunner = rememberEventSequenceRunner()
 
     LaunchedEffect(resource.resource.id, mediaReloadKey) {
         val res = resource.resource
@@ -129,6 +135,10 @@ fun ResourcePreviewScreen(
         sceneMessages = if (res.type == ResourceType.SCENE) parseSceneMessages(res.sceneJson.orEmpty()) else emptyList()
     }
 
+    val handleEventSequence: (EventSequence) -> Unit = { sequence ->
+        eventRunner.start(sequence)
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -141,138 +151,152 @@ fun ResourcePreviewScreen(
             )
         }
     ) { inner ->
-        Column(
-            modifier = Modifier
-                .padding(inner)
-                .fillMaxSize()
-                .verticalScroll(scrollState)
-                .padding(horizontal = 16.dp, vertical = 16.dp)
-                .padding(bottom = 96.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            Text(
-                text = resource.resource.title,
-                style = MaterialTheme.typography.headlineSmall,
-                fontWeight = FontWeight.Bold
-            )
-            if (resource.resource.type != ResourceType.FLOW) {
-                ResourceMetaRow(label = "标签") {
-                    if (resource.tags.isNotEmpty()) {
-                        FlowRow(
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
-                            verticalArrangement = Arrangement.spacedBy(6.dp)
-                        ) {
-                            resource.tags.forEach { tag ->
-                                TagBadge(tag = tag)
-                            }
-                        }
-                    } else {
-                        Text("无标签", style = MaterialTheme.typography.labelSmall)
-                    }
-                }
-                ResourceMetaRow(label = "角色") {
-                    if (resource.characters.isNotEmpty()) {
-                        FlowRow(
-                            horizontalArrangement = Arrangement.spacedBy(6.dp),
-                            verticalArrangement = Arrangement.spacedBy(6.dp)
-                        ) {
-                            resource.characters.forEach { character ->
-                                CharacterBadge(name = character.name)
-                            }
-                        }
-                    } else {
-                        Text("未选择角色", style = MaterialTheme.typography.labelSmall)
-                    }
-                }
-            }
-
-            Card(
-                modifier = Modifier.fillMaxWidth()
+        Box(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .padding(inner)
+                    .fillMaxSize()
+                    .verticalScroll(scrollState)
+                    .padding(horizontal = 16.dp, vertical = 16.dp)
+                    .padding(bottom = 96.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Column(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                Text(
+                    text = resource.resource.title,
+                    style = MaterialTheme.typography.headlineSmall,
+                    fontWeight = FontWeight.Bold
+                )
+                if (resource.resource.type != ResourceType.FLOW) {
+                    ResourceMetaRow(label = "标签") {
+                        if (resource.tags.isNotEmpty()) {
+                            FlowRow(
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp)
+                            ) {
+                                resource.tags.forEach { tag ->
+                                    TagBadge(tag = tag)
+                                }
+                            }
+                        } else {
+                            Text("无标签", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                    ResourceMetaRow(label = "角色") {
+                        if (resource.characters.isNotEmpty()) {
+                            FlowRow(
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp)
+                            ) {
+                                resource.characters.forEach { character ->
+                                    CharacterBadge(name = character.name)
+                                }
+                            }
+                        } else {
+                            Text("未选择角色", style = MaterialTheme.typography.labelSmall)
+                        }
+                    }
+                }
+
+                Card(
+                    modifier = Modifier.fillMaxWidth()
                 ) {
-                    when (resource.resource.type) {
-                        ResourceType.TEXT -> {
-                            val quoteText = resource.resource.quoteText.orEmpty()
-                            if (quoteText.isNotBlank()) {
-                                val displayText = rememberFormattedText(quoteText)
-                                Text(displayText)
-                            }
-                            QuoteImagePager(images = quoteImages)
-                        }
-                        ResourceType.IMAGE -> {
-                            if (quoteImages.isNotEmpty()) {
-                                QuoteImagePager(images = quoteImages)
-                            } else {
-                                Text("图片加载中…")
-                            }
-                        }
-                        ResourceType.VIDEO -> {
-                            if (mediaUris.isNotEmpty()) {
-                                MediaPreviewPager(uris = mediaUris)
-                            } else if (mediaLoadFailed) {
-                                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                                    Text("视频加载失败")
-                                    AssistChip(
-                                        onClick = { mediaReloadKey += 1 },
-                                        label = { Text("重试") }
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        when (resource.resource.type) {
+                            ResourceType.TEXT -> {
+                                val quoteText = resource.resource.quoteText.orEmpty()
+                                if (quoteText.isNotBlank()) {
+                                    PreviewTextBlock(
+                                        text = quoteText,
+                                        onEventSequence = handleEventSequence
                                     )
                                 }
-                            } else {
-                                Text("视频加载中…")
+                                QuoteImagePager(images = quoteImages)
                             }
-                        }
-                        ResourceType.SCENE -> {
-                            if (sceneMessages.isNotEmpty()) {
-                                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                    sceneMessages.forEach { message ->
-                                        SceneBubble(message = message)
-                                    }
+                            ResourceType.IMAGE -> {
+                                if (quoteImages.isNotEmpty()) {
+                                    QuoteImagePager(images = quoteImages)
+                                } else {
+                                    Text("图片加载中…")
                                 }
-                            } else {
-                                Text(resource.resource.sceneJson.orEmpty())
                             }
-                        }
-                        ResourceType.FLOW -> {
-                            if (flowItems.isEmpty()) {
-                                Text("流程内容为空")
-                            } else {
-                                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                                    flowItems.forEach { item ->
-                                        Card(modifier = Modifier.fillMaxWidth()) {
-                                            Column(
-                                                modifier = Modifier
-                                                    .fillMaxWidth()
-                                                    .padding(12.dp),
-                                                verticalArrangement = Arrangement.spacedBy(8.dp)
-                                            ) {
-                                                val title = item.title?.ifBlank { null } ?: typeLabel(item.type)
-                                                Text(title, style = MaterialTheme.typography.titleMedium)
-                                                when (item.type) {
-                                                    ResourceType.TEXT -> {
-                                                        val displayText = rememberFormattedText(item.text)
-                                                        Text(displayText)
-                                                    }
-                                                    ResourceType.SCENE -> {
-                                                        item.sceneMessages.forEach { message ->
-                                                            SceneBubble(message = message)
+                            ResourceType.VIDEO -> {
+                                if (mediaUris.isNotEmpty()) {
+                                    MediaPreviewPager(uris = mediaUris)
+                                } else if (mediaLoadFailed) {
+                                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        Text("视频加载失败")
+                                        AssistChip(
+                                            onClick = { mediaReloadKey += 1 },
+                                            label = { Text("重试") }
+                                        )
+                                    }
+                                } else {
+                                    Text("视频加载中…")
+                                }
+                            }
+                            ResourceType.SCENE -> {
+                                if (sceneMessages.isNotEmpty()) {
+                                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                        sceneMessages.forEach { message ->
+                                            SceneBubble(
+                                                message = message,
+                                                highlightedSpeaker = highlightedSpeaker,
+                                                onEventSequence = handleEventSequence
+                                            )
+                                        }
+                                    }
+                                } else {
+                                    Text(resource.resource.sceneJson.orEmpty())
+                                }
+                            }
+                            ResourceType.FLOW -> {
+                                if (flowItems.isEmpty()) {
+                                    Text("流程内容为空")
+                                } else {
+                                    Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                        flowItems.forEach { item ->
+                                            Card(modifier = Modifier.fillMaxWidth()) {
+                                                Column(
+                                                    modifier = Modifier
+                                                        .fillMaxWidth()
+                                                        .padding(12.dp),
+                                                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                                                ) {
+                                                    val title = item.title?.ifBlank { null } ?: typeLabel(item.type)
+                                                    Text(title, style = MaterialTheme.typography.titleMedium)
+                                                    when (item.type) {
+                                                        ResourceType.TEXT -> {
+                                                            PreviewTextBlock(
+                                                                text = item.text,
+                                                                onEventSequence = handleEventSequence
+                                                            )
                                                         }
-                                                    }
-                                                    ResourceType.IMAGE -> QuoteImagePager(images = item.images)
-                                                    ResourceType.VIDEO -> {
-                                                        if (item.mediaUris.isNotEmpty()) {
-                                                            MediaPreviewPager(uris = item.mediaUris)
-                                                        } else if (item.mediaFailed) {
-                                                            Text("视频加载失败")
-                                                        } else {
-                                                            Text("视频加载中…")
+                                                        ResourceType.SCENE -> {
+                                                            item.sceneMessages.forEach { message ->
+                                                                SceneBubble(
+                                                                    message = message,
+                                                                    highlightedSpeaker = highlightedSpeaker,
+                                                                    onEventSequence = handleEventSequence
+                                                                )
+                                                            }
                                                         }
+                                                        ResourceType.IMAGE -> QuoteImagePager(images = item.images)
+                                                        ResourceType.VIDEO -> {
+                                                            if (item.mediaUris.isNotEmpty()) {
+                                                                MediaPreviewPager(uris = item.mediaUris)
+                                                            } else if (item.mediaFailed) {
+                                                                Text("视频加载失败")
+                                                            } else {
+                                                                Text("视频加载中…")
+                                                            }
+                                                        }
+                                                        else -> {}
                                                     }
-                                                    else -> {}
                                                 }
                                             }
                                         }
@@ -280,6 +304,26 @@ fun ResourcePreviewScreen(
                                 }
                             }
                         }
+                    }
+                }
+            }
+            if (eventRunner.overlayText != null) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.TopCenter
+                ) {
+                    Card(
+                        modifier = Modifier.padding(top = 24.dp),
+                        colors = androidx.compose.material3.CardDefaults.cardColors(
+                            containerColor = MaterialTheme.colorScheme.surfaceVariant
+                        )
+                    ) {
+                        Text(
+                            text = eventRunner.overlayText.orEmpty(),
+                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
+                            style = MaterialTheme.typography.titleMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                     }
                 }
             }
@@ -433,27 +477,43 @@ private fun decodeImageSource(item: String, vm: ResourceViewModel): android.grap
 }
 
 @Composable
-private fun SceneBubble(message: SceneMessage) {
+private fun SceneBubble(
+    message: SceneMessage,
+    highlightedSpeaker: String?,
+    onEventSequence: (EventSequence) -> Unit
+) {
+    val isHighlighted = highlightedSpeaker != null && highlightedSpeaker == message.speaker
     Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.Start
+        horizontalArrangement = if (isHighlighted) Arrangement.End else Arrangement.Start
     ) {
         Column(
             modifier = Modifier
-                .background(MaterialTheme.colorScheme.primaryContainer, MaterialTheme.shapes.medium)
+                .background(
+                    if (isHighlighted) MaterialTheme.colorScheme.secondaryContainer else MaterialTheme.colorScheme.primaryContainer,
+                    MaterialTheme.shapes.medium
+                )
                 .padding(12.dp)
         ) {
             Text(
                 text = message.speaker,
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onPrimaryContainer
+                color = if (isHighlighted) {
+                    MaterialTheme.colorScheme.onSecondaryContainer
+                } else {
+                    MaterialTheme.colorScheme.onPrimaryContainer
+                }
             )
             Spacer(Modifier.height(4.dp))
-            val content = rememberFormattedText(message.content)
-            Text(text = content)
+            PreviewTextBlock(
+                text = message.content,
+                onEventSequence = onEventSequence,
+                textStyle = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }
+
 
 private fun parseSceneMessages(raw: String): List<SceneMessage> {
     return runCatching {


### PR DESCRIPTION
### Motivation
- Support inline event tokens of the form `++[...]++` in preview text so users can click a label to start non-blocking overlay displays and countdowns with audible beats. 
- Make preview text selectable/copyable and ensure dialogs and selection pickers are scrollable and constrained so long lists and long labels render and select predictably. 
- Allow reordering of flow steps and scene messages in the create/edit screens and keep list summaries compact for easier management. 

### Description
- Added a new selectable preview component `PreviewTextBlock` that parses `++...++` tokens into clickable `EventSequence` items and displays normal text segments (file: `app/src/main/java/com/example/quotepicker/ui/components/PreviewTextBlock.kt`).
- Implemented an event runner `rememberEventSequenceRunner` that shows a floating non-blocking overlay and runs display/countdown steps (with optional randomized intervals) while emitting a short beep per tick (file: `app/src/main/java/com/example/quotepicker/ui/components/EventSequenceRunner.kt`).
- Integrated preview parsing and event handling into `ResourcePreviewScreen` and `RandomScreen`, and made scene message bubbles use `PreviewTextBlock` so event tokens and clickable labels work in previews (files: `ResourcePreviewScreen.kt`, `RandomScreen.kt`).
- Added up/down reorder controls for flow steps and scene messages, and truncated selection summaries and chips to a single line with ellipsis so pickers and lists stay compact (files: `ResourceScreen.kt`, `CharacterScreen.kt`, `TagScreen.kt`).
- Improved scrolling/height constraints across many dialogs and picker panels by wrapping selection sections with `heightIn` and `verticalScroll` so long content is scrollable and dialog sizes are bounded (multiple UI files). 
- Kept original display token handling by adjusting `DisplayFormatters` to avoid stripping `++` so event tokens remain available to the preview parser. 

### Testing
- No automated unit or UI tests were executed against these changes as part of this PR; only manual verification was performed during development (no CI tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69708c24da14832bbf7a492a148eac8e)