### PR TITLE
Refresh flow previews on resource updates and add selectable event tones

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -753,6 +754,12 @@ private fun ResourceCreateScreen(
         availableResources.filter { it.resource.type != ResourceType.FLOW }
     }
 
+    LaunchedEffect(availableResources) {
+        if (mode == CreateMode.Flow) {
+            flowItems = refreshFlowItemsFromResources(flowItems, availableResources)
+        }
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -1155,6 +1162,12 @@ private fun ResourceEditScreen(
     }
     val flowResources = remember(availableResources) {
         availableResources.filter { it.resource.type != ResourceType.FLOW }
+    }
+
+    LaunchedEffect(availableResources) {
+        if (resource.resource.type == ResourceType.FLOW) {
+            flowItems = refreshFlowItemsFromResources(flowItems, availableResources)
+        }
     }
 
     val canSave = title.isNotBlank() && selectedCharacters.isNotEmpty() && when (resource.resource.type) {
@@ -2173,6 +2186,19 @@ private fun flowItemFromResource(resource: ResourceWithTagsCharacters): FlowUpda
             videos = parseVideoItems(data.contentUriOrPath)
         )
         else -> FlowUpdateItem(type = data.type, title = data.title, resourceId = data.id)
+    }
+}
+
+private fun refreshFlowItemsFromResources(
+    items: List<FlowUpdateItem>,
+    resources: List<ResourceWithTagsCharacters>
+): List<FlowUpdateItem> {
+    if (items.isEmpty()) return items
+    val resourceMap = resources.associateBy { it.resource.id }
+    return items.map { item ->
+        val resourceId = item.resourceId ?: return@map item
+        val resource = resourceMap[resourceId] ?: return@map item
+        flowItemFromResource(resource)
     }
 }
 

--- a/app/src/main/java/com/example/quotepicker/ui/components/EventSequenceRunner.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/EventSequenceRunner.kt
@@ -51,6 +51,7 @@ private suspend fun runEventSequence(
     toneGenerator: ToneGenerator,
     onOverlayUpdate: (String?) -> Unit
 ) {
+    val tone = resolveTone(sequence.toneIndex)
     for (step in sequence.steps) {
         when (step) {
             is EventStep.Display -> {
@@ -61,11 +62,22 @@ private suspend fun runEventSequence(
                 val interval = step.intervalMs ?: step.randomRange?.random() ?: 1000L
                 for (count in step.total downTo 1) {
                     onOverlayUpdate(count.toString())
-                    toneGenerator.startTone(ToneGenerator.TONE_PROP_BEEP, 80)
+                    toneGenerator.startTone(tone, 80)
                     delay(interval)
                 }
             }
         }
     }
     onOverlayUpdate(null)
+}
+
+private fun resolveTone(index: Int?): Int {
+    val tones = listOf(
+        ToneGenerator.TONE_PROP_BEEP,
+        ToneGenerator.TONE_PROP_ACK,
+        ToneGenerator.TONE_PROP_NACK,
+        ToneGenerator.TONE_PROP_PROMPT
+    )
+    val resolved = index?.takeIf { it in tones.indices } ?: 0
+    return tones[resolved]
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/PreviewTextBlock.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/PreviewTextBlock.kt
@@ -24,7 +24,8 @@ sealed interface PreviewSegment {
 
 data class EventSequence(
     val label: String,
-    val steps: List<EventStep>
+    val steps: List<EventStep>,
+    val toneIndex: Int? = null
 )
 
 sealed interface EventStep {
@@ -69,8 +70,12 @@ fun parsePreviewSegments(text: String, random: Random = Random.Default): List<Pr
 }
 
 fun parseEventSequence(raw: String): EventSequence? {
+    val trimmed = raw.trim()
+    val toneMatch = Regex("^(\\d+)").find(trimmed)
+    val toneIndex = toneMatch?.value?.toIntOrNull()?.minus(1)
+    val content = if (toneMatch != null) trimmed.drop(toneMatch.value.length) else trimmed
     val steps = mutableListOf<EventStep>()
-    eventStepRegex.findAll(raw).forEach { match ->
+    eventStepRegex.findAll(content).forEach { match ->
         val parts = match.groupValues.getOrNull(1)
             ?.split(",", limit = 2)
             ?.map { it.trim() }
@@ -90,7 +95,7 @@ fun parseEventSequence(raw: String): EventSequence? {
     }
     if (steps.isEmpty()) return null
     val label = (steps.firstOrNull { it is EventStep.Display } as? EventStep.Display)?.text ?: "开始"
-    return EventSequence(label = label, steps = steps)
+    return EventSequence(label = label, steps = steps, toneIndex = toneIndex)
 }
 
 @OptIn(ExperimentalLayoutApi::class)

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.calculateTopPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.pager.HorizontalPager
@@ -96,12 +95,13 @@ fun ResourcePreviewScreen(
     var flowItems by remember { mutableStateOf<List<FlowPreviewItem>>(emptyList()) }
     val scrollState = rememberScrollState()
     val uiState by vm.uiState.collectAsState()
+    val allResources by vm.allResources.collectAsState()
     val highlightedSpeaker = uiState.filters.selectedCharacterId?.let { id ->
         uiState.characters.firstOrNull { it.id == id }?.name
     }
     val eventRunner = rememberEventSequenceRunner()
 
-    LaunchedEffect(resource.resource.id, mediaReloadKey) {
+    LaunchedEffect(resource.resource.id, mediaReloadKey, allResources) {
         val res = resource.resource
         quoteImages = emptyList()
         mediaLoadFailed = false
@@ -111,7 +111,7 @@ fun ResourcePreviewScreen(
         } else if (res.type == ResourceType.TEXT) {
             quoteImages = decodeQuoteImages(res.quoteImageBase64, vm)
         } else if (res.type == ResourceType.FLOW) {
-            flowItems = parseFlowItems(res.sceneJson.orEmpty(), vm)
+            flowItems = parseFlowItems(res.sceneJson.orEmpty(), vm, allResources)
         }
         mediaUris = when (res.type) {
             ResourceType.VIDEO -> {
@@ -532,8 +532,13 @@ private fun parseSceneMessages(raw: String): List<SceneMessage> {
     }.getOrDefault(emptyList())
 }
 
-private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<FlowPreviewItem> {
+private suspend fun parseFlowItems(
+    raw: String,
+    vm: ResourceViewModel,
+    resources: List<ResourceWithTagsCharacters>
+): List<FlowPreviewItem> {
     if (raw.isBlank()) return emptyList()
+    val resourceMap = resources.associateBy { it.resource.id }
     return runCatching {
         val array = JSONArray(raw)
         buildList {
@@ -541,6 +546,12 @@ private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<Flo
                 val obj = array.optJSONObject(i) ?: continue
                 val type = runCatching { ResourceType.valueOf(obj.optString("type")) }.getOrNull() ?: continue
                 val title = obj.optString("title").ifBlank { null }
+                val resourceId = obj.optLong("resourceId", -1L).takeIf { it > 0 }
+                val resource = resourceId?.let { id -> resourceMap[id] }
+                if (resource != null) {
+                    add(flowPreviewItemFromResource(resource, vm))
+                    continue
+                }
                 when (type) {
                     ResourceType.TEXT -> add(
                         FlowPreviewItem(type = type, title = title, text = obj.optString("text"))
@@ -606,6 +617,42 @@ private suspend fun parseFlowItems(raw: String, vm: ResourceViewModel): List<Flo
             }
         }
     }.getOrDefault(emptyList())
+}
+
+private suspend fun flowPreviewItemFromResource(
+    resource: ResourceWithTagsCharacters,
+    vm: ResourceViewModel
+): FlowPreviewItem {
+    val data = resource.resource
+    return when (data.type) {
+        ResourceType.TEXT -> FlowPreviewItem(
+            type = data.type,
+            title = data.title,
+            text = data.quoteText.orEmpty()
+        )
+        ResourceType.SCENE -> FlowPreviewItem(
+            type = data.type,
+            title = data.title,
+            sceneMessages = parseSceneMessages(data.sceneJson.orEmpty())
+        )
+        ResourceType.IMAGE -> FlowPreviewItem(
+            type = data.type,
+            title = data.title,
+            images = decodeImageSources(data.contentUriOrPath ?: data.quoteImageBase64, vm)
+        )
+        ResourceType.VIDEO -> {
+            val raw = data.contentUriOrPath
+            val paths = raw?.takeIf { it.isNotBlank() }?.let { parseMediaPaths(it) }.orEmpty()
+            val uriList = paths.mapNotNull { path -> path.takeIf { it.isNotBlank() }?.let(Uri::parse) }
+            FlowPreviewItem(
+                type = data.type,
+                title = data.title,
+                mediaUris = uriList,
+                mediaFailed = raw.isNullOrBlank() || (uriList.isEmpty() && raw.isNotBlank())
+            )
+        }
+        else -> FlowPreviewItem(type = data.type, title = data.title)
+    }
 }
 
 private fun typeLabel(type: ResourceType): String = when (type) {


### PR DESCRIPTION
### Motivation
- Ensure flow previews update immediately when referenced resources change so that editing images/videos/titles reflects in top-level flows without manual refresh. 
- Allow choosing different beep/tone styles for event countdowns using a numeric prefix after `++` (e.g. `++1[` or `++3[`), improving feedback for countdown events. 
- Clean up an unused import in the preview screen to remove a minor lint/compile issue.

### Description
- Make `ResourcePreviewScreen` observe `vm.allResources` and include it in the `LaunchedEffect` so flow preview parsing can resolve referenced resource IDs by passing `allResources` into `parseFlowItems`. 
- Extend `parseFlowItems` to accept `resources: List<ResourceWithTagsCharacters>` and, when a `resourceId` is present in a flow step, resolve it to an actual preview with the new helper `flowPreviewItemFromResource`. 
- In `ResourceScreen` add `LaunchedEffect(availableResources)` hooks in both create and edit flows and a `refreshFlowItemsFromResources` helper to refresh `flowItems` from the latest `availableResources` so upper-level flows update after resource changes. 
- Add tone selection support by extending `EventSequence` with a `toneIndex`, parse an optional leading number in `parseEventSequence` in `PreviewTextBlock`, and make `EventSequenceRunner` select the tone via `resolveTone` and call `toneGenerator.startTone` with the selected tone. 
- Remove the unused import `calculateTopPadding` from `ResourcePreviewScreen`.

### Testing
- No automated tests or CI jobs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970a04aed18832b83ecdb5c7f3ad605)