### PR TITLE
Adjust tag sorting, make tag selection dialogs compact/collapsible, and enlarge countdown overlay

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.clickable
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material.icons.Icons
@@ -28,6 +29,8 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -69,6 +72,7 @@ import com.example.quotepicker.ui.components.tagTextColor
 import com.example.quotepicker.ui.components.ResourceGridCard
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.SquareGridItem
+import com.example.quotepicker.ui.components.sortTagsForDisplay
 import com.example.quotepicker.vm.CharacterViewModel
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.launch
@@ -238,7 +242,7 @@ fun CharacterScreen(
                                             ResourceGridCard(
                                                 title = resource.resource.title,
                                                 typeLabel = typeLabel(resource.resource.type),
-                                                tags = resource.tags,
+                                                tags = sortTagsForDisplay(resource.tags, resourceUi.categories),
                                                 onClick = { previewTarget = resource },
                                                 onLongClick = {}
                                             )
@@ -379,7 +383,8 @@ private fun TagSummarySection(
     tags: List<TagEntity>,
     onEdit: () -> Unit
 ) {
-    val grouped = tags.groupBy { it.categoryId }
+    val sortedTags = sortTagsForDisplay(tags, categories)
+    val grouped = sortedTags.groupBy { it.categoryId }
     val categoryMap = categories.associateBy { it.id }
     Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp)) {
         Row(
@@ -405,7 +410,7 @@ private fun TagSummarySection(
                 Spacer(Modifier.height(8.dp))
             }
         }
-        val uncategorized = tags.filter { it.categoryId !in categoryMap.keys }
+        val uncategorized = sortedTags.filter { it.categoryId !in categoryMap.keys }
         if (uncategorized.isNotEmpty()) {
             Text("未分类", style = MaterialTheme.typography.labelMedium)
             FlowRow(
@@ -525,26 +530,98 @@ private fun TagSelectionSection(
     selected: Set<Long>,
     onChange: (Set<Long>) -> Unit
 ) {
-    val grouped = tags.groupBy { it.categoryId }
+    val sortedTags = sortTagsForDisplay(tags, categories)
+    val grouped = sortedTags.groupBy { it.categoryId }
     val knownCategoryIds = categories.map { it.id }.toSet()
-    val uncategorized = tags.filter { it.categoryId !in knownCategoryIds }
+    val uncategorized = sortedTags.filter { it.categoryId !in knownCategoryIds }
+    val expandedState = remember(categories) {
+        mutableStateOf(categories.associate { it.id to true }.toMutableMap())
+    }
+    var uncategorizedExpanded by remember { mutableStateOf(true) }
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .heightIn(max = 360.dp)
             .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(4.dp)
     ) {
         Text(label)
         categories.forEach { category ->
             val items = grouped[category.id].orEmpty()
             if (items.isNotEmpty()) {
-                Text(category.name, style = MaterialTheme.typography.labelMedium)
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                val isExpanded = expandedState.value[category.id] ?: true
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            expandedState.value = expandedState.value.toMutableMap().apply {
+                                put(category.id, !isExpanded)
+                            }
+                        },
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    items.forEach { tag ->
+                    Text(category.name, style = MaterialTheme.typography.labelMedium)
+                    Spacer(Modifier.width(6.dp))
+                    Icon(
+                        imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                        contentDescription = null
+                    )
+                }
+                if (isExpanded) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        items.forEach { tag ->
+                            val isSelected = selected.contains(tag.id)
+                            val tagColor = Color(tag.colorArgb)
+                            val selectedTextColor = tagTextColor(tagColor)
+                            FilterChip(
+                                selected = isSelected,
+                                onClick = {
+                                    val newSet = selected.toMutableSet()
+                                    if (isSelected) newSet.remove(tag.id) else newSet.add(tag.id)
+                                    onChange(newSet)
+                                },
+                                label = {
+                                    Text(
+                                        text = tag.name,
+                                        maxLines = 1,
+                                        overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+                                    )
+                                },
+                                colors = FilterChipDefaults.filterChipColors(
+                                    containerColor = tagColor.copy(alpha = 0.2f),
+                                    selectedContainerColor = tagColor,
+                                    labelColor = MaterialTheme.colorScheme.onSurface,
+                                    selectedLabelColor = selectedTextColor
+                                )
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        if (uncategorized.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { uncategorizedExpanded = !uncategorizedExpanded },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("未分类", style = MaterialTheme.typography.labelMedium)
+                Spacer(Modifier.width(6.dp))
+                Icon(
+                    imageVector = if (uncategorizedExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                    contentDescription = null
+                )
+            }
+            if (uncategorizedExpanded) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    uncategorized.forEach { tag ->
                         val isSelected = selected.contains(tag.id)
                         val tagColor = Color(tag.colorArgb)
                         val selectedTextColor = tagTextColor(tagColor)
@@ -570,40 +647,6 @@ private fun TagSelectionSection(
                             )
                         )
                     }
-                }
-            }
-        }
-        if (uncategorized.isNotEmpty()) {
-            Text("未分类", style = MaterialTheme.typography.labelMedium)
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                uncategorized.forEach { tag ->
-                    val isSelected = selected.contains(tag.id)
-                    val tagColor = Color(tag.colorArgb)
-                    val selectedTextColor = tagTextColor(tagColor)
-                    FilterChip(
-                        selected = isSelected,
-                        onClick = {
-                            val newSet = selected.toMutableSet()
-                            if (isSelected) newSet.remove(tag.id) else newSet.add(tag.id)
-                            onChange(newSet)
-                        },
-                        label = {
-                            Text(
-                                text = tag.name,
-                                maxLines = 1,
-                                overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
-                            )
-                        },
-                        colors = FilterChipDefaults.filterChipColors(
-                            containerColor = tagColor.copy(alpha = 0.2f),
-                            selectedContainerColor = tagColor,
-                            labelColor = MaterialTheme.colorScheme.onSurface,
-                            selectedLabelColor = selectedTextColor
-                        )
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.clickable
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
@@ -24,6 +25,8 @@ import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Casino
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material.icons.filled.Visibility
@@ -42,6 +45,7 @@ import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.CharacterBadge
 import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.ui.components.PreviewTextBlock
+import com.example.quotepicker.ui.components.sortTagsForDisplay
 import com.example.quotepicker.ui.components.rememberEventSequenceRunner
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.TagCategoryEntity
@@ -102,7 +106,10 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
                     Text("未选择标签")
                 } else {
                     FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        ui.tags.filter { ui.selectedTagIds.contains(it.id) }.forEach { tag ->
+                        sortTagsForDisplay(
+                            ui.tags.filter { ui.selectedTagIds.contains(it.id) },
+                            ui.categories
+                        ).forEach { tag ->
                             TagBadge(tag = tag)
                         }
                     }
@@ -154,21 +161,16 @@ fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(
             }
         }
         if (eventRunner.overlayText != null) {
-            androidx.compose.material3.Card(
+            Text(
+                text = eventRunner.overlayText.orEmpty(),
                 modifier = Modifier
                     .align(Alignment.TopCenter)
                     .padding(top = 24.dp),
-                colors = androidx.compose.material3.CardDefaults.cardColors(
-                    containerColor = androidx.compose.material3.MaterialTheme.colorScheme.surfaceVariant
-                )
-            ) {
-                Text(
-                    text = eventRunner.overlayText.orEmpty(),
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                    style = androidx.compose.material3.MaterialTheme.typography.titleMedium,
-                    color = androidx.compose.material3.MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
+                style = androidx.compose.material3.MaterialTheme.typography.titleMedium.copy(
+                    fontSize = androidx.compose.material3.MaterialTheme.typography.titleMedium.fontSize * 2
+                ),
+                color = androidx.compose.ui.graphics.Color.Red
+            )
         }
     }
 
@@ -201,7 +203,7 @@ private fun TagPickerDialog(
                     .fillMaxWidth()
                     .heightIn(max = 360.dp)
                     .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 TagSelectionSection(
                     categories = categories,
@@ -226,40 +228,78 @@ private fun TagSelectionSection(
     selected: Set<Long>,
     onChange: (Set<Long>) -> Unit
 ) {
-    val grouped = tags.groupBy { it.categoryId }
+    val sortedTags = sortTagsForDisplay(tags, categories)
+    val grouped = sortedTags.groupBy { it.categoryId }
     val knownCategoryIds = categories.map { it.id }.toSet()
-    val uncategorized = tags.filter { it.categoryId !in knownCategoryIds }
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    val uncategorized = sortedTags.filter { it.categoryId !in knownCategoryIds }
+    val expandedState = remember(categories) {
+        mutableStateOf(categories.associate { it.id to true }.toMutableMap())
+    }
+    var uncategorizedExpanded by remember { mutableStateOf(true) }
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         categories.forEach { category ->
             val items = grouped[category.id].orEmpty()
             if (items.isNotEmpty()) {
-                Text(category.name)
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                val isExpanded = expandedState.value[category.id] ?: true
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            expandedState.value = expandedState.value.toMutableMap().apply {
+                                put(category.id, !isExpanded)
+                            }
+                        },
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    items.forEach { tag ->
+                    Text(category.name)
+                    Spacer(Modifier.width(6.dp))
+                    Icon(
+                        imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                        contentDescription = null
+                    )
+                }
+                if (isExpanded) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        items.forEach { tag ->
+                            TagFilterChip(
+                                tag = tag,
+                                selected = selected,
+                                onChange = onChange
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        if (uncategorized.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { uncategorizedExpanded = !uncategorizedExpanded },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("未分类")
+                Spacer(Modifier.width(6.dp))
+                Icon(
+                    imageVector = if (uncategorizedExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                    contentDescription = null
+                )
+            }
+            if (uncategorizedExpanded) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    uncategorized.forEach { tag ->
                         TagFilterChip(
                             tag = tag,
                             selected = selected,
                             onChange = onChange
                         )
                     }
-                }
-            }
-        }
-        if (uncategorized.isNotEmpty()) {
-            Text("未分类")
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                uncategorized.forEach { tag ->
-                    TagFilterChip(
-                        tag = tag,
-                        selected = selected,
-                        onChange = onChange
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -83,6 +83,7 @@ import com.example.quotepicker.ui.components.CharacterBadge
 import com.example.quotepicker.ui.components.ResourceGridCard
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.TagBadge
+import com.example.quotepicker.ui.components.sortTagsForDisplay
 import com.example.quotepicker.ui.components.tagTextColor
 import com.example.quotepicker.vm.FlowUpdateItem
 import com.example.quotepicker.vm.ImageUpdateItem
@@ -222,7 +223,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                         ResourceGridCard(
                             title = res.resource.title,
                             typeLabel = typeLabel(res.resource.type),
-                            tags = res.tags,
+                            tags = sortTagsForDisplay(res.tags, ui.categories),
                             onClick = { previewTarget = res },
                             onLongClick = { bottomSheetTarget = res }
                         )
@@ -582,7 +583,7 @@ private fun FilterTagDialog(
                     .fillMaxWidth()
                     .heightIn(max = 360.dp)
                     .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 TagSelectionSection(
                     label = "标签",
@@ -1745,7 +1746,7 @@ private fun TagPickerDialog(
                     .fillMaxWidth()
                     .heightIn(max = 360.dp)
                     .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(4.dp)
             ) {
                 TagSelectionSection(
                     label = "标签",
@@ -1820,41 +1821,81 @@ private fun TagSelectionSection(
     selected: Set<Long>,
     onChange: (Set<Long>) -> Unit
 ) {
-    val grouped = tags.groupBy { it.categoryId }
+    val sortedTags = sortTagsForDisplay(tags, categories)
+    val grouped = sortedTags.groupBy { it.categoryId }
     val knownCategoryIds = categories.map { it.id }.toSet()
-    val uncategorized = tags.filter { it.categoryId !in knownCategoryIds }
-    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+    val uncategorized = sortedTags.filter { it.categoryId !in knownCategoryIds }
+    val expandedState = remember(categories) {
+        mutableStateOf(
+            categories.associate { it.id to true }.toMutableMap()
+        )
+    }
+    var uncategorizedExpanded by remember { mutableStateOf(true) }
+    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
         Text(label)
         categories.forEach { category ->
             val items = grouped[category.id].orEmpty()
             if (items.isNotEmpty()) {
-                Text(category.name, style = MaterialTheme.typography.labelMedium)
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                val isExpanded = expandedState.value[category.id] ?: true
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            expandedState.value = expandedState.value.toMutableMap().apply {
+                                put(category.id, !isExpanded)
+                            }
+                        },
+                    verticalAlignment = Alignment.CenterVertically
                 ) {
-                    items.forEach { tag ->
+                    Text(category.name, style = MaterialTheme.typography.labelMedium)
+                    Spacer(Modifier.width(6.dp))
+                    Icon(
+                        imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                        contentDescription = null
+                    )
+                }
+                if (isExpanded) {
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(4.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        items.forEach { tag ->
+                            TagFilterChip(
+                                tag = tag,
+                                selected = selected,
+                                onChange = onChange
+                            )
+                        }
+                    }
+                }
+            }
+        }
+        if (uncategorized.isNotEmpty()) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clickable { uncategorizedExpanded = !uncategorizedExpanded },
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text("未分类", style = MaterialTheme.typography.labelMedium)
+                Spacer(Modifier.width(6.dp))
+                Icon(
+                    imageVector = if (uncategorizedExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+                    contentDescription = null
+                )
+            }
+            if (uncategorizedExpanded) {
+                FlowRow(
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    uncategorized.forEach { tag ->
                         TagFilterChip(
                             tag = tag,
                             selected = selected,
                             onChange = onChange
                         )
                     }
-                }
-            }
-        }
-        if (uncategorized.isNotEmpty()) {
-            Text("未分类", style = MaterialTheme.typography.labelMedium)
-            FlowRow(
-                horizontalArrangement = Arrangement.spacedBy(8.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                uncategorized.forEach { tag ->
-                    TagFilterChip(
-                        tag = tag,
-                        selected = selected,
-                        onChange = onChange
-                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -60,6 +60,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.ui.components.TagBadge
+import com.example.quotepicker.ui.components.sortTagsForDisplay
 import com.example.quotepicker.vm.ResourceViewModel
 import org.json.JSONArray
 
@@ -96,6 +97,9 @@ fun ResourcePreviewScreen(
     val scrollState = rememberScrollState()
     val uiState by vm.uiState.collectAsState()
     val allResources by vm.allResources.collectAsState()
+    val sortedTags = remember(resource.tags, uiState.categories) {
+        sortTagsForDisplay(resource.tags, uiState.categories)
+    }
     val highlightedSpeaker = uiState.filters.selectedCharacterId?.let { id ->
         uiState.characters.firstOrNull { it.id == id }?.name
     }
@@ -169,12 +173,12 @@ fun ResourcePreviewScreen(
                 )
                 if (resource.resource.type != ResourceType.FLOW) {
                     ResourceMetaRow(label = "标签") {
-                        if (resource.tags.isNotEmpty()) {
+                        if (sortedTags.isNotEmpty()) {
                             FlowRow(
                                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                                 verticalArrangement = Arrangement.spacedBy(6.dp)
                             ) {
-                                resource.tags.forEach { tag ->
+                                sortedTags.forEach { tag ->
                                     TagBadge(tag = tag)
                                 }
                             }
@@ -313,19 +317,14 @@ fun ResourcePreviewScreen(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.TopCenter
                 ) {
-                    Card(
+                    Text(
+                        text = eventRunner.overlayText.orEmpty(),
                         modifier = Modifier.padding(top = inner.calculateTopPadding() + 24.dp),
-                        colors = androidx.compose.material3.CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.surfaceVariant
-                        )
-                    ) {
-                        Text(
-                            text = eventRunner.overlayText.orEmpty(),
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
-                            style = MaterialTheme.typography.titleMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }
+                        style = MaterialTheme.typography.titleMedium.copy(
+                            fontSize = MaterialTheme.typography.titleMedium.fontSize * 2
+                        ),
+                        color = Color.Red
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/quotepicker/ui/components/TagSort.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/TagSort.kt
@@ -1,0 +1,13 @@
+package com.example.quotepicker.ui.components
+
+import com.example.quotepicker.data.TagCategoryEntity
+import com.example.quotepicker.data.TagEntity
+
+fun sortTagsForDisplay(tags: List<TagEntity>, categories: List<TagCategoryEntity>): List<TagEntity> {
+    val categoryOrder = categories.mapIndexed { index, category -> category.id to index }.toMap()
+    return tags.sortedWith(
+        compareBy<TagEntity> { categoryOrder[it.categoryId] ?: Int.MAX_VALUE }
+            .thenBy { it.colorArgb }
+            .thenBy { it.name.lowercase() }
+    )
+}


### PR DESCRIPTION
### Motivation
- Ensure tag lists are presented consistently by category, then color, then name so previews and pickers are more predictable.  
- Make tag selection dialogs denser and easier to scan by reducing spacing and allowing categories to be collapsed.  
- Make countdown overlay text and numbers more visible by enlarging them and removing the background, with a red color for emphasis.

### Description
- Add a shared sorting helper `sortTagsForDisplay` in `app/src/main/java/com/example/quotepicker/ui/components/TagSort.kt` that orders tags by category order, then `colorArgb`, then lowercase `name`.  
- Apply `sortTagsForDisplay` to tag displays in `ResourceScreen.kt`, `ResourcePreviewScreen.kt`, `CharacterScreen.kt`, and `RandomScreen.kt` so grids, previews, and selected-badge lists use the new ordering.  
- Make tag selection UIs more compact by changing spacing from `8.dp` to `4.dp` and add collapsible category headers in `TagSelectionSection` (used by the various tag picker/dialog implementations).  
- Restyle the event/countdown overlay in `RandomScreen.kt` and `ResourcePreviewScreen.kt` to render larger, red text without a card background (font size multiplied by 2 and color set to red).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697161efec44832b9723cd5d01edc50b)