### PR TITLE
Group characters by squad tags on role list

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -84,7 +84,7 @@ import kotlinx.coroutines.launch
 import android.widget.Toast
 import java.util.Locale
 
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 fun CharacterScreen(
     modifier: Modifier = Modifier,
@@ -212,32 +212,68 @@ fun CharacterScreen(
                         Text("暂无角色，点击右下角添加")
                     }
                 } else {
-                    LazyVerticalGrid(
-                        columns = GridCells.Fixed(5),
-                        contentPadding = androidx.compose.foundation.layout.PaddingValues(8.dp),
-                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    val teamCategoryId = ui.categories.firstOrNull { it.name == "队伍体系" }?.id
+                    val teamEntries = ui.characters.map { character ->
+                        val teamTag = teamCategoryId?.let { categoryId ->
+                            character.tags.firstOrNull { it.categoryId == categoryId }
+                        }
+                        val info = parseTeamInfo(teamTag)
+                        CharacterTeamEntry(
+                            character = character,
+                            teamName = info.teamName,
+                            levelLabel = info.levelLabel,
+                            levelOrder = info.levelOrder,
+                            borderColor = info.borderColor
+                        )
+                    }
+                    val groupedTeams = teamEntries.groupBy { it.teamName }
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState())
+                            .padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp)
                     ) {
-                        items(ui.characters, key = { it.character.id }) { character ->
-                            SquareGridItem(
-                                title = character.character.name,
-                                bottomContent = {
-                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                        Text(
-                                            text = character.character.points.toString(),
-                                            style = MaterialTheme.typography.labelSmall,
-                                            color = Color(0xFF2E7D32)
-                                        )
-                                        Text(
-                                            text = "${character.character.probability}%",
-                                            style = MaterialTheme.typography.labelSmall,
-                                            color = Color(0xFF1565C0)
-                                        )
+                        groupedTeams.forEach { (teamName, members) ->
+                            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                                Text(text = teamName, style = MaterialTheme.typography.titleMedium)
+                                val groupedLevels = members
+                                    .groupBy { it.levelLabel }
+                                    .toList()
+                                    .sortedWith(compareBy({ it.second.first().levelOrder }, { it.first }))
+                                groupedLevels.forEach { (_, levelMembers) ->
+                                    FlowRow(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                                    ) {
+                                        levelMembers.forEach { entry ->
+                                            SquareGridItem(
+                                                title = entry.character.character.name,
+                                                subtitle = entry.levelLabel,
+                                                borderColor = entry.borderColor,
+                                                modifier = Modifier.width(96.dp),
+                                                bottomContent = {
+                                                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                                        Text(
+                                                            text = entry.character.character.points.toString(),
+                                                            style = MaterialTheme.typography.labelSmall,
+                                                            color = Color(0xFF2E7D32)
+                                                        )
+                                                        Text(
+                                                            text = "${entry.character.character.probability}%",
+                                                            style = MaterialTheme.typography.labelSmall,
+                                                            color = Color(0xFF1565C0)
+                                                        )
+                                                    }
+                                                },
+                                                onClick = { selectedId = entry.character.character.id },
+                                                onLongClick = { bottomSheetTarget = entry.character }
+                                            )
+                                        }
                                     }
-                                },
-                                onClick = { selectedId = character.character.id },
-                                onLongClick = { bottomSheetTarget = character }
-                            )
+                                }
+                            }
                         }
                     }
                 }
@@ -485,6 +521,34 @@ fun CharacterScreen(
             dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text("取消") } }
         )
     }
+}
+
+private data class CharacterTeamEntry(
+    val character: CharacterWithTags,
+    val teamName: String,
+    val levelLabel: String,
+    val levelOrder: Int,
+    val borderColor: Color?
+)
+
+private data class TeamTagInfo(
+    val teamName: String,
+    val levelLabel: String,
+    val levelOrder: Int,
+    val borderColor: Color?
+)
+
+private fun parseTeamInfo(tag: TagEntity?): TeamTagInfo {
+    val defaultTeam = "未分队"
+    val defaultLevel = "未设等级"
+    if (tag == null) {
+        return TeamTagInfo(defaultTeam, defaultLevel, Int.MAX_VALUE, null)
+    }
+    val parts = tag.name.split("|", limit = 2)
+    val teamName = parts.firstOrNull()?.ifBlank { defaultTeam } ?: defaultTeam
+    val levelLabel = parts.getOrNull(1)?.ifBlank { defaultLevel } ?: defaultLevel
+    val levelOrder = Regex("\\d+").find(levelLabel)?.value?.toIntOrNull() ?: Int.MAX_VALUE
+    return TeamTagInfo(teamName, levelLabel, levelOrder, Color(tag.colorArgb))
 }
 
 private fun formatBytes(bytes: Long): String {

--- a/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.BorderStroke
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -28,16 +29,19 @@ fun SquareGridItem(
     modifier: Modifier = Modifier,
     backgroundColor: Color = MaterialTheme.colorScheme.surface,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
+    borderColor: Color? = null,
     bottomContent: (@Composable () -> Unit)? = null,
     onClick: () -> Unit,
     onLongClick: () -> Unit
 ) {
+    val border = borderColor?.let { BorderStroke(1.dp, it) } ?: CardDefaults.outlinedCardBorder()
     OutlinedCard(
         modifier = modifier
             .aspectRatio(1f)
             .combinedClickable(onClick = onClick, onLongClick = onLongClick)
         ,
-        colors = CardDefaults.outlinedCardColors(containerColor = backgroundColor)
+        colors = CardDefaults.outlinedCardColors(containerColor = backgroundColor),
+        border = border
     ) {
         Box(
             modifier = Modifier


### PR DESCRIPTION
### Motivation
- Implement grouping of characters by the `队伍体系` tag category so the role list shows squads.
- Show the level label (e.g. `1级`) on each character card and make character card borders use the squad tag color rather than changing the background.
- Display characters split into separate lines per level within each squad for clearer visual grouping.

### Description
- Added optional `borderColor` support to `SquareGridItem` and apply a `BorderStroke` when provided (file: `app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt`).
- Added `parseTeamInfo` to parse a squad tag name formatted like `王牌小队|1级` into team name, level label, numeric order and color (file: `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt`).
- Built `CharacterTeamEntry` objects from `CharacterWithTags`, grouped entries by team and then by level, and render squads with level rows using `FlowRow`, passing `subtitle` and `borderColor` into `SquareGridItem` (file: `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt`).
- Opted into `ExperimentalLayoutApi` for the layout changes and kept existing behavior for selected character/detail views.

### Testing
- No automated tests were executed for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69771ed9d7ac832ba5c24782cdb08e18)