### PR TITLE
Sort category tags by color then name

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -166,7 +166,10 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                         Text("暂无标签，点击右下角添加")
                     }
                 } else {
-                    val tags = ui.tags.sortedBy { it.name.lowercase() }
+                    val tags = ui.tags.sortedWith(
+                        compareBy<TagEntity> { it.colorArgb }
+                            .thenBy { it.name.lowercase() }
+                    )
                     LazyVerticalGrid(
                         columns = GridCells.Fixed(5),
                         contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),


### PR DESCRIPTION
### Motivation
- Group tags with the same/similar colors together in the category detail view so color organization appears before alphabetical order.

### Description
- Update in `app/src/main/java/com/example/quotepicker/ui/TagScreen.kt` to replace `ui.tags.sortedBy { it.name.lowercase() }` with `ui.tags.sortedWith(compareBy<TagEntity> { it.colorArgb }.thenBy { it.name.lowercase() })` so tags are sorted by color then name.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976d605a1e4832b9bb37d0fb07a59f6)