### PR TITLE
Add import/export progress indicator

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Button
 import androidx.compose.runtime.Composable
@@ -77,6 +78,7 @@ import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.SquareGridItem
 import com.example.quotepicker.ui.components.sortTagsForDisplay
 import com.example.quotepicker.vm.CharacterViewModel
+import com.example.quotepicker.vm.TransferMode
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.launch
 import android.widget.Toast
@@ -89,6 +91,7 @@ fun CharacterScreen(
     resourceVm: ResourceViewModel = viewModel()
 ) {
     val ui by vm.uiState.collectAsState()
+    val transferState by vm.transferState.collectAsState()
     val resources by resourceVm.allResources.collectAsState()
     val resourceUi by resourceVm.uiState.collectAsState()
     var selectedId by remember { mutableStateOf<Long?>(null) }
@@ -128,6 +131,27 @@ fun CharacterScreen(
             onBack = { previewTarget = null }
         )
         return
+    }
+
+    if (transferState.inProgress) {
+        val label = when (transferState.mode) {
+            TransferMode.EXPORT -> "正在导出..."
+            TransferMode.IMPORT -> "正在导入..."
+            null -> "处理中..."
+        }
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text(label) },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Text("请保持应用在前台以完成任务")
+                    transferState.progress?.let { progress ->
+                        LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
+                    } ?: LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                }
+            },
+            confirmButton = {}
+        )
     }
 
     Scaffold(

--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -82,6 +82,7 @@ import com.example.quotepicker.vm.TransferMode
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.launch
 import android.widget.Toast
+import java.util.Locale
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -139,12 +140,28 @@ fun CharacterScreen(
             TransferMode.IMPORT -> "正在导入..."
             null -> "处理中..."
         }
+        val processedBytes = transferState.processedBytes
+        val totalBytes = transferState.totalBytes
+        val outputBytes = transferState.outputBytes
+        val percent = if (processedBytes != null && totalBytes != null && totalBytes > 0) {
+            ((processedBytes.toDouble() / totalBytes.toDouble()) * 100).coerceIn(0.0, 100.0)
+        } else {
+            null
+        }
         AlertDialog(
             onDismissRequest = {},
             title = { Text(label) },
             text = {
                 Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                     Text("请保持应用在前台以完成任务")
+                    if (percent != null && processedBytes != null && totalBytes != null) {
+                        Text(
+                            "进度：${percent.toInt()}% (${formatBytes(processedBytes)} / ${formatBytes(totalBytes)})"
+                        )
+                    }
+                    if (transferState.mode == TransferMode.EXPORT && outputBytes != null) {
+                        Text("文件大小：${formatBytes(outputBytes)}")
+                    }
                     transferState.progress?.let { progress ->
                         LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())
                     } ?: LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
@@ -468,6 +485,22 @@ fun CharacterScreen(
             dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text("取消") } }
         )
     }
+}
+
+private fun formatBytes(bytes: Long): String {
+    val units = listOf("B", "KB", "MB", "GB", "TB")
+    var value = bytes.toDouble()
+    var unitIndex = 0
+    while (value >= 1024 && unitIndex < units.lastIndex) {
+        value /= 1024
+        unitIndex += 1
+    }
+    val format = when {
+        value >= 100 || unitIndex == 0 -> "%.0f"
+        value >= 10 -> "%.1f"
+        else -> "%.2f"
+    }
+    return "${String.format(Locale.getDefault(), format, value)} ${units[unitIndex]}"
 }
 
 @Composable

--- a/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
@@ -12,6 +12,9 @@ import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
 import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
 import java.nio.charset.Charset
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
@@ -35,7 +38,10 @@ data class CharacterUiState(
 data class TransferState(
     val inProgress: Boolean = false,
     val mode: TransferMode? = null,
-    val progress: Float? = null
+    val progress: Float? = null,
+    val processedBytes: Long? = null,
+    val totalBytes: Long? = null,
+    val outputBytes: Long? = null
 )
 
 enum class TransferMode {
@@ -88,86 +94,159 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch { repo.addResponseRecord(characterId, tagId, count) }
 
     fun exportSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
-        _transferState.update { it.copy(inProgress = true, mode = TransferMode.EXPORT, progress = 0f) }
+        _transferState.update {
+            it.copy(
+                inProgress = true,
+                mode = TransferMode.EXPORT,
+                progress = 0f,
+                processedBytes = 0L,
+                totalBytes = 0L,
+                outputBytes = 0L
+            )
+        }
         try {
             val resolver = getApplication<Application>().contentResolver
             val exportPackage = repo.exportSnapshotPackage()
-            val totalEntries = exportPackage.mediaPayloads.size + 1
-            var completedEntries = 0
-            resolver.openOutputStream(uri)?.use { output ->
-                ZipOutputStream(output).use { zip ->
-                    zip.putNextEntry(ZipEntry(BACKUP_JSON_NAME))
-                    zip.write(exportPackage.snapshot.toJsonString().toByteArray(Charset.forName("UTF-8")))
-                    zip.closeEntry()
-                    completedEntries += 1
-                    _transferState.update { it.copy(progress = completedEntries.toFloat() / totalEntries) }
-                    exportPackage.mediaPayloads.forEach { (fileName, bytes) ->
-                        zip.putNextEntry(ZipEntry("media/$fileName"))
-                        zip.write(bytes)
-                        zip.closeEntry()
-                        completedEntries += 1
-                        _transferState.update { current ->
-                            current.copy(progress = completedEntries.toFloat() / totalEntries)
-                        }
+            val snapshotBytes = exportPackage.snapshot.toJsonString().toByteArray(Charset.forName("UTF-8"))
+            val totalBytes = exportPackage.mediaPayloads.values.sumOf { it.size.toLong() } + snapshotBytes.size.toLong()
+            var processedBytes = 0L
+            var outputBytes = 0L
+            var lastProgressBytes = 0L
+            var lastOutputBytes = 0L
+            val safeTotalBytes = totalBytes.coerceAtLeast(1L)
+            fun updateProgress(force: Boolean = false) {
+                val progress = (processedBytes.toFloat() / safeTotalBytes).coerceIn(0f, 1f)
+                if (force || processedBytes - lastProgressBytes >= PROGRESS_UPDATE_BYTES || outputBytes - lastOutputBytes >= PROGRESS_UPDATE_BYTES) {
+                    lastProgressBytes = processedBytes
+                    lastOutputBytes = outputBytes
+                    _transferState.update { current ->
+                        current.copy(
+                            progress = progress,
+                            processedBytes = processedBytes,
+                            totalBytes = totalBytes,
+                            outputBytes = outputBytes
+                        )
                     }
                 }
             }
+            _transferState.update { it.copy(totalBytes = totalBytes) }
+            resolver.openOutputStream(uri)?.use { output ->
+                val countingOutput = CountingOutputStream(output) { bytesWritten ->
+                    outputBytes = bytesWritten
+                    updateProgress()
+                }
+                ZipOutputStream(countingOutput).use { zip ->
+                    zip.putNextEntry(ZipEntry(BACKUP_JSON_NAME))
+                    writeChunked(zip, snapshotBytes) { written ->
+                        processedBytes += written
+                        updateProgress()
+                    }
+                    zip.closeEntry()
+                    exportPackage.mediaPayloads.forEach { (fileName, bytes) ->
+                        zip.putNextEntry(ZipEntry("media/$fileName"))
+                        writeChunked(zip, bytes) { written ->
+                            processedBytes += written
+                            updateProgress()
+                        }
+                        zip.closeEntry()
+                    }
+                }
+            }
+            updateProgress(force = true)
         } finally {
-            _transferState.update { it.copy(inProgress = false, mode = null, progress = null) }
+            _transferState.update {
+                it.copy(
+                    inProgress = false,
+                    mode = null,
+                    progress = null,
+                    processedBytes = null,
+                    totalBytes = null,
+                    outputBytes = null
+                )
+            }
         }
     }
 
     fun importSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
-        _transferState.update { it.copy(inProgress = true, mode = TransferMode.IMPORT, progress = 0f) }
+        _transferState.update {
+            it.copy(
+                inProgress = true,
+                mode = TransferMode.IMPORT,
+                progress = 0f,
+                processedBytes = 0L,
+                totalBytes = 0L,
+                outputBytes = null
+            )
+        }
         try {
             val resolver = getApplication<Application>().contentResolver
             val bytes = resolver.openInputStream(uri)?.use { it.readBytes() } ?: return@launch
+            val totalBytes = bytes.size.toLong()
+            val safeTotalBytes = totalBytes.coerceAtLeast(1L)
+            var processedBytes = 0L
+            var lastProgressBytes = 0L
+            fun updateProgress(force: Boolean = false) {
+                val progress = (processedBytes.toFloat() / safeTotalBytes).coerceIn(0f, 1f)
+                if (force || processedBytes - lastProgressBytes >= PROGRESS_UPDATE_BYTES) {
+                    lastProgressBytes = processedBytes
+                    _transferState.update { current ->
+                        current.copy(
+                            progress = progress,
+                            processedBytes = processedBytes,
+                            totalBytes = totalBytes
+                        )
+                    }
+                }
+            }
+            _transferState.update { it.copy(totalBytes = totalBytes) }
             var snapshot: BackupSnapshot? = null
             val mediaPayloads = mutableMapOf<String, ByteArray>()
             if (bytes.size >= 2 && bytes[0] == ZIP_MAGIC_P && bytes[1] == ZIP_MAGIC_K) {
-                val totalEntries = ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
-                    var entryCount = 0
-                    var entry = zip.nextEntry
-                    while (entry != null) {
-                        entryCount += 1
-                        zip.closeEntry()
-                        entry = zip.nextEntry
-                    }
-                    entryCount.coerceAtLeast(1)
+                val countingInput = CountingInputStream(ByteArrayInputStream(bytes)) { bytesRead ->
+                    processedBytes = bytesRead
+                    updateProgress()
                 }
-                var completedEntries = 0
-                ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+                ZipInputStream(countingInput).use { zip ->
                     var entry = zip.nextEntry
                     var payload: String? = null
+                    val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
                     while (entry != null) {
                         when {
                             entry.name == BACKUP_JSON_NAME -> {
-                                payload = zip.readBytes().toString(Charset.forName("UTF-8"))
+                                payload = readEntryString(zip, buffer)
                             }
                             entry.name.startsWith("media/") -> {
                                 val fileName = entry.name.removePrefix("media/")
-                                mediaPayloads[fileName] = zip.readBytes()
+                                mediaPayloads[fileName] = readEntryBytes(zip, buffer)
                             }
                         }
                         zip.closeEntry()
-                        completedEntries += 1
-                        _transferState.update { current ->
-                            current.copy(progress = completedEntries.toFloat() / totalEntries)
-                        }
                         entry = zip.nextEntry
                     }
                     if (!payload.isNullOrBlank()) {
                         snapshot = BackupSnapshot.fromJson(payload)
                     }
+                    processedBytes = countingInput.bytesRead
+                    updateProgress(force = true)
                 }
             } else {
                 val payload = bytes.toString(Charset.forName("UTF-8"))
                 snapshot = BackupSnapshot.fromJson(payload)
-                _transferState.update { it.copy(progress = 1f) }
+                processedBytes = totalBytes
+                updateProgress(force = true)
             }
             snapshot?.let { repo.replaceSnapshot(it, mediaPayloads) }
         } finally {
-            _transferState.update { it.copy(inProgress = false, mode = null, progress = null) }
+            _transferState.update {
+                it.copy(
+                    inProgress = false,
+                    mode = null,
+                    progress = null,
+                    processedBytes = null,
+                    totalBytes = null,
+                    outputBytes = null
+                )
+            }
         }
     }
 
@@ -175,5 +254,89 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
         const val BACKUP_JSON_NAME = "backup.json"
         const val ZIP_MAGIC_P: Byte = 0x50
         const val ZIP_MAGIC_K: Byte = 0x4B
+        const val PROGRESS_UPDATE_BYTES = 32 * 1024
+    }
+
+    private class CountingOutputStream(
+        private val delegate: OutputStream,
+        private val onBytesWritten: (Long) -> Unit
+    ) : OutputStream() {
+        var bytesWritten: Long = 0
+            private set
+
+        override fun write(b: Int) {
+            delegate.write(b)
+            bytesWritten += 1
+            onBytesWritten(bytesWritten)
+        }
+
+        override fun write(b: ByteArray, off: Int, len: Int) {
+            delegate.write(b, off, len)
+            bytesWritten += len
+            onBytesWritten(bytesWritten)
+        }
+
+        override fun flush() {
+            delegate.flush()
+        }
+
+        override fun close() {
+            delegate.close()
+        }
+    }
+
+    private class CountingInputStream(
+        private val delegate: InputStream,
+        private val onBytesRead: (Long) -> Unit
+    ) : InputStream() {
+        var bytesRead: Long = 0
+            private set
+
+        override fun read(): Int {
+            val value = delegate.read()
+            if (value >= 0) {
+                bytesRead += 1
+                onBytesRead(bytesRead)
+            }
+            return value
+        }
+
+        override fun read(b: ByteArray, off: Int, len: Int): Int {
+            val read = delegate.read(b, off, len)
+            if (read > 0) {
+                bytesRead += read
+                onBytesRead(bytesRead)
+            }
+            return read
+        }
+
+        override fun close() {
+            delegate.close()
+        }
+    }
+
+    private fun writeChunked(output: OutputStream, data: ByteArray, onChunk: (Int) -> Unit) {
+        var offset = 0
+        while (offset < data.size) {
+            val size = minOf(PROGRESS_UPDATE_BYTES, data.size - offset)
+            output.write(data, offset, size)
+            onChunk(size)
+            offset += size
+        }
+    }
+
+    private fun readEntryBytes(zip: ZipInputStream, buffer: ByteArray): ByteArray {
+        val output = ByteArrayOutputStream()
+        var read = zip.read(buffer)
+        while (read > 0) {
+            output.write(buffer, 0, read)
+            read = zip.read(buffer)
+        }
+        return output.toByteArray()
+    }
+
+    private fun readEntryString(zip: ZipInputStream, buffer: ByteArray): String {
+        val output = readEntryBytes(zip, buffer)
+        return output.toString(Charset.forName("UTF-8"))
     }
 }

--- a/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
@@ -19,8 +19,10 @@ import java.util.zip.ZipOutputStream
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 data class CharacterUiState(
@@ -30,8 +32,21 @@ data class CharacterUiState(
     val executionSettings: com.example.quotepicker.data.ExecutionSettingsEntity = com.example.quotepicker.data.ExecutionSettingsEntity()
 )
 
+data class TransferState(
+    val inProgress: Boolean = false,
+    val mode: TransferMode? = null,
+    val progress: Float? = null
+)
+
+enum class TransferMode {
+    IMPORT,
+    EXPORT
+}
+
 class CharacterViewModel(app: Application) : AndroidViewModel(app) {
     private val repo = Repository.get(app)
+    private val _transferState = MutableStateFlow(TransferState())
+    val transferState: StateFlow<TransferState> = _transferState
 
     init {
         viewModelScope.launch {
@@ -73,53 +88,87 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch { repo.addResponseRecord(characterId, tagId, count) }
 
     fun exportSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
-        val resolver = getApplication<Application>().contentResolver
-        val exportPackage = repo.exportSnapshotPackage()
-        resolver.openOutputStream(uri)?.use { output ->
-            ZipOutputStream(output).use { zip ->
-                zip.putNextEntry(ZipEntry(BACKUP_JSON_NAME))
-                zip.write(exportPackage.snapshot.toJsonString().toByteArray(Charset.forName("UTF-8")))
-                zip.closeEntry()
-                exportPackage.mediaPayloads.forEach { (fileName, bytes) ->
-                    zip.putNextEntry(ZipEntry("media/$fileName"))
-                    zip.write(bytes)
+        _transferState.update { it.copy(inProgress = true, mode = TransferMode.EXPORT, progress = 0f) }
+        try {
+            val resolver = getApplication<Application>().contentResolver
+            val exportPackage = repo.exportSnapshotPackage()
+            val totalEntries = exportPackage.mediaPayloads.size + 1
+            var completedEntries = 0
+            resolver.openOutputStream(uri)?.use { output ->
+                ZipOutputStream(output).use { zip ->
+                    zip.putNextEntry(ZipEntry(BACKUP_JSON_NAME))
+                    zip.write(exportPackage.snapshot.toJsonString().toByteArray(Charset.forName("UTF-8")))
                     zip.closeEntry()
+                    completedEntries += 1
+                    _transferState.update { it.copy(progress = completedEntries.toFloat() / totalEntries) }
+                    exportPackage.mediaPayloads.forEach { (fileName, bytes) ->
+                        zip.putNextEntry(ZipEntry("media/$fileName"))
+                        zip.write(bytes)
+                        zip.closeEntry()
+                        completedEntries += 1
+                        _transferState.update { current ->
+                            current.copy(progress = completedEntries.toFloat() / totalEntries)
+                        }
+                    }
                 }
             }
+        } finally {
+            _transferState.update { it.copy(inProgress = false, mode = null, progress = null) }
         }
     }
 
     fun importSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
-        val resolver = getApplication<Application>().contentResolver
-        val bytes = resolver.openInputStream(uri)?.use { it.readBytes() } ?: return@launch
-        var snapshot: BackupSnapshot? = null
-        val mediaPayloads = mutableMapOf<String, ByteArray>()
-        if (bytes.size >= 2 && bytes[0] == ZIP_MAGIC_P && bytes[1] == ZIP_MAGIC_K) {
-            ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
-                var entry = zip.nextEntry
-                var payload: String? = null
-                while (entry != null) {
-                    when {
-                        entry.name == BACKUP_JSON_NAME -> {
-                            payload = zip.readBytes().toString(Charset.forName("UTF-8"))
-                        }
-                        entry.name.startsWith("media/") -> {
-                            val fileName = entry.name.removePrefix("media/")
-                            mediaPayloads[fileName] = zip.readBytes()
-                        }
+        _transferState.update { it.copy(inProgress = true, mode = TransferMode.IMPORT, progress = 0f) }
+        try {
+            val resolver = getApplication<Application>().contentResolver
+            val bytes = resolver.openInputStream(uri)?.use { it.readBytes() } ?: return@launch
+            var snapshot: BackupSnapshot? = null
+            val mediaPayloads = mutableMapOf<String, ByteArray>()
+            if (bytes.size >= 2 && bytes[0] == ZIP_MAGIC_P && bytes[1] == ZIP_MAGIC_K) {
+                val totalEntries = ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+                    var entryCount = 0
+                    var entry = zip.nextEntry
+                    while (entry != null) {
+                        entryCount += 1
+                        zip.closeEntry()
+                        entry = zip.nextEntry
                     }
-                    zip.closeEntry()
-                    entry = zip.nextEntry
+                    entryCount.coerceAtLeast(1)
                 }
-                if (!payload.isNullOrBlank()) {
-                    snapshot = BackupSnapshot.fromJson(payload)
+                var completedEntries = 0
+                ZipInputStream(ByteArrayInputStream(bytes)).use { zip ->
+                    var entry = zip.nextEntry
+                    var payload: String? = null
+                    while (entry != null) {
+                        when {
+                            entry.name == BACKUP_JSON_NAME -> {
+                                payload = zip.readBytes().toString(Charset.forName("UTF-8"))
+                            }
+                            entry.name.startsWith("media/") -> {
+                                val fileName = entry.name.removePrefix("media/")
+                                mediaPayloads[fileName] = zip.readBytes()
+                            }
+                        }
+                        zip.closeEntry()
+                        completedEntries += 1
+                        _transferState.update { current ->
+                            current.copy(progress = completedEntries.toFloat() / totalEntries)
+                        }
+                        entry = zip.nextEntry
+                    }
+                    if (!payload.isNullOrBlank()) {
+                        snapshot = BackupSnapshot.fromJson(payload)
+                    }
                 }
+            } else {
+                val payload = bytes.toString(Charset.forName("UTF-8"))
+                snapshot = BackupSnapshot.fromJson(payload)
+                _transferState.update { it.copy(progress = 1f) }
             }
-        } else {
-            val payload = bytes.toString(Charset.forName("UTF-8"))
-            snapshot = BackupSnapshot.fromJson(payload)
+            snapshot?.let { repo.replaceSnapshot(it, mediaPayloads) }
+        } finally {
+            _transferState.update { it.copy(inProgress = false, mode = null, progress = null) }
         }
-        snapshot?.let { repo.replaceSnapshot(it, mediaPayloads) }
     }
 
     private companion object {


### PR DESCRIPTION
### Motivation
- Exports could appear to stop if the app is backgrounded or closed, leaving users uncertain about progress. 
- Provide visible feedback during long-running import/export operations so users know the task is active. 
- Prevent accidental interruption by informing users to keep the app in the foreground during transfer.

### Description
- Added `TransferState` data class and `TransferMode` enum and exposed a `transferState: StateFlow<TransferState>` backed by `_transferState: MutableStateFlow` in `CharacterViewModel`. 
- Updated `exportSnapshot` to set the transfer state to `EXPORT`, stream entries into the zip, and update `progress` as entries complete, then clear the state on finish. 
- Updated `importSnapshot` to set the transfer state to `IMPORT`, count total ZIP entries, update `progress` while reading entries (including media), call `repo.replaceSnapshot(...)`, and clear the state on finish. 
- Updated `CharacterScreen` to collect `vm.transferState` and display a blocking `AlertDialog` with a `LinearProgressIndicator` and a message asking users to keep the app in the foreground during import/export.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976f2e40cfc832bb3ff06e1647dcb3f)