### PR TITLE
Bump Room database version to 5

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
@@ -33,7 +33,7 @@ class Converters {
         ResponseRecordEntity::class,
         ExecutionSettingsEntity::class
     ],
-    version = 4,
+    version = 5,
     exportSchema = false
 )
 @TypeConverters(Converters::class)


### PR DESCRIPTION
### Motivation
- The app hit a Room integrity check failure (identity hash mismatch) after schema changes, so the database `version` must be increased to avoid `IllegalStateException` on open.

### Description
- Update the `@Database` `version` from `4` to `5` in `app/src/main/java/com/example/quotepicker/data/AppDatabase.kt` while retaining `.fallbackToDestructiveMigration()`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697879110c0c832bbd59eb378144c0bd)