### PR TITLE
Show level above character name and fit 5 character cards per row

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -61,6 +61,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -244,15 +245,18 @@ fun CharacterScreen(
                                 groupedLevels.forEach { (_, levelMembers) ->
                                     FlowRow(
                                         modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                                        horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                        verticalArrangement = Arrangement.spacedBy(6.dp)
                                     ) {
                                         levelMembers.forEach { entry ->
                                             SquareGridItem(
                                                 title = entry.character.character.name,
                                                 subtitle = entry.levelLabel,
                                                 borderColor = entry.borderColor,
-                                                modifier = Modifier.width(96.dp),
+                                                subtitleOnTop = true,
+                                                subtitleColor = entry.borderColor,
+                                                subtitleFontWeight = FontWeight.Bold,
+                                                modifier = Modifier.width(60.dp),
                                                 bottomContent = {
                                                     Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                                                         Text(

--- a/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
@@ -30,11 +30,16 @@ fun SquareGridItem(
     backgroundColor: Color = MaterialTheme.colorScheme.surface,
     contentColor: Color = MaterialTheme.colorScheme.onSurface,
     borderColor: Color? = null,
+    subtitleOnTop: Boolean = false,
+    subtitleColor: Color? = null,
+    subtitleFontWeight: FontWeight? = null,
     bottomContent: (@Composable () -> Unit)? = null,
     onClick: () -> Unit,
     onLongClick: () -> Unit
 ) {
-    val border = borderColor?.let { BorderStroke(1.dp, it) } ?: CardDefaults.outlinedCardBorder()
+    val border = borderColor?.let { BorderStroke(2.dp, it) } ?: CardDefaults.outlinedCardBorder()
+    val resolvedSubtitleColor = subtitleColor ?: contentColor.copy(alpha = 0.8f)
+    val resolvedSubtitleWeight = subtitleFontWeight ?: FontWeight.Normal
     OutlinedCard(
         modifier = modifier
             .aspectRatio(1f)
@@ -46,13 +51,25 @@ fun SquareGridItem(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(10.dp),
+                .padding(6.dp),
             contentAlignment = Alignment.Center
         ) {
             Column(
                 verticalArrangement = Arrangement.spacedBy(4.dp),
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
+                if (subtitleOnTop) {
+                    subtitle?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = resolvedSubtitleColor,
+                            fontWeight = resolvedSubtitleWeight,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
+                }
                 Text(
                     text = title,
                     style = MaterialTheme.typography.bodyMedium,
@@ -61,14 +78,17 @@ fun SquareGridItem(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis
                 )
-                subtitle?.let {
-                    Text(
-                        text = it,
-                        style = MaterialTheme.typography.labelSmall,
-                        color = contentColor.copy(alpha = 0.8f),
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis
-                    )
+                if (!subtitleOnTop) {
+                    subtitle?.let {
+                        Text(
+                            text = it,
+                            style = MaterialTheme.typography.labelSmall,
+                            color = resolvedSubtitleColor,
+                            fontWeight = resolvedSubtitleWeight,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis
+                        )
+                    }
                 }
                 bottomContent?.invoke()
             }


### PR DESCRIPTION
### Motivation
- Surface the character "level" above the name and style it to match the character border, as the UI currently places the level below the name and the user requested it be shown above with matching border color and bold weight. 
- Reduce character card size and spacing so a single row can display five characters instead of the current three.

### Description
- Added optional subtitle placement and styling to `SquareGridItem` by introducing `subtitleOnTop`, `subtitleColor`, and `subtitleFontWeight` parameters, and resolving subtitle color/weight when provided in `app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt`.
- Increased border stroke for bordered cards from `1.dp` to `2.dp` and reduced internal padding from `10.dp` to `6.dp` in `SquareGridItem` to achieve a bolder border and smaller card footprint.
- Updated `CharacterScreen` to place the level (subtitle) above the character name and make it bold and the same color as the border by calling `SquareGridItem` with `subtitleOnTop = true`, `subtitleColor = entry.borderColor`, and `subtitleFontWeight = FontWeight.Bold`, and reduced card width from `96.dp` to `60.dp` while tightening spacing to `6.dp` to allow five items per row in `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt`.

### Testing
- No automated tests were run for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69772363a84c832b8a73e059e76d40ab)