### PR TITLE
Show flow item titles and fix preview event overlay position

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -1495,11 +1495,25 @@ private fun ResourceEditScreen(
                                             modifier = Modifier.weight(1f),
                                             verticalArrangement = Arrangement.spacedBy(4.dp)
                                         ) {
-                                            Text(
-                                                text = typeLabel(item.type),
-                                                style = MaterialTheme.typography.labelMedium,
-                                                color = MaterialTheme.colorScheme.primary
-                                            )
+                                            val title = item.title?.ifBlank { null }
+                                            if (title != null) {
+                                                Text(
+                                                    text = title,
+                                                    style = MaterialTheme.typography.labelMedium,
+                                                    color = MaterialTheme.colorScheme.primary
+                                                )
+                                                Text(
+                                                    text = typeLabel(item.type),
+                                                    style = MaterialTheme.typography.bodySmall,
+                                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                                )
+                                            } else {
+                                                Text(
+                                                    text = typeLabel(item.type),
+                                                    style = MaterialTheme.typography.labelMedium,
+                                                    color = MaterialTheme.colorScheme.primary
+                                                )
+                                            }
                                             val summary = when (item.type) {
                                                 ResourceType.TEXT -> item.text.orEmpty()
                                                 ResourceType.SCENE -> "对话 ${item.sceneMessages.size} 条"

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.calculateTopPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.pager.HorizontalPager
@@ -313,7 +314,7 @@ fun ResourcePreviewScreen(
                     contentAlignment = Alignment.TopCenter
                 ) {
                     Card(
-                        modifier = Modifier.padding(top = 24.dp),
+                        modifier = Modifier.padding(top = inner.calculateTopPadding() + 24.dp),
                         colors = androidx.compose.material3.CardDefaults.cardColors(
                             containerColor = MaterialTheme.colorScheme.surfaceVariant
                         )


### PR DESCRIPTION
### Motivation
- Make flow steps easier to identify by showing a resource `title` when available in the flow editor UI. 
- Ensure floating event text and countdowns (triggered by `PreviewTextBlock` events) are visible below the preview app bar instead of being hidden under it.

### Description
- Update `ResourceScreen.kt` to display the item `title` as the primary label when present and show the `typeLabel(item.type)` as a secondary line, falling back to the type as primary when the title is blank.
- Adjust the preview overlay in `ResourcePreviewScreen.kt` to respect Scaffold padding by using `inner.calculateTopPadding()` and add that to the overlay top offset so the card appears below the top bar.
- Add the `calculateTopPadding` import and update the overlay `Card` padding to `inner.calculateTopPadding() + 24.dp` so countdown/display text is not obscured.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69709cd31d70832b93d6d249bc70c89f)