### PR TITLE
Add execution flow, character points/probabilities and sound resources

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
@@ -29,9 +29,11 @@ class Converters {
         ResourceEntity::class,
         ResourceTagCrossRef::class,
         CharacterTagCrossRef::class,
-        ResourceCharacterCrossRef::class
+        ResourceCharacterCrossRef::class,
+        ResponseRecordEntity::class,
+        ExecutionSettingsEntity::class
     ],
-    version = 3,
+    version = 4,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -41,6 +43,8 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun characterDao(): CharacterDao
     abstract fun resourceDao(): ResourceDao
     abstract fun crossRefDao(): CrossRefDao
+    abstract fun responseRecordDao(): ResponseRecordDao
+    abstract fun executionSettingsDao(): ExecutionSettingsDao
 
     companion object {
         @Volatile private var INSTANCE: AppDatabase? = null

--- a/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
+++ b/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
@@ -11,13 +11,15 @@ data class BackupSnapshot(
     val resourceTagRefs: List<ResourceTagCrossRef>,
     val characterTagRefs: List<CharacterTagCrossRef>,
     val resourceCharacterRefs: List<ResourceCharacterCrossRef>,
+    val responseRecords: List<ResponseRecordEntity> = emptyList(),
+    val executionSettings: ExecutionSettingsEntity? = null,
     val media: List<MediaBackupItem> = emptyList()
 ) {
     fun toJsonString(): String = toJson().toString()
 
     fun toJson(): JSONObject {
         return JSONObject().apply {
-            put("version", 3)
+            put("version", 4)
             put("categories", JSONArray(categories.map(::categoryToJson)))
             put("tags", JSONArray(tags.map(::tagToJson)))
             put("characters", JSONArray(characters.map(::characterToJson)))
@@ -25,6 +27,8 @@ data class BackupSnapshot(
             put("resourceTagRefs", JSONArray(resourceTagRefs.map(::resourceTagToJson)))
             put("characterTagRefs", JSONArray(characterTagRefs.map(::characterTagToJson)))
             put("resourceCharacterRefs", JSONArray(resourceCharacterRefs.map(::resourceCharacterToJson)))
+            put("responseRecords", JSONArray(responseRecords.map(::responseRecordToJson)))
+            executionSettings?.let { put("executionSettings", executionSettingsToJson(it)) }
             put("media", JSONArray(media.map(::mediaToJson)))
         }
     }
@@ -40,6 +44,8 @@ data class BackupSnapshot(
                 resourceTagRefs = parseArray(obj, "resourceTagRefs", ::resourceTagFromJson),
                 characterTagRefs = parseArray(obj, "characterTagRefs", ::characterTagFromJson),
                 resourceCharacterRefs = parseArray(obj, "resourceCharacterRefs", ::resourceCharacterFromJson),
+                responseRecords = parseArray(obj, "responseRecords", ::responseRecordFromJson),
+                executionSettings = obj.optJSONObject("executionSettings")?.let(::executionSettingsFromJson),
                 media = parseArray(obj, "media", ::mediaFromJson)
             )
         }
@@ -75,6 +81,9 @@ private fun characterToJson(character: CharacterEntity): JSONObject =
         .put("id", character.id)
         .put("name", character.name)
         .put("description", character.description)
+        .put("points", character.points)
+        .put("probability", character.probability)
+        .put("probabilityDate", character.probabilityDate)
         .put("createdAt", character.createdAt)
         .put("updatedAt", character.updatedAt)
 
@@ -104,6 +113,22 @@ private fun resourceCharacterToJson(ref: ResourceCharacterCrossRef): JSONObject 
     JSONObject()
         .put("resourceId", ref.resourceId)
         .put("characterId", ref.characterId)
+
+private fun responseRecordToJson(record: ResponseRecordEntity): JSONObject =
+    JSONObject()
+        .put("characterId", record.characterId)
+        .put("tagId", record.tagId)
+        .put("count", record.count)
+        .put("createdAt", record.createdAt)
+
+private fun executionSettingsToJson(settings: ExecutionSettingsEntity): JSONObject =
+    JSONObject()
+        .put("id", settings.id)
+        .put("buttonLabel", settings.buttonLabel)
+        .put("successToast", settings.successToast)
+        .put("failureToast", settings.failureToast)
+        .put("createdAt", settings.createdAt)
+        .put("updatedAt", settings.updatedAt)
 
 private fun mediaToJson(item: MediaBackupItem): JSONObject =
     JSONObject().apply {
@@ -137,6 +162,9 @@ private fun characterFromJson(obj: JSONObject): CharacterEntity =
         id = obj.getLong("id"),
         name = obj.getString("name"),
         description = readNullableString(obj, "description"),
+        points = obj.optInt("points", 30),
+        probability = obj.optInt("probability", 1),
+        probabilityDate = readNullableString(obj, "probabilityDate"),
         createdAt = obj.getLong("createdAt"),
         updatedAt = obj.getLong("updatedAt")
     )
@@ -170,6 +198,24 @@ private fun resourceCharacterFromJson(obj: JSONObject): ResourceCharacterCrossRe
     ResourceCharacterCrossRef(
         resourceId = obj.getLong("resourceId"),
         characterId = obj.getLong("characterId")
+    )
+
+private fun responseRecordFromJson(obj: JSONObject): ResponseRecordEntity =
+    ResponseRecordEntity(
+        characterId = obj.getLong("characterId"),
+        tagId = obj.getLong("tagId"),
+        count = obj.optInt("count", 1),
+        createdAt = obj.optLong("createdAt", System.currentTimeMillis())
+    )
+
+private fun executionSettingsFromJson(obj: JSONObject): ExecutionSettingsEntity =
+    ExecutionSettingsEntity(
+        id = obj.optLong("id", 1),
+        buttonLabel = obj.optString("buttonLabel", "祈求"),
+        successToast = obj.optString("successToast", "[]赐予了你[]"),
+        failureToast = obj.optString("failureToast", "[]无视了你"),
+        createdAt = obj.optLong("createdAt", System.currentTimeMillis()),
+        updatedAt = obj.optLong("updatedAt", System.currentTimeMillis())
     )
 
 private fun mediaFromJson(obj: JSONObject): MediaBackupItem =

--- a/app/src/main/java/com/example/quotepicker/data/Dao.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Dao.kt
@@ -3,6 +3,7 @@ package com.example.quotepicker.data
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Insert
+import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Transaction
 import androidx.room.Update
@@ -167,4 +168,40 @@ interface CrossRefDao {
 
     @Query("DELETE FROM resource_character_cross_ref")
     suspend fun deleteAllResourceCharacters()
+}
+
+@Dao
+interface ResponseRecordDao {
+    @Query("SELECT * FROM response_records")
+    fun observeRecords(): Flow<List<ResponseRecordEntity>>
+
+    @Query("SELECT * FROM response_records")
+    suspend fun listAll(): List<ResponseRecordEntity>
+
+    @Query("SELECT * FROM response_records WHERE characterId = :characterId AND tagId = :tagId LIMIT 1")
+    suspend fun findRecord(characterId: Long, tagId: Long): ResponseRecordEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(record: ResponseRecordEntity)
+
+    @Query("DELETE FROM response_records WHERE characterId = :characterId AND tagId = :tagId")
+    suspend fun deleteRecord(characterId: Long, tagId: Long)
+
+    @Query("DELETE FROM response_records")
+    suspend fun deleteAll()
+}
+
+@Dao
+interface ExecutionSettingsDao {
+    @Query("SELECT * FROM execution_settings WHERE id = 1 LIMIT 1")
+    fun observeSettings(): Flow<ExecutionSettingsEntity?>
+
+    @Query("SELECT * FROM execution_settings WHERE id = 1 LIMIT 1")
+    suspend fun getSettings(): ExecutionSettingsEntity?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(settings: ExecutionSettingsEntity)
+
+    @Query("DELETE FROM execution_settings")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/example/quotepicker/data/Entities.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Entities.kt
@@ -6,7 +6,7 @@ import androidx.room.Index
 import androidx.room.PrimaryKey
 import androidx.room.Relation
 
-enum class ResourceType { FLOW, TEXT, IMAGE, VIDEO, SCENE }
+enum class ResourceType { FLOW, TEXT, IMAGE, VIDEO, SOUND, SCENE }
 
 enum class TagCategoryType { CHARACTER, RESOURCE }
 
@@ -43,6 +43,30 @@ data class CharacterEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val name: String,
     val description: String? = null,
+    val points: Int = 30,
+    val probability: Int = 1,
+    val probabilityDate: String? = null,
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis()
+)
+
+@Entity(
+    tableName = "response_records",
+    primaryKeys = ["characterId", "tagId"]
+)
+data class ResponseRecordEntity(
+    val characterId: Long,
+    val tagId: Long,
+    val count: Int = 1,
+    val createdAt: Long = System.currentTimeMillis()
+)
+
+@Entity(tableName = "execution_settings")
+data class ExecutionSettingsEntity(
+    @PrimaryKey val id: Long = 1,
+    val buttonLabel: String = "祈求",
+    val successToast: String = "[]赐予了你[]",
+    val failureToast: String = "[]无视了你",
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis()
 )

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Base64
 import java.io.File
+import java.time.LocalDate
 import org.json.JSONArray
 import kotlinx.coroutines.flow.Flow
 
@@ -15,6 +16,8 @@ class Repository private constructor(context: Context) {
     private val characterDao = db.characterDao()
     private val resourceDao = db.resourceDao()
     private val crossRefDao = db.crossRefDao()
+    private val responseRecordDao = db.responseRecordDao()
+    private val executionSettingsDao = db.executionSettingsDao()
 
     fun observeCategories(): Flow<List<TagCategoryEntity>> = categoryDao.observeCategories()
     fun observeTagsByCategory(categoryId: Long): Flow<List<TagEntity>> = tagDao.observeTagsByCategory(categoryId)
@@ -25,6 +28,8 @@ class Repository private constructor(context: Context) {
     fun observeCharactersWithTags(): Flow<List<CharacterWithTags>> = characterDao.observeCharactersWithTags()
     fun observeResources(): Flow<List<ResourceEntity>> = resourceDao.observeResources()
     fun observeResourcesWithRelations(): Flow<List<ResourceWithTagsCharacters>> = resourceDao.observeResourcesWithRelations()
+    fun observeResponseRecords(): Flow<List<ResponseRecordEntity>> = responseRecordDao.observeRecords()
+    fun observeExecutionSettings(): Flow<ExecutionSettingsEntity?> = executionSettingsDao.observeSettings()
 
     data class ExportPackage(
         val snapshot: BackupSnapshot,
@@ -54,6 +59,8 @@ class Repository private constructor(context: Context) {
             resourceTagRefs = crossRefDao.listResourceTags(),
             characterTagRefs = crossRefDao.listCharacterTags(),
             resourceCharacterRefs = crossRefDao.listResourceCharacters(),
+            responseRecords = responseRecordDao.listAll(),
+            executionSettings = executionSettingsDao.getSettings(),
             media = mediaItems
         )
         return ExportPackage(snapshot = snapshot, mediaPayloads = mediaPayloads)
@@ -64,7 +71,8 @@ class Repository private constructor(context: Context) {
         val restoredResources = snapshot.resources.map { resource ->
             when (resource.type) {
                 ResourceType.IMAGE,
-                ResourceType.VIDEO -> resource.copy(
+                ResourceType.VIDEO,
+                ResourceType.SOUND -> resource.copy(
                     contentUriOrPath = replacePathsInPayload(resource.contentUriOrPath, mediaMapping)
                 )
                 ResourceType.FLOW -> resource.copy(
@@ -73,6 +81,8 @@ class Repository private constructor(context: Context) {
                 else -> resource
             }
         }
+        responseRecordDao.deleteAll()
+        executionSettingsDao.deleteAll()
         crossRefDao.deleteAllResourceTags()
         crossRefDao.deleteAllCharacterTags()
         crossRefDao.deleteAllResourceCharacters()
@@ -87,6 +97,10 @@ class Repository private constructor(context: Context) {
         if (snapshot.resourceTagRefs.isNotEmpty()) crossRefDao.insertResourceTags(snapshot.resourceTagRefs)
         if (snapshot.characterTagRefs.isNotEmpty()) crossRefDao.insertCharacterTags(snapshot.characterTagRefs)
         if (snapshot.resourceCharacterRefs.isNotEmpty()) crossRefDao.insertResourceCharacters(snapshot.resourceCharacterRefs)
+        if (snapshot.responseRecords.isNotEmpty()) {
+            snapshot.responseRecords.forEach { responseRecordDao.upsert(it) }
+        }
+        snapshot.executionSettings?.let { executionSettingsDao.upsert(it) }
     }
 
     suspend fun addCategory(name: String, type: TagCategoryType) =
@@ -114,7 +128,14 @@ class Repository private constructor(context: Context) {
     suspend fun updateTag(tag: TagEntity) = tagDao.update(tag.copy(updatedAt = System.currentTimeMillis()))
     suspend fun deleteTag(tag: TagEntity) = tagDao.delete(tag)
 
-    suspend fun addCharacter(name: String) = characterDao.insert(CharacterEntity(name = name))
+    suspend fun addCharacter(name: String) = characterDao.insert(
+        CharacterEntity(
+            name = name,
+            points = 30,
+            probability = (1..10).random(),
+            probabilityDate = currentDateString()
+        )
+    )
     suspend fun updateCharacter(character: CharacterEntity) =
         characterDao.update(character.copy(updatedAt = System.currentTimeMillis()))
 
@@ -156,6 +177,75 @@ class Repository private constructor(context: Context) {
     suspend fun resourceIdsForCharacter(characterId: Long) = crossRefDao.resourceIdsForCharacter(characterId)
     suspend fun resourceIdsForTags(tagIds: List<Long>) = crossRefDao.resourceIdsForTags(tagIds)
 
+    suspend fun updateCharacterPoints(characterId: Long, points: Int) {
+        val characters = characterDao.listAll()
+        val target = characters.firstOrNull { it.id == characterId } ?: return
+        characterDao.update(target.copy(points = points.coerceIn(0, 30), updatedAt = System.currentTimeMillis()))
+    }
+
+    suspend fun updateCharacterProbability(characterId: Long, probability: Int, date: String) {
+        val characters = characterDao.listAll()
+        val target = characters.firstOrNull { it.id == characterId } ?: return
+        characterDao.update(
+            target.copy(
+                probability = probability.coerceIn(1, 10),
+                probabilityDate = date,
+                updatedAt = System.currentTimeMillis()
+            )
+        )
+    }
+
+    suspend fun refreshDailyProbabilities() {
+        val today = currentDateString()
+        val characters = characterDao.listAll()
+        characters.forEach { character ->
+            if (character.probabilityDate != today) {
+                characterDao.update(
+                    character.copy(
+                        probability = (1..10).random(),
+                        probabilityDate = today,
+                        updatedAt = System.currentTimeMillis()
+                    )
+                )
+            }
+        }
+    }
+
+    suspend fun ensureExecutionSettings(): ExecutionSettingsEntity {
+        val existing = executionSettingsDao.getSettings()
+        if (existing != null) return existing
+        val settings = ExecutionSettingsEntity()
+        executionSettingsDao.upsert(settings)
+        return settings
+    }
+
+    suspend fun updateExecutionSettings(settings: ExecutionSettingsEntity) {
+        executionSettingsDao.upsert(settings.copy(updatedAt = System.currentTimeMillis()))
+    }
+
+    suspend fun addResponseRecord(characterId: Long, tagId: Long, count: Int = 1) {
+        val existing = responseRecordDao.findRecord(characterId, tagId)
+        val nextCount = (existing?.count ?: 0) + count
+        responseRecordDao.upsert(
+            ResponseRecordEntity(
+                characterId = characterId,
+                tagId = tagId,
+                count = nextCount,
+                createdAt = existing?.createdAt ?: System.currentTimeMillis()
+            )
+        )
+    }
+
+    suspend fun consumeResponseRecord(characterId: Long, tagId: Long) {
+        val existing = responseRecordDao.findRecord(characterId, tagId) ?: return
+        val nextCount = existing.count - 1
+        if (nextCount <= 0) {
+            responseRecordDao.deleteRecord(characterId, tagId)
+        } else {
+            responseRecordDao.upsert(existing.copy(count = nextCount))
+        }
+    }
+
     private fun collectMediaPaths(resources: List<ResourceEntity>): List<Pair<String, ResourceType>> {
         val unique = linkedSetOf<Pair<String, ResourceType>>()
         resources.forEach { resource ->
@@ -166,6 +256,11 @@ class Repository private constructor(context: Context) {
                     }
                 }
                 ResourceType.VIDEO -> {
+                    parseMediaPaths(resource.contentUriOrPath).forEach { path ->
+                        unique.add(path to resource.type)
+                    }
+                }
+                ResourceType.SOUND -> {
                     parseMediaPaths(resource.contentUriOrPath).forEach { path ->
                         unique.add(path to resource.type)
                     }
@@ -299,6 +394,7 @@ class Repository private constructor(context: Context) {
             val folder = when (item.type) {
                 ResourceType.IMAGE -> "images"
                 ResourceType.VIDEO -> "videos"
+                ResourceType.SOUND -> "audio"
                 else -> "media"
             }
             val dir = File(appContext.filesDir, folder).apply { mkdirs() }
@@ -387,6 +483,8 @@ class Repository private constructor(context: Context) {
             array.toString()
         }.getOrDefault(payload)
     }
+
+    private fun currentDateString(): String = LocalDate.now().toString()
 
     companion object {
         const val ORPHAN_CATEGORY_NAME = "未分类"

--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -48,6 +48,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Button
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -60,12 +61,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.CharacterWithTags
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
+import com.example.quotepicker.ui.components.PreviewTextBlock
 import com.example.quotepicker.ui.components.NameDialog
 import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.ui.components.tagTextColor
@@ -76,6 +79,7 @@ import com.example.quotepicker.ui.components.sortTagsForDisplay
 import com.example.quotepicker.vm.CharacterViewModel
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.launch
+import android.widget.Toast
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -98,8 +102,9 @@ fun CharacterScreen(
     var selectedTagIds by remember { mutableStateOf(setOf<Long>()) }
     var selectedType by remember { mutableStateOf<ResourceType?>(null) }
     var previewTarget by remember { mutableStateOf<com.example.quotepicker.data.ResourceWithTagsCharacters?>(null) }
-    val pagerState = rememberPagerState(pageCount = { 2 })
+    val pagerState = rememberPagerState(pageCount = { 3 })
     val pagerScope = rememberCoroutineScope()
+    val context = LocalContext.current
     val importPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri != null) {
             vm.importSnapshot(uri)
@@ -175,6 +180,20 @@ fun CharacterScreen(
                         items(ui.characters, key = { it.character.id }) { character ->
                             SquareGridItem(
                                 title = character.character.name,
+                                bottomContent = {
+                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                        Text(
+                                            text = character.character.points.toString(),
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = Color(0xFF2E7D32)
+                                        )
+                                        Text(
+                                            text = "${character.character.probability}%",
+                                            style = MaterialTheme.typography.labelSmall,
+                                            color = Color(0xFF1565C0)
+                                        )
+                                    }
+                                },
                                 onClick = { selectedId = character.character.id },
                                 onLongClick = { bottomSheetTarget = character }
                             )
@@ -190,8 +209,18 @@ fun CharacterScreen(
                     val tagMatch = if (selectedTagIds.isEmpty()) true else res.tags.any { selectedTagIds.contains(it.id) }
                     typeMatch && tagMatch
                 }
+                val narrativeCategory = resourceUi.categories.firstOrNull { it.name == "叙事类别" }
+                val narrativeTags = narrativeCategory?.let { category ->
+                    resourceUi.tags.filter { it.categoryId == category.id }
+                }.orEmpty()
+                val introCandidates = resources.filter { res ->
+                    res.characters.any { c -> c.id == char.id } &&
+                        res.resource.type == ResourceType.TEXT &&
+                        res.resource.title.take(2) == "要点"
+                }
+                val introText = introCandidates.firstOrNull()?.resource?.quoteText.orEmpty()
                 TabRow(selectedTabIndex = pagerState.currentPage) {
-                    listOf("标签", "资源").forEachIndexed { index, title ->
+                    listOf("标签", "要点", "资源").forEachIndexed { index, title ->
                         Tab(
                             selected = pagerState.currentPage == index,
                             onClick = { pagerScope.launch { pagerState.animateScrollToPage(index) } },
@@ -218,6 +247,83 @@ fun CharacterScreen(
                             }
                         }
                         1 -> {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .verticalScroll(rememberScrollState())
+                                    .padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(12.dp)
+                            ) {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Button(onClick = {
+                                        val current = char
+                                        if (current.points <= 0) {
+                                            vm.updateCharacterPoints(current.id, 30)
+                                            val fallbackTag = narrativeTags.firstOrNull()
+                                            if (fallbackTag != null) {
+                                                vm.addResponseRecord(current.id, fallbackTag.id, count = 3)
+                                                Toast.makeText(
+                                                    context,
+                                                    fillTemplate(
+                                                        ui.executionSettings.successToast,
+                                                        listOf(current.name, fallbackTag.name)
+                                                    ),
+                                                    Toast.LENGTH_SHORT
+                                                ).show()
+                                            } else {
+                                                Toast.makeText(context, "未找到叙事类别标签", Toast.LENGTH_SHORT).show()
+                                            }
+                                        } else {
+                                            vm.updateCharacterPoints(current.id, current.points - 1)
+                                            val hit = (1..100).random() <= current.probability
+                                            if (hit) {
+                                                val pick = narrativeTags.randomOrNull()
+                                                if (pick != null) {
+                                                    vm.addResponseRecord(current.id, pick.id)
+                                                    Toast.makeText(
+                                                        context,
+                                                        fillTemplate(
+                                                            ui.executionSettings.successToast,
+                                                            listOf(current.name, pick.name)
+                                                        ),
+                                                        Toast.LENGTH_SHORT
+                                                    ).show()
+                                                } else {
+                                                    Toast.makeText(context, "未找到叙事类别标签", Toast.LENGTH_SHORT).show()
+                                                }
+                                            } else {
+                                                Toast.makeText(
+                                                    context,
+                                                    fillTemplate(ui.executionSettings.failureToast, listOf(current.name)),
+                                                    Toast.LENGTH_SHORT
+                                                ).show()
+                                            }
+                                        }
+                                    }) {
+                                        Text(ui.executionSettings.buttonLabel)
+                                    }
+                                    Text(
+                                        text = char.points.toString(),
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = Color(0xFF2E7D32)
+                                    )
+                                    Text(
+                                        text = "${char.probability}%",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        color = Color(0xFF1565C0)
+                                    )
+                                }
+                                if (introText.isBlank()) {
+                                    Text("暂无要点", style = MaterialTheme.typography.labelMedium)
+                                } else {
+                                    PreviewTextBlock(text = introText, onEventSequence = {})
+                                }
+                            }
+                        }
+                        2 -> {
                             Column(Modifier.fillMaxSize()) {
                                 Spacer(Modifier.height(12.dp))
                                 CharacterResourceFilterBar(
@@ -439,6 +545,7 @@ private fun CharacterResourceFilterBar(
                 ResourceType.TEXT,
                 ResourceType.IMAGE,
                 ResourceType.VIDEO,
+                ResourceType.SOUND,
                 ResourceType.SCENE
             )
             orderedTypes.forEach { type ->
@@ -489,8 +596,17 @@ private fun typeLabel(type: ResourceType): String = when (type) {
     ResourceType.FLOW -> "流程"
     ResourceType.IMAGE -> "图片"
     ResourceType.VIDEO -> "视频"
+    ResourceType.SOUND -> "声音"
     ResourceType.TEXT -> "文本"
     ResourceType.SCENE -> "情景"
+}
+
+private fun fillTemplate(template: String, values: List<String>): String {
+    var result = template
+    values.forEach { value ->
+        result = result.replaceFirst("[]", value)
+    }
+    return result
 }
 
 @Composable

--- a/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
@@ -49,7 +49,7 @@ fun MainScreen() {
                     selected = currentTab == 3,
                     onClick = { currentTab = 3 },
                     icon = { Icon(Icons.Default.Casino, contentDescription = null) },
-                    label = { Text("随机") }
+                    label = { Text("执行") }
                 )
             }
         }
@@ -59,7 +59,7 @@ fun MainScreen() {
                 0 -> TagScreen(modifier = Modifier.padding(inner))
                 1 -> CharacterScreen(modifier = Modifier.padding(inner))
                 2 -> ResourceScreen(modifier = Modifier.padding(inner))
-                else -> RandomScreen(modifier = Modifier.padding(inner))
+                else -> ExecutionScreen(modifier = Modifier.padding(inner))
             }
         }
     }

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -1,332 +1,303 @@
 package com.example.quotepicker.ui
 
+import android.widget.Toast
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.FilterChip
-import androidx.compose.material3.FilterChipDefaults
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Casino
-import androidx.compose.material.icons.filled.KeyboardArrowDown
-import androidx.compose.material.icons.filled.KeyboardArrowUp
-import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material.icons.filled.SkipNext
-import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.quotepicker.data.ExecutionSettingsEntity
+import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
-import com.example.quotepicker.ui.components.CharacterBadge
-import com.example.quotepicker.ui.components.TagBadge
-import com.example.quotepicker.ui.components.PreviewTextBlock
-import com.example.quotepicker.ui.components.sortTagsForDisplay
-import com.example.quotepicker.ui.components.rememberEventSequenceRunner
-import com.example.quotepicker.data.ResourceType
-import com.example.quotepicker.data.TagCategoryEntity
-import com.example.quotepicker.data.TagEntity
-import com.example.quotepicker.vm.RandomViewModel
+import com.example.quotepicker.vm.ExecutionViewModel
 import com.example.quotepicker.vm.ResourceViewModel
+import kotlin.math.roundToInt
 
-@OptIn(ExperimentalLayoutApi::class)
+private data class ExecutionResourceItem(
+    val resource: ResourceWithTagsCharacters,
+    val characterId: Long,
+    val characterName: String,
+    val tagName: String
+)
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun RandomScreen(modifier: Modifier = Modifier, vm: RandomViewModel = viewModel(), resourceVm: ResourceViewModel = viewModel()) {
+fun ExecutionScreen(
+    modifier: Modifier = Modifier,
+    vm: ExecutionViewModel = viewModel(),
+    resourceVm: ResourceViewModel = viewModel()
+) {
     val ui by vm.uiState.collectAsState()
+    var showSettings by remember { mutableStateOf(false) }
     var showPreview by remember { mutableStateOf(false) }
-    var showTagDialog by remember { mutableStateOf(false) }
-    var showIntro by remember { mutableStateOf(false) }
-    val eventRunner = rememberEventSequenceRunner()
+    var previewTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
+    var executionItems by remember { mutableStateOf<List<ExecutionResourceItem>>(emptyList()) }
+    var completionTarget by remember { mutableStateOf<ExecutionResourceItem?>(null) }
+    val context = LocalContext.current
 
-    if (showPreview && ui.selectedResource != null) {
+    if (showPreview && previewTarget != null) {
         ResourcePreviewScreen(
-            resource = ui.selectedResource!!,
+            resource = previewTarget!!,
             vm = resourceVm,
-            onBack = { showPreview = false }
+            onBack = {
+                showPreview = false
+                previewTarget = null
+            }
         )
         return
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
-        Column(
-            Modifier
-                .padding(16.dp)
-                .verticalScroll(rememberScrollState()),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
-        ) {
-            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                Button(onClick = {
-                    vm.randomCharacter()
-                    showIntro = false
-                }) {
-                    Icon(Icons.Default.Casino, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text("随机角色")
-                }
-                Button(onClick = { showIntro = true }, enabled = ui.selectedCharacter != null) {
-                    Text("显示介绍")
-                }
-            }
-            if (ui.selectedCharacter == null) {
-                Text("未选择角色")
-            } else {
-                CharacterBadge(name = ui.selectedCharacter!!.name)
-            }
-            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                    TextButton(onClick = { showTagDialog = true }) {
-                        Text("资源标签筛选(${ui.selectedTagIds.size})")
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            TopAppBar(
+                title = { Text("执行") },
+                actions = {
+                    IconButton(onClick = { showSettings = true }) {
+                        Icon(Icons.Default.Settings, contentDescription = "设置")
                     }
                 }
-                if (ui.selectedTagIds.isEmpty()) {
-                    Text("未选择标签")
+            )
+        }
+    ) { inner ->
+        Column(
+            modifier = Modifier
+                .padding(inner)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("响应记录", style = MaterialTheme.typography.titleMedium)
+                if (ui.records.isEmpty()) {
+                    Text("暂无响应记录", style = MaterialTheme.typography.labelMedium)
                 } else {
-                    FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        sortTagsForDisplay(
-                            ui.tags.filter { ui.selectedTagIds.contains(it.id) },
-                            ui.categories
-                        ).forEach { tag ->
-                            TagBadge(tag = tag)
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        ui.records.forEach { record ->
+                            val label = buildString {
+                                append(record.characterName)
+                                append("的")
+                                append(record.tagName)
+                                if (record.count > 1) {
+                                    append("×")
+                                    append(record.count)
+                                }
+                            }
+                            Button(onClick = {
+                                vm.consumeRecord(record.characterId, record.tagId)
+                                val candidates = ui.resources.filter { res ->
+                                    res.characters.any { it.id == record.characterId } &&
+                                        res.tags.any { it.id == record.tagId }
+                                }
+                                val picked = candidates.randomOrNull()
+                                if (picked == null) {
+                                    Toast.makeText(context, "未找到匹配资源", Toast.LENGTH_SHORT).show()
+                                    return@Button
+                                }
+                                executionItems = executionItems + ExecutionResourceItem(
+                                    resource = picked,
+                                    characterId = record.characterId,
+                                    characterName = record.characterName,
+                                    tagName = record.tagName
+                                )
+                            }) {
+                                Text(label, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            }
                         }
                     }
                 }
             }
-            Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                Button(onClick = { vm.randomResource() }, enabled = ui.selectedCharacter != null) {
-                    Icon(Icons.Default.Casino, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text("随机资源")
-                }
-                Button(onClick = { vm.nextResource() }, enabled = ui.selectedCharacter != null) {
-                    Icon(Icons.Default.SkipNext, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text("下一个")
-                }
-                Button(onClick = { vm.reset() }) {
-                    Icon(Icons.Default.Refresh, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text("重置")
-                }
-            }
-            Spacer(Modifier.height(8.dp))
-            val res = ui.selectedResource
-            if (res == null) {
-                Text("暂无资源")
-            } else {
-                Text("当前资源：${res.resource.title}")
-                Button(onClick = { showPreview = true }) {
-                    Icon(Icons.Default.Visibility, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text("预览")
-                }
-            }
-            if (showIntro && ui.selectedCharacter != null) {
-                val introCandidates = ui.characterResources.filter { res ->
-                    res.resource.type == ResourceType.TEXT &&
-                        res.resource.title.take(2) == "要点"
-                }
-                if (introCandidates.size == 1) {
-                    val introText = introCandidates.first().resource.quoteText.orEmpty()
-                    PreviewTextBlock(
-                        text = introText,
-                        onEventSequence = { eventRunner.start(it) }
-                    )
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.weight(1f, fill = false)) {
+                Text("执行资源", style = MaterialTheme.typography.titleMedium)
+                if (executionItems.isEmpty()) {
+                    Text("暂无执行资源", style = MaterialTheme.typography.labelMedium)
                 } else {
-                    Text("资源错误")
+                    LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                        items(executionItems) { item ->
+                            Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .combinedClickable(
+                                        onClick = {
+                                            previewTarget = item.resource
+                                            showPreview = true
+                                        },
+                                        onLongClick = { completionTarget = item }
+                                    )
+                            ) {
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(12.dp),
+                                    verticalArrangement = Arrangement.spacedBy(6.dp)
+                                ) {
+                                    Text(item.resource.resource.title, style = MaterialTheme.typography.titleMedium)
+                                    Text(
+                                        text = "${item.characterName} ${item.tagName}",
+                                        style = MaterialTheme.typography.labelSmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    )
+                                }
+                            }
+                        }
+                    }
                 }
             }
-        }
-        if (eventRunner.overlayText != null) {
-            Text(
-                text = eventRunner.overlayText.orEmpty(),
-                modifier = Modifier
-                    .align(Alignment.TopCenter)
-                    .padding(top = 24.dp),
-                style = androidx.compose.material3.MaterialTheme.typography.titleMedium.copy(
-                    fontSize = androidx.compose.material3.MaterialTheme.typography.titleMedium.fontSize * 2
-                ),
-                color = androidx.compose.ui.graphics.Color.Red
-            )
         }
     }
 
-    if (showTagDialog) {
-        TagPickerDialog(
-            categories = ui.categories,
-            tags = ui.tags,
-            selectedIds = ui.selectedTagIds,
-            onConfirm = vm::updateTagFilter,
-            onDismiss = { showTagDialog = false }
+    if (showSettings) {
+        SettingsDialog(
+            settings = ui.settings,
+            onConfirm = { vm.updateSettings(it); showSettings = false },
+            onDismiss = { showSettings = false }
+        )
+    }
+
+    completionTarget?.let { target ->
+        CompletionDialog(
+            characterName = target.characterName,
+            onConfirm = { completion, belonging, emotion ->
+                val sum = completion + belonging + emotion
+                val currentPoints = ui.characters.firstOrNull { it.id == target.characterId }?.points ?: 0
+                val newPoints = ((sum + currentPoints) / 2.0).roundToInt()
+                vm.updateCharacterPoints(target.characterId, newPoints)
+                executionItems = executionItems.filterNot { it == target }
+                completionTarget = null
+            },
+            onDismiss = { completionTarget = null }
         )
     }
 }
 
 @Composable
-private fun TagPickerDialog(
-    categories: List<TagCategoryEntity>,
-    tags: List<TagEntity>,
-    selectedIds: Set<Long>,
-    onConfirm: (Set<Long>) -> Unit,
+private fun SettingsDialog(
+    settings: ExecutionSettingsEntity,
+    onConfirm: (ExecutionSettingsEntity) -> Unit,
     onDismiss: () -> Unit
 ) {
-    var selected by remember { mutableStateOf(selectedIds.toMutableSet()) }
+    var buttonLabel by remember { mutableStateOf(settings.buttonLabel) }
+    var successToast by remember { mutableStateOf(settings.successToast) }
+    var failureToast by remember { mutableStateOf(settings.failureToast) }
+
     AlertDialog(
         onDismissRequest = onDismiss,
-        title = { Text("资源标签筛选") },
+        title = { Text("设置") },
         text = {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .heightIn(max = 360.dp)
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(4.dp)
-            ) {
-                TagSelectionSection(
-                    categories = categories,
-                    tags = tags,
-                    selected = selected,
-                    onChange = { selected = it.toMutableSet() }
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                OutlinedTextField(
+                    value = buttonLabel,
+                    onValueChange = { buttonLabel = it },
+                    label = { Text("按钮名") },
+                    modifier = Modifier.fillMaxWidth()
                 )
+                OutlinedTextField(
+                    value = successToast,
+                    onValueChange = { successToast = it },
+                    label = { Text("响应 toast") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = failureToast,
+                    onValueChange = { failureToast = it },
+                    label = { Text("非响应 toast") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Text("提示：用 [] 代表角色或标签占位", style = MaterialTheme.typography.labelSmall)
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(selected); onDismiss() }) { Text("确定") }
+            TextButton(onClick = {
+                onConfirm(
+                    settings.copy(
+                        buttonLabel = buttonLabel.trim().ifBlank { settings.buttonLabel },
+                        successToast = successToast.trim().ifBlank { settings.successToast },
+                        failureToast = failureToast.trim().ifBlank { settings.failureToast }
+                    )
+                )
+            }) { Text("确定") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun TagSelectionSection(
-    categories: List<TagCategoryEntity>,
-    tags: List<TagEntity>,
-    selected: Set<Long>,
-    onChange: (Set<Long>) -> Unit
+private fun CompletionDialog(
+    characterName: String,
+    onConfirm: (Int, Int, Int) -> Unit,
+    onDismiss: () -> Unit
 ) {
-    val sortedTags = sortTagsForDisplay(tags, categories)
-    val grouped = sortedTags.groupBy { it.categoryId }
-    val knownCategoryIds = categories.map { it.id }.toSet()
-    val uncategorized = sortedTags.filter { it.categoryId !in knownCategoryIds }
-    val expandedState = remember(categories) {
-        mutableStateOf(categories.associate { it.id to true }.toMutableMap())
-    }
-    var uncategorizedExpanded by remember { mutableStateOf(true) }
-    Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        categories.forEach { category ->
-            val items = grouped[category.id].orEmpty()
-            if (items.isNotEmpty()) {
-                val isExpanded = expandedState.value[category.id] ?: true
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .clickable {
-                            expandedState.value = expandedState.value.toMutableMap().apply {
-                                put(category.id, !isExpanded)
-                            }
-                        },
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(category.name)
-                    Spacer(Modifier.width(6.dp))
-                    Icon(
-                        imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
-                        contentDescription = null
-                    )
-                }
-                if (isExpanded) {
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        items.forEach { tag ->
-                            TagFilterChip(
-                                tag = tag,
-                                selected = selected,
-                                onChange = onChange
-                            )
-                        }
-                    }
-                }
-            }
-        }
-        if (uncategorized.isNotEmpty()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { uncategorizedExpanded = !uncategorizedExpanded },
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text("未分类")
-                Spacer(Modifier.width(6.dp))
-                Icon(
-                    imageVector = if (uncategorizedExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
-                    contentDescription = null
+    var completionText by remember { mutableStateOf("") }
+    var belongingText by remember { mutableStateOf("") }
+    var emotionText by remember { mutableStateOf("") }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("完成记录") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("$characterName 的完成情况")
+                OutlinedTextField(
+                    value = completionText,
+                    onValueChange = { completionText = it },
+                    label = { Text("完成度(0-10)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = belongingText,
+                    onValueChange = { belongingText = it },
+                    label = { Text("归属感(0-10)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = emotionText,
+                    onValueChange = { emotionText = it },
+                    label = { Text("情绪值(0-10)") },
+                    modifier = Modifier.fillMaxWidth()
                 )
             }
-            if (uncategorizedExpanded) {
-                FlowRow(
-                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    uncategorized.forEach { tag ->
-                        TagFilterChip(
-                            tag = tag,
-                            selected = selected,
-                            onChange = onChange
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun TagFilterChip(
-    tag: TagEntity,
-    selected: Set<Long>,
-    onChange: (Set<Long>) -> Unit
-) {
-    val isSelected = selected.contains(tag.id)
-    FilterChip(
-        selected = isSelected,
-        onClick = {
-            val updated = selected.toMutableSet()
-            if (isSelected) updated.remove(tag.id) else updated.add(tag.id)
-            onChange(updated)
         },
-        label = {
-            Text(
-                text = tag.name,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis
-            )
+        confirmButton = {
+            TextButton(onClick = {
+                val completion = completionText.toIntOrNull()?.coerceIn(0, 10) ?: 0
+                val belonging = belongingText.toIntOrNull()?.coerceIn(0, 10) ?: 0
+                val emotion = emotionText.toIntOrNull()?.coerceIn(0, 10) ?: 0
+                onConfirm(completion, belonging, emotion)
+            }) { Text("完成") }
         },
-        colors = FilterChipDefaults.filterChipColors()
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )
 }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -39,6 +39,7 @@ import androidx.compose.material.icons.filled.Chat
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
+import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.AlertDialog
@@ -91,6 +92,7 @@ import com.example.quotepicker.vm.ResourceViewModel
 import com.example.quotepicker.vm.SceneMessageDraft
 import com.example.quotepicker.vm.StoredMediaItem
 import com.example.quotepicker.vm.VideoUpdateItem
+import com.example.quotepicker.vm.SoundUpdateItem
 import java.io.File
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -261,6 +263,11 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                     Spacer(Modifier.width(8.dp))
                     Text("上传视频组")
                 }
+                TextButton(onClick = { createMode = CreateMode.SoundGroup; showAddMenu = false }) {
+                    Icon(Icons.Default.MusicNote, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("上传声音组")
+                }
             }
         }
     }
@@ -339,11 +346,13 @@ private fun ManageStorageScreen(
     val context = LocalContext.current
     val imagesDir = remember { File(context.filesDir, "images").absolutePath }
     val videosDir = remember { File(context.filesDir, "videos").absolutePath }
+    val audioDir = remember { File(context.filesDir, "audio").absolutePath }
     var displayType by remember { mutableStateOf(ResourceType.IMAGE) }
     var actionTarget by remember { mutableStateOf<StoredMediaItem?>(null) }
     var deleteTarget by remember { mutableStateOf<StoredMediaItem?>(null) }
     val coroutineScope = rememberCoroutineScope()
     val filteredItems = remember(items, displayType) { items.filter { it.type == displayType } }
+    val displayTypes = listOf(ResourceType.IMAGE, ResourceType.VIDEO, ResourceType.SOUND)
 
     Scaffold(
         topBar = {
@@ -356,13 +365,16 @@ private fun ManageStorageScreen(
                 },
                 actions = {
                     TextButton(onClick = {
-                        displayType = if (displayType == ResourceType.IMAGE) {
-                            ResourceType.VIDEO
-                        } else {
-                            ResourceType.IMAGE
-                        }
+                        val index = displayTypes.indexOf(displayType).takeIf { it >= 0 } ?: 0
+                        displayType = displayTypes[(index + 1) % displayTypes.size]
                     }) {
-                        Text(if (displayType == ResourceType.IMAGE) "显示视频" else "显示图片")
+                        Text(
+                            when (displayType) {
+                                ResourceType.IMAGE -> "显示视频"
+                                ResourceType.VIDEO -> "显示音频"
+                                else -> "显示图片"
+                            }
+                        )
                     }
                     TextButton(onClick = onRefresh) { Text("刷新") }
                 }
@@ -380,6 +392,7 @@ private fun ManageStorageScreen(
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
                 Text("图片目录：$imagesDir", style = MaterialTheme.typography.labelSmall)
                 Text("视频目录：$videosDir", style = MaterialTheme.typography.labelSmall)
+                Text("音频目录：$audioDir", style = MaterialTheme.typography.labelSmall)
             }
             Text("长按文件可选择恢复或删除", style = MaterialTheme.typography.labelSmall)
             if (filteredItems.isEmpty()) {
@@ -460,6 +473,7 @@ private fun StorageMediaRow(
             when (item.type) {
                 ResourceType.IMAGE -> vm.decodeUriToBitmap(Uri.parse(item.path))
                 ResourceType.VIDEO -> vm.decodeVideoFrame(Uri.parse(item.path))
+                ResourceType.SOUND -> null
                 else -> null
             }
         }
@@ -491,14 +505,24 @@ private fun StorageMediaRow(
                 contentAlignment = Alignment.Center
             ) {
                 Icon(
-                    imageVector = if (item.type == ResourceType.IMAGE) Icons.Default.Image else Icons.Default.Videocam,
+                    imageVector = when (item.type) {
+                        ResourceType.IMAGE -> Icons.Default.Image
+                        ResourceType.VIDEO -> Icons.Default.Videocam
+                        ResourceType.SOUND -> Icons.Default.MusicNote
+                        else -> Icons.Default.Videocam
+                    },
                     contentDescription = null
                 )
             }
         }
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = if (item.type == ResourceType.IMAGE) "图片" else "视频",
+                text = when (item.type) {
+                    ResourceType.IMAGE -> "图片"
+                    ResourceType.VIDEO -> "视频"
+                    ResourceType.SOUND -> "音频"
+                    else -> "资源"
+                },
                 style = MaterialTheme.typography.labelMedium
             )
             Text(
@@ -516,6 +540,7 @@ private sealed class CreateMode {
     data object ImageGroup : CreateMode()
     data object Scene : CreateMode()
     data object VideoGroup : CreateMode()
+    data object SoundGroup : CreateMode()
 }
 
 @Composable
@@ -535,6 +560,7 @@ private fun FilterBar(
                 ResourceType.TEXT,
                 ResourceType.IMAGE,
                 ResourceType.VIDEO,
+                ResourceType.SOUND,
                 ResourceType.SCENE
             )
             orderedTypes.forEach { type ->
@@ -561,6 +587,7 @@ private fun typeLabel(type: ResourceType): String = when (type) {
     ResourceType.FLOW -> "流程"
     ResourceType.IMAGE -> "图片"
     ResourceType.VIDEO -> "视频"
+    ResourceType.SOUND -> "声音"
     ResourceType.TEXT -> "文本"
     ResourceType.SCENE -> "情景"
 }
@@ -696,6 +723,7 @@ private fun ResourceCreateScreen(
     var selectedCharacters by remember { mutableStateOf(setOf<Long>()) }
     var imageUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var videoUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
+    var soundUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var showTagPicker by remember { mutableStateOf(false) }
     var showCharacterPicker by remember { mutableStateOf(false) }
     var showSceneDialog by remember { mutableStateOf(false) }
@@ -723,6 +751,15 @@ private fun ResourceCreateScreen(
             )
         }
     }
+    val soundPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+        soundUris = uris
+        uris.forEach { uri ->
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+        }
+    }
 
     val screenTitle = when (mode) {
         CreateMode.Flow -> "创建流程"
@@ -730,6 +767,7 @@ private fun ResourceCreateScreen(
         CreateMode.ImageGroup -> "上传图片组"
         CreateMode.Scene -> "创建情景"
         CreateMode.VideoGroup -> "上传视频组"
+        CreateMode.SoundGroup -> "上传声音组"
     }
 
     val titleLabel = when (mode) {
@@ -738,6 +776,7 @@ private fun ResourceCreateScreen(
         CreateMode.Scene -> "情景名"
         CreateMode.ImageGroup -> "名称"
         CreateMode.VideoGroup -> "名称"
+        CreateMode.SoundGroup -> "名称"
     }
 
     val canSubmit = title.isNotBlank() && selectedCharacters.isNotEmpty() && when (mode) {
@@ -746,6 +785,7 @@ private fun ResourceCreateScreen(
         CreateMode.ImageGroup -> imageUris.isNotEmpty()
         CreateMode.Scene -> sceneMessages.isNotEmpty()
         CreateMode.VideoGroup -> videoUris.isNotEmpty()
+        CreateMode.SoundGroup -> soundUris.isNotEmpty()
     }
 
     val selectedSpeakerNames = remember(selectedCharacters, characters) {
@@ -801,6 +841,12 @@ private fun ResourceCreateScreen(
                             CreateMode.VideoGroup -> vm.addVideoGroup(
                                 title.trim(),
                                 videoUris,
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            CreateMode.SoundGroup -> vm.addSoundGroup(
+                                title.trim(),
+                                soundUris,
                                 selectedTags.toList(),
                                 selectedCharacters.toList()
                             )
@@ -1009,6 +1055,14 @@ private fun ResourceCreateScreen(
                     }
                     Text(if (videoUris.isEmpty()) "未选择视频" else "已选择 ${videoUris.size} 个视频")
                 }
+                CreateMode.SoundGroup -> {
+                    TextButton(onClick = { soundPicker.launch(arrayOf("audio/*")) }) {
+                        Icon(Icons.Default.MusicNote, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("选择音频")
+                    }
+                    Text(if (soundUris.isEmpty()) "未选择音频" else "已选择 ${soundUris.size} 个音频")
+                }
             }
             ResourceTagPickerRow(
                 label = "标签",
@@ -1127,6 +1181,7 @@ private fun ResourceEditScreen(
         mutableStateOf(parseImageItems(resource.resource.contentUriOrPath, resource.resource.quoteImageBase64))
     }
     var videoItems by remember { mutableStateOf(parseVideoItems(resource.resource.contentUriOrPath)) }
+    var soundItems by remember { mutableStateOf(parseSoundItems(resource.resource.contentUriOrPath)) }
     var flowItems by remember { mutableStateOf(parseFlowItems(resource.resource.sceneJson)) }
     var showSceneDialog by remember { mutableStateOf(false) }
     var editSceneIndex by remember { mutableStateOf<Int?>(null) }
@@ -1157,6 +1212,17 @@ private fun ResourceEditScreen(
         }
         videoItems = updated
     }
+    val soundPicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenMultipleDocuments()) { uris ->
+        val updated = soundItems.toMutableList()
+        uris.forEach { uri ->
+            context.contentResolver.takePersistableUriPermission(
+                uri,
+                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+            )
+            updated.add(SoundUpdateItem(uri = uri))
+        }
+        soundItems = updated
+    }
 
     val selectedSpeakerNames = remember(selectedCharacters, characters) {
         characters.filter { selectedCharacters.contains(it.id) }.map { it.name }
@@ -1176,6 +1242,7 @@ private fun ResourceEditScreen(
         ResourceType.TEXT -> textContent.isNotBlank()
         ResourceType.IMAGE -> imageItems.isNotEmpty()
         ResourceType.VIDEO -> videoItems.isNotEmpty()
+        ResourceType.SOUND -> soundItems.isNotEmpty()
         ResourceType.SCENE -> sceneMessages.isNotEmpty()
     }
 
@@ -1216,6 +1283,13 @@ private fun ResourceEditScreen(
                                 resource.resource,
                                 title.trim(),
                                 videoItems,
+                                selectedTags.toList(),
+                                selectedCharacters.toList()
+                            )
+                            ResourceType.SOUND -> vm.updateSoundGroup(
+                                resource.resource,
+                                title.trim(),
+                                soundItems,
                                 selectedTags.toList(),
                                 selectedCharacters.toList()
                             )
@@ -1400,6 +1474,55 @@ private fun ResourceEditScreen(
                                         }
                                         IconButton(onClick = {
                                             videoItems = videoItems.toMutableList().also { it.removeAt(index) }
+                                        }) {
+                                            Icon(Icons.Default.Delete, contentDescription = "删除")
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                ResourceType.SOUND -> {
+                    TextButton(onClick = { soundPicker.launch(arrayOf("audio/*")) }) {
+                        Icon(Icons.Default.MusicNote, contentDescription = null)
+                        Spacer(Modifier.width(8.dp))
+                        Text("追加音频")
+                    }
+                    if (soundItems.isEmpty()) {
+                        Text("暂无音频", style = MaterialTheme.typography.labelSmall)
+                    } else {
+                        Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                            soundItems.forEachIndexed { index, item ->
+                                Row(
+                                    modifier = Modifier.fillMaxWidth(),
+                                    verticalAlignment = Alignment.CenterVertically
+                                ) {
+                                    Icon(Icons.Default.MusicNote, contentDescription = null)
+                                    Spacer(Modifier.width(12.dp))
+                                    val label = item.path?.let { "音频 ${index + 1}" } ?: "新音频 ${index + 1}"
+                                    Text(text = label, modifier = Modifier.weight(1f))
+                                    Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                        IconButton(onClick = {
+                                            if (index > 0) {
+                                                soundItems = soundItems.toMutableList().also {
+                                                    it.add(index - 1, it.removeAt(index))
+                                                }
+                                            }
+                                        }) {
+                                            Icon(Icons.Default.KeyboardArrowUp, contentDescription = "上移")
+                                        }
+                                        IconButton(onClick = {
+                                            if (index < soundItems.lastIndex) {
+                                                soundItems = soundItems.toMutableList().also {
+                                                    it.add(index + 1, it.removeAt(index))
+                                                }
+                                            }
+                                        }) {
+                                            Icon(Icons.Default.KeyboardArrowDown, contentDescription = "下移")
+                                        }
+                                        IconButton(onClick = {
+                                            soundItems = soundItems.toMutableList().also { it.removeAt(index) }
                                         }) {
                                             Icon(Icons.Default.Delete, contentDescription = "删除")
                                         }
@@ -2188,6 +2311,12 @@ private fun parseVideoItems(raw: String?): List<VideoUpdateItem> {
     return list.map { VideoUpdateItem(path = it) }
 }
 
+private fun parseSoundItems(raw: String?): List<SoundUpdateItem> {
+    if (raw.isNullOrBlank()) return emptyList()
+    val list = parsePathList(raw)
+    return list.map { SoundUpdateItem(path = it) }
+}
+
 private fun parsePathList(raw: String): List<String> {
     return if (raw.trim().startsWith("[")) {
         runCatching {
@@ -2259,6 +2388,10 @@ private fun resourceSummary(resource: ResourceWithTagsCharacters): String {
         ResourceType.VIDEO -> {
             val videos = parseVideoItems(data.contentUriOrPath)
             if (videos.isEmpty()) "" else "视频 ${videos.size} 个"
+        }
+        ResourceType.SOUND -> {
+            val sounds = parseSoundItems(data.contentUriOrPath)
+            if (sounds.isEmpty()) "" else "音频 ${sounds.size} 个"
         }
         else -> ""
     }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -2,6 +2,7 @@ package com.example.quotepicker.ui.components
 
 import android.net.Uri
 import android.util.Log
+import android.media.MediaPlayer
 import android.widget.MediaController
 import android.widget.VideoView
 import androidx.compose.foundation.Image
@@ -90,6 +91,7 @@ fun ResourcePreviewScreen(
 ) {
     var quoteImages by remember { mutableStateOf<List<ImagePreviewItem>>(emptyList()) }
     var mediaUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
+    var soundUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
     var mediaLoadFailed by remember { mutableStateOf(false) }
     var mediaReloadKey by remember { mutableStateOf(0) }
     var sceneMessages by remember { mutableStateOf<List<SceneMessage>>(emptyList()) }
@@ -134,6 +136,19 @@ fun ResourcePreviewScreen(
                     mediaLoadFailed = true
                 }
                 uriList
+            }
+            else -> emptyList()
+        }
+        soundUris = when (res.type) {
+            ResourceType.SOUND -> {
+                val raw = res.contentUriOrPath
+                if (raw.isNullOrBlank()) {
+                    Log.e("ResourcePreview", "Missing media uri for type=${res.type} id=${res.id}")
+                    mediaLoadFailed = true
+                    return@LaunchedEffect
+                }
+                val paths = parseMediaPaths(raw)
+                paths.mapNotNull { path -> path.takeIf { it.isNotBlank() }?.let(Uri::parse) }
             }
             else -> emptyList()
         }
@@ -242,6 +257,15 @@ fun ResourcePreviewScreen(
                                     }
                                 } else {
                                     Text("视频加载中…")
+                                }
+                            }
+                            ResourceType.SOUND -> {
+                                if (soundUris.isNotEmpty()) {
+                                    AudioPreviewList(uris = soundUris)
+                                } else if (mediaLoadFailed) {
+                                    Text("音频加载失败")
+                                } else {
+                                    Text("音频加载中…")
                                 }
                             }
                             ResourceType.SCENE -> {
@@ -420,6 +444,39 @@ private fun parseMediaPaths(raw: String): List<String> {
         }.getOrDefault(listOf(raw))
     }
     return listOf(raw)
+}
+
+@Composable
+private fun AudioPreviewList(uris: List<Uri>) {
+    val context = androidx.compose.ui.platform.LocalContext.current
+    val playerState = remember { mutableStateOf<MediaPlayer?>(null) }
+    DisposableEffect(Unit) {
+        onDispose {
+            playerState.value?.release()
+            playerState.value = null
+        }
+    }
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        uris.forEachIndexed { index, uri ->
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(text = "音频 ${index + 1}", style = MaterialTheme.typography.labelMedium)
+                TextButton(onClick = {
+                    playerState.value?.release()
+                    playerState.value = MediaPlayer().apply {
+                        setDataSource(context, uri)
+                        setOnPreparedListener { it.start() }
+                        prepareAsync()
+                    }
+                }) {
+                    Text("播放")
+                }
+            }
+        }
+    }
 }
 
 private fun parseImagePayloadEntries(payload: String): List<ImagePayloadEntry> {
@@ -659,6 +716,7 @@ private fun typeLabel(type: ResourceType): String = when (type) {
     ResourceType.TEXT -> "文本"
     ResourceType.IMAGE -> "图片"
     ResourceType.VIDEO -> "视频"
+    ResourceType.SOUND -> "声音"
     ResourceType.SCENE -> "情景"
 }
 

--- a/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
@@ -28,6 +28,7 @@ fun SquareGridItem(
     modifier: Modifier = Modifier,
     backgroundColor: Color = MaterialTheme.colorScheme.surface,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    bottomContent: (@Composable () -> Unit)? = null,
     onClick: () -> Unit,
     onLongClick: () -> Unit
 ) {
@@ -65,6 +66,7 @@ fun SquareGridItem(
                         overflow = TextOverflow.Ellipsis
                     )
                 }
+                bottomContent?.invoke()
             }
         }
     }

--- a/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
@@ -26,21 +26,35 @@ import kotlinx.coroutines.launch
 data class CharacterUiState(
     val characters: List<CharacterWithTags> = emptyList(),
     val categories: List<TagCategoryEntity> = emptyList(),
-    val tags: List<TagEntity> = emptyList()
+    val tags: List<TagEntity> = emptyList(),
+    val executionSettings: com.example.quotepicker.data.ExecutionSettingsEntity = com.example.quotepicker.data.ExecutionSettingsEntity()
 )
 
 class CharacterViewModel(app: Application) : AndroidViewModel(app) {
     private val repo = Repository.get(app)
 
+    init {
+        viewModelScope.launch {
+            repo.ensureExecutionSettings()
+            repo.refreshDailyProbabilities()
+        }
+    }
+
     val uiState: StateFlow<CharacterUiState> = combine(
         repo.observeCharactersWithTags(),
         repo.observeCategories(),
-        repo.observeAllTags()
-    ) { characters, categories, tags ->
+        repo.observeAllTags(),
+        repo.observeExecutionSettings()
+    ) { characters, categories, tags, settings ->
         val roleCategories = categories.filter { it.type == TagCategoryType.CHARACTER }
         val roleCategoryIds = roleCategories.map { it.id }.toSet()
         val roleTags = tags.filter { it.categoryId in roleCategoryIds }
-        CharacterUiState(characters = characters, categories = roleCategories, tags = roleTags)
+        CharacterUiState(
+            characters = characters,
+            categories = roleCategories,
+            tags = roleTags,
+            executionSettings = settings ?: com.example.quotepicker.data.ExecutionSettingsEntity()
+        )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, CharacterUiState())
 
     fun addCharacter(name: String) = viewModelScope.launch { repo.addCharacter(name) }
@@ -48,6 +62,15 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
     fun deleteCharacter(character: CharacterEntity) = viewModelScope.launch { repo.deleteCharacter(character) }
     fun updateCharacterTags(characterId: Long, tagIds: List<Long>) =
         viewModelScope.launch { repo.updateCharacterTags(characterId, tagIds) }
+
+    fun updateCharacterPoints(characterId: Long, points: Int) =
+        viewModelScope.launch { repo.updateCharacterPoints(characterId, points) }
+
+    fun updateCharacterProbability(characterId: Long, probability: Int, date: String) =
+        viewModelScope.launch { repo.updateCharacterProbability(characterId, probability, date) }
+
+    fun addResponseRecord(characterId: Long, tagId: Long, count: Int = 1) =
+        viewModelScope.launch { repo.addResponseRecord(characterId, tagId, count) }
 
     fun exportSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
         val resolver = getApplication<Application>().contentResolver

--- a/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
@@ -1,0 +1,81 @@
+package com.example.quotepicker.vm
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.quotepicker.data.CharacterEntity
+import com.example.quotepicker.data.ExecutionSettingsEntity
+import com.example.quotepicker.data.Repository
+import com.example.quotepicker.data.ResourceWithTagsCharacters
+import com.example.quotepicker.data.TagEntity
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+
+data class ResponseRecordDisplay(
+    val characterId: Long,
+    val tagId: Long,
+    val count: Int,
+    val characterName: String,
+    val tagName: String
+)
+
+data class ExecutionUiState(
+    val records: List<ResponseRecordDisplay> = emptyList(),
+    val settings: ExecutionSettingsEntity = ExecutionSettingsEntity(),
+    val resources: List<ResourceWithTagsCharacters> = emptyList(),
+    val characters: List<CharacterEntity> = emptyList(),
+    val tags: List<TagEntity> = emptyList()
+)
+
+class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
+    private val repo = Repository.get(app)
+
+    init {
+        viewModelScope.launch {
+            repo.ensureExecutionSettings()
+        }
+    }
+
+    val uiState: StateFlow<ExecutionUiState> = combine(
+        repo.observeResponseRecords(),
+        repo.observeCharacters(),
+        repo.observeAllTags(),
+        repo.observeResourcesWithRelations(),
+        repo.observeExecutionSettings()
+    ) { records, characters, tags, resources, settings ->
+        val characterMap = characters.associateBy { it.id }
+        val tagMap = tags.associateBy { it.id }
+        val displayRecords = records.map { record ->
+            ResponseRecordDisplay(
+                characterId = record.characterId,
+                tagId = record.tagId,
+                count = record.count,
+                characterName = characterMap[record.characterId]?.name ?: "角色",
+                tagName = tagMap[record.tagId]?.name ?: "标签"
+            )
+        }
+        ExecutionUiState(
+            records = displayRecords,
+            settings = settings ?: ExecutionSettingsEntity(),
+            resources = resources,
+            characters = characters,
+            tags = tags
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, ExecutionUiState())
+
+    fun consumeRecord(characterId: Long, tagId: Long) = viewModelScope.launch {
+        repo.consumeResponseRecord(characterId, tagId)
+    }
+
+    fun updateSettings(settings: ExecutionSettingsEntity) = viewModelScope.launch {
+        repo.updateExecutionSettings(settings)
+    }
+
+    fun updateCharacterPoints(characterId: Long, points: Int) = viewModelScope.launch {
+        repo.updateCharacterPoints(characterId, points)
+    }
+}

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -58,6 +58,11 @@ data class VideoUpdateItem(
     val uri: Uri? = null
 )
 
+data class SoundUpdateItem(
+    val path: String? = null,
+    val uri: Uri? = null
+)
+
 data class StoredImageResult(
     val imagePath: String,
     val motionVideoPath: String? = null
@@ -198,6 +203,23 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             )
         }
 
+    fun addSoundGroup(title: String, uris: List<Uri>, tagIds: List<Long>, characterIds: List<Long>) =
+        viewModelScope.launch(Dispatchers.IO) {
+            if (characterIds.isEmpty()) return@launch
+            val storedUris = uris.mapNotNull { uri -> storeAudioToInternal(uri) }
+            if (storedUris.isEmpty()) return@launch
+            val payload = org.json.JSONArray(storedUris).toString()
+            repo.addResource(
+                ResourceEntity(
+                    type = ResourceType.SOUND,
+                    title = title,
+                    contentUriOrPath = payload
+                ),
+                tagIds,
+                characterIds
+            )
+        }
+
     fun addFlow(
         title: String,
         items: List<FlowUpdateItem>,
@@ -281,6 +303,22 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         updateResourceCharacters(resource.id, characterIds)
     }
 
+    fun updateSoundGroup(
+        resource: ResourceEntity,
+        title: String,
+        items: List<SoundUpdateItem>,
+        tagIds: List<Long>,
+        characterIds: List<Long>
+    ) = viewModelScope.launch(Dispatchers.IO) {
+        if (characterIds.isEmpty()) return@launch
+        val newUris = resolveSoundItems(items)
+        if (newUris.isEmpty()) return@launch
+        val payload = org.json.JSONArray(newUris).toString()
+        repo.updateResource(resource.copy(title = title, contentUriOrPath = payload))
+        updateResourceTags(resource.id, tagIds)
+        updateResourceCharacters(resource.id, characterIds)
+    }
+
     fun updateFlow(
         resource: ResourceEntity,
         title: String,
@@ -308,6 +346,12 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     private suspend fun resolveVideoItems(items: List<VideoUpdateItem>): List<String> {
         return items.mapNotNull { item ->
             item.path?.ifBlank { null } ?: item.uri?.let { uri -> storeVideoToInternal(uri) }
+        }.filter { it.isNotBlank() }
+    }
+
+    private suspend fun resolveSoundItems(items: List<SoundUpdateItem>): List<String> {
+        return items.mapNotNull { item ->
+            item.path?.ifBlank { null } ?: item.uri?.let { uri -> storeAudioToInternal(uri) }
         }.filter { it.isNotBlank() }
     }
 
@@ -351,6 +395,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                 }
                 ResourceType.IMAGE -> obj.put("images", org.json.JSONArray(resolveImageItems(item.images)))
                 ResourceType.VIDEO -> obj.put("videos", org.json.JSONArray(resolveVideoItems(item.videos)))
+                ResourceType.SOUND -> obj.put("text", item.text.orEmpty())
                 ResourceType.FLOW -> obj.put("text", item.text.orEmpty())
             }
             array.put(obj)
@@ -399,7 +444,12 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             ?.sortedByDescending { it.lastModified() }
             ?.map { StoredMediaItem(path = Uri.fromFile(it).toString(), type = ResourceType.VIDEO) }
             .orEmpty()
-        return images + videos
+        val sounds = File(app.filesDir, "audio")
+            .listFiles()
+            ?.sortedByDescending { it.lastModified() }
+            ?.map { StoredMediaItem(path = Uri.fromFile(it).toString(), type = ResourceType.SOUND) }
+            .orEmpty()
+        return images + videos + sounds
     }
 
     fun restoreMediaToDirectory(path: String, type: ResourceType, directoryUri: Uri): Boolean {
@@ -412,6 +462,7 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         val mime = when (type) {
             ResourceType.IMAGE -> "image/*"
             ResourceType.VIDEO -> "video/*"
+            ResourceType.SOUND -> "audio/*"
             else -> "*/*"
         }
         val target = tree.createFile(mime, sourceFile.name) ?: return false
@@ -471,6 +522,22 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     private fun storeVideoToInternal(uri: Uri, deleteSource: Boolean = true): String? {
         return runCatching {
             val dir = File(getApplication<Application>().filesDir, "videos").apply { mkdirs() }
+            val target = File(dir, "media_${System.currentTimeMillis()}_${UUID.randomUUID()}.dat")
+            getApplication<Application>().contentResolver.openInputStream(uri)?.use { input ->
+                FileOutputStream(target).use { output ->
+                    input.copyTo(output)
+                }
+            } ?: return null
+            if (deleteSource) {
+                deleteSourceUri(uri)
+            }
+            Uri.fromFile(target).toString()
+        }.getOrNull()
+    }
+
+    private fun storeAudioToInternal(uri: Uri, deleteSource: Boolean = true): String? {
+        return runCatching {
+            val dir = File(getApplication<Application>().filesDir, "audio").apply { mkdirs() }
             val target = File(dir, "media_${System.currentTimeMillis()}_${UUID.randomUUID()}.dat")
             getApplication<Application>().contentResolver.openInputStream(uri)?.use { input ->
                 FileOutputStream(target).use { output ->


### PR DESCRIPTION
### Motivation
- Introduce a simple execution workflow that consumes recorded "character+tag" responses and lets users execute resources for those records. 
- Track per-character points and a daily probability to support a "祈求" interaction and auto-refresh of daily probabilities. 
- Add first-class support for sound/audio resources (upload, store, preview and include in backups) and settings for the execution behavior.

### Description
- Database and data model: added `ResourceType.SOUND`, character fields `points`/`probability`/`probabilityDate`, `ResponseRecordEntity` and `ExecutionSettingsEntity`, bumped DB `version` to `4`, and added DAOs `ResponseRecordDao` and `ExecutionSettingsDao` and repository methods (`addResponseRecord`, `consumeResponseRecord`, `updateCharacterPoints`, `updateCharacterProbability`, `refreshDailyProbabilities`, `ensureExecutionSettings`, `updateExecutionSettings`). Backup export/import now includes `responseRecords` and `executionSettings` and restores audio media paths. (`Entities.kt`, `Dao.kt`, `AppDatabase.kt`, `BackupSnapshot.kt`, `Repository.kt`)
- ViewModels: new `ExecutionViewModel` to surface response records, settings and resources for the execution UI, and added character/response management API hooks to `CharacterViewModel` and resource audio helpers to `ResourceViewModel` (`ExecutionViewModel.kt`, `CharacterViewModel.kt`, `ResourceViewModel.kt`).
- UI changes: replaced the old "随机" tab with an `ExecutionScreen` (exposes response-record buttons, execution list, completion dialog and settings dialog); added the "要点" tab and a `祈求` button to the character detail screen showing `points` and `probability` and creating response records on successful hits; added sound upload/edit flows and storage management and preview UI (audio playback) in the resource screens; small component updates to `SquareGridItem` to allow displaying the numeric badges. (`MainScreen.kt`, `CharacterScreen.kt`, `RandomScreen.kt` → `ExecutionScreen`, `ResourceScreen.kt`, `ResourcePreviewScreen.kt`, `components/*`).
- Media/storage: implemented storing audio files under `filesDir/audio`, listing/restoring/deleting audio in resource storage manager, and included audio in media collection for backup/restore and preview parsing. (`Repository.kt`, `ResourceViewModel.kt`, `ResourceScreen.kt`, `ResourcePreviewScreen.kt`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697183c559a4832b8b9727199a53e778)