### PR TITLE
Add character familiarity and streaming backup import/export

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
@@ -33,7 +33,7 @@ class Converters {
         ResponseRecordEntity::class,
         ExecutionSettingsEntity::class
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
+++ b/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
@@ -19,7 +19,7 @@ data class BackupSnapshot(
 
     fun toJson(): JSONObject {
         return JSONObject().apply {
-            put("version", 4)
+            put("version", 5)
             put("categories", JSONArray(categories.map(::categoryToJson)))
             put("tags", JSONArray(tags.map(::tagToJson)))
             put("characters", JSONArray(characters.map(::characterToJson)))
@@ -82,6 +82,7 @@ private fun characterToJson(character: CharacterEntity): JSONObject =
         .put("name", character.name)
         .put("description", character.description)
         .put("points", character.points)
+        .put("familiarity", character.familiarity)
         .put("probability", character.probability)
         .put("probabilityDate", character.probabilityDate)
         .put("createdAt", character.createdAt)
@@ -168,6 +169,7 @@ private fun characterFromJson(obj: JSONObject): CharacterEntity =
         name = obj.getString("name"),
         description = readNullableString(obj, "description"),
         points = obj.optInt("points", 30),
+        familiarity = obj.optInt("familiarity", 0),
         probability = obj.optInt("probability", 1),
         probabilityDate = readNullableString(obj, "probabilityDate"),
         createdAt = obj.getLong("createdAt"),

--- a/app/src/main/java/com/example/quotepicker/data/Entities.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Entities.kt
@@ -44,6 +44,7 @@ data class CharacterEntity(
     val name: String,
     val description: String? = null,
     val points: Int = 30,
+    val familiarity: Int = 0,
     val probability: Int = 1,
     val probabilityDate: String? = null,
     val createdAt: Long = System.currentTimeMillis(),

--- a/app/src/main/java/com/example/quotepicker/data/MediaPayload.kt
+++ b/app/src/main/java/com/example/quotepicker/data/MediaPayload.kt
@@ -1,0 +1,8 @@
+package com.example.quotepicker.data
+
+import java.io.File
+
+data class MediaPayload(
+    val bytes: ByteArray? = null,
+    val file: File? = null
+)

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.Uri
 import android.util.Base64
 import java.io.File
+import java.io.InputStream
 import java.time.LocalDate
 import org.json.JSONArray
 import kotlinx.coroutines.flow.Flow
@@ -33,23 +34,20 @@ class Repository private constructor(context: Context) {
 
     data class ExportPackage(
         val snapshot: BackupSnapshot,
-        val mediaPayloads: Map<String, ByteArray>
+        val mediaSources: List<MediaExportSource>
     )
 
     suspend fun exportSnapshot(): BackupSnapshot = exportSnapshotPackage().snapshot
 
     suspend fun exportSnapshotPackage(): ExportPackage {
         val resources = resourceDao.listAll()
-        val mediaPayloads = linkedMapOf<String, ByteArray>()
+        val mediaSources = mutableListOf<MediaExportSource>()
         val mediaItems = collectMediaPaths(resources).mapNotNull { (path, type) ->
-            val bytes = readMedia(path) ?: return@mapNotNull null
-            val fileName = "media_${mediaPayloads.size}_${path.hashCode()}.dat"
-            mediaPayloads[fileName] = bytes
-            MediaBackupItem(
-                originalPath = path,
-                type = type,
-                fileName = fileName
-            )
+            val stream = openMediaStream(path) ?: return@mapNotNull null
+            stream.close()
+            val fileName = "media_${mediaSources.size}_${path.hashCode()}.dat"
+            mediaSources.add(MediaExportSource(fileName = fileName, originalPath = path, type = type))
+            MediaBackupItem(originalPath = path, type = type, fileName = fileName)
         }
         val snapshot = BackupSnapshot(
             categories = categoryDao.listAll(),
@@ -63,10 +61,10 @@ class Repository private constructor(context: Context) {
             executionSettings = executionSettingsDao.getSettings(),
             media = mediaItems
         )
-        return ExportPackage(snapshot = snapshot, mediaPayloads = mediaPayloads)
+        return ExportPackage(snapshot = snapshot, mediaSources = mediaSources)
     }
 
-    suspend fun replaceSnapshot(snapshot: BackupSnapshot, mediaPayloads: Map<String, ByteArray> = emptyMap()) {
+    suspend fun replaceSnapshot(snapshot: BackupSnapshot, mediaPayloads: Map<String, MediaPayload> = emptyMap()) {
         val mediaMapping = restoreMedia(snapshot.media, mediaPayloads)
         val restoredResources = snapshot.resources.map { resource ->
             when (resource.type) {
@@ -367,27 +365,15 @@ class Repository private constructor(context: Context) {
         }.getOrDefault(emptyList())
     }
 
-    private fun readMedia(path: String): ByteArray? {
-        val uri = Uri.parse(path)
-        return runCatching {
-            if (uri.scheme == "file") {
-                val filePath = uri.path ?: return@runCatching null
-                File(filePath).takeIf { it.exists() }?.readBytes()
-            } else {
-                appContext.contentResolver.openInputStream(uri)?.use { it.readBytes() }
-            }
-        }.getOrNull()
-    }
-
     private fun restoreMedia(
         items: List<MediaBackupItem>,
-        mediaPayloads: Map<String, ByteArray>
+        mediaPayloads: Map<String, MediaPayload>
     ): Map<String, String> {
         if (items.isEmpty()) return emptyMap()
         val mapping = mutableMapOf<String, String>()
         items.forEach { item ->
-            val bytes = when {
-                item.base64 != null -> runCatching { Base64.decode(item.base64, Base64.DEFAULT) }.getOrNull()
+            val payload = when {
+                item.base64 != null -> MediaPayload(bytes = runCatching { Base64.decode(item.base64, Base64.DEFAULT) }.getOrNull())
                 item.fileName != null -> mediaPayloads[item.fileName]
                 else -> null
             } ?: return@forEach
@@ -400,7 +386,14 @@ class Repository private constructor(context: Context) {
             val dir = File(appContext.filesDir, folder).apply { mkdirs() }
             val target = File(dir, "media_import_${System.currentTimeMillis()}_${item.originalPath.hashCode()}.dat")
             runCatching {
-                target.writeBytes(bytes)
+                when {
+                    payload.bytes != null -> target.writeBytes(payload.bytes)
+                    payload.file != null -> payload.file.inputStream().use { input ->
+                        target.outputStream().use { output ->
+                            input.copyTo(output)
+                        }
+                    }
+                }
                 mapping[item.originalPath] = Uri.fromFile(target).toString()
             }
         }
@@ -485,6 +478,37 @@ class Repository private constructor(context: Context) {
     }
 
     private fun currentDateString(): String = LocalDate.now().toString()
+
+    fun openMediaStream(path: String): InputStream? {
+        val uri = Uri.parse(path)
+        return runCatching {
+            if (uri.scheme == "file") {
+                val filePath = uri.path ?: return@runCatching null
+                File(filePath).takeIf { it.exists() }?.inputStream()
+            } else {
+                appContext.contentResolver.openInputStream(uri)
+            }
+        }.getOrNull()
+    }
+
+    fun mediaSize(path: String): Long? {
+        val uri = Uri.parse(path)
+        return runCatching {
+            if (uri.scheme == "file") {
+                val filePath = uri.path ?: return@runCatching null
+                File(filePath).takeIf { it.exists() }?.length()?.takeIf { it > 0 }
+            } else {
+                appContext.contentResolver.openAssetFileDescriptor(uri, "r")?.use { it.length }
+                    ?.takeIf { it > 0 }
+            }
+        }.getOrNull()
+    }
+
+    data class MediaExportSource(
+        val fileName: String,
+        val originalPath: String,
+        val type: ResourceType
+    )
 
     companion object {
         const val ORPHAN_CATEGORY_NAME = "未分类"

--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -215,19 +215,20 @@ fun CharacterScreen(
                     }
                 } else {
                     val teamCategoryId = ui.categories.firstOrNull { it.name == "队伍体系" }?.id
-                    val teamEntries = ui.characters.map { character ->
-                        val teamTag = teamCategoryId?.let { categoryId ->
-                            character.tags.firstOrNull { it.categoryId == categoryId }
+                        val teamEntries = ui.characters.map { character ->
+                            val teamTag = teamCategoryId?.let { categoryId ->
+                                character.tags.firstOrNull { it.categoryId == categoryId }
+                            }
+                            val info = parseTeamInfo(teamTag)
+                            CharacterTeamEntry(
+                                character = character,
+                                teamName = info.teamName,
+                                levelLabel = info.levelLabel,
+                                levelOrder = info.levelOrder,
+                                borderColor = info.borderColor,
+                                familiarity = character.character.familiarity
+                            )
                         }
-                        val info = parseTeamInfo(teamTag)
-                        CharacterTeamEntry(
-                            character = character,
-                            teamName = info.teamName,
-                            levelLabel = info.levelLabel,
-                            levelOrder = info.levelOrder,
-                            borderColor = info.borderColor
-                        )
-                    }
                     val groupedTeams = teamEntries.groupBy { it.teamName }
                     Column(
                         modifier = Modifier
@@ -256,11 +257,27 @@ fun CharacterScreen(
                                             levelMembers.forEach { entry ->
                                                 SquareGridItem(
                                                     title = entry.character.character.name,
-                                                    subtitle = entry.levelLabel,
                                                     borderColor = entry.borderColor,
                                                     subtitleOnTop = true,
-                                                    subtitleColor = entry.borderColor,
-                                                    subtitleFontWeight = FontWeight.Bold,
+                                                    subtitleContent = {
+                                                        Row(
+                                                            modifier = Modifier.fillMaxWidth(),
+                                                            horizontalArrangement = Arrangement.SpaceBetween
+                                                        ) {
+                                                            Text(
+                                                                text = entry.familiarity.toString(),
+                                                                style = MaterialTheme.typography.labelSmall,
+                                                                color = Color(0xFFFF5DA2),
+                                                                fontWeight = FontWeight.Bold
+                                                            )
+                                                            Text(
+                                                                text = entry.levelLabel,
+                                                                style = MaterialTheme.typography.labelSmall,
+                                                                color = entry.borderColor ?: MaterialTheme.colorScheme.onSurfaceVariant,
+                                                                fontWeight = FontWeight.Bold
+                                                            )
+                                                        }
+                                                    },
                                                     modifier = Modifier.width(itemSize),
                                                     bottomContent = {
                                                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
@@ -348,7 +365,7 @@ fun CharacterScreen(
                                     Button(onClick = {
                                         val current = char
                                         if (current.points <= 0) {
-                                            vm.updateCharacterPoints(current.id, 30)
+                                            vm.updateCharacter(current.copy(points = 30, familiarity = current.familiarity + 1))
                                             val fallbackTag = narrativeTags.firstOrNull()
                                             if (fallbackTag != null) {
                                                 vm.addResponseRecord(current.id, fallbackTag.id, count = 3)
@@ -389,6 +406,7 @@ fun CharacterScreen(
                                                 ).show()
                                             }
                                         }
+                                        vm.consumeExecutionRemaining()
                                     }) {
                                         Text(ui.executionSettings.buttonLabel)
                                     }
@@ -538,7 +556,8 @@ private data class CharacterTeamEntry(
     val teamName: String,
     val levelLabel: String,
     val levelOrder: Int,
-    val borderColor: Color?
+    val borderColor: Color?,
+    val familiarity: Int
 )
 
 private data class TeamTagInfo(

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -174,7 +174,6 @@ fun ExecutionScreen(
                                     return@Button
                                 }
                                 vm.consumeRecord(record.characterId, record.tagId)
-                                vm.consumeExecutionRemaining()
                                 val candidates = ui.resources.filter { res ->
                                     res.characters.any { it.id == record.characterId } &&
                                         res.tags.any { it.id == record.tagId }

--- a/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/SquareGridItem.kt
@@ -33,6 +33,7 @@ fun SquareGridItem(
     subtitleOnTop: Boolean = false,
     subtitleColor: Color? = null,
     subtitleFontWeight: FontWeight? = null,
+    subtitleContent: (@Composable () -> Unit)? = null,
     bottomContent: (@Composable () -> Unit)? = null,
     onClick: () -> Unit,
     onLongClick: () -> Unit
@@ -59,15 +60,18 @@ fun SquareGridItem(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 if (subtitleOnTop) {
-                    subtitle?.let {
-                        Text(
-                            text = it,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = resolvedSubtitleColor,
-                            fontWeight = resolvedSubtitleWeight,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
-                        )
+                    when {
+                        subtitleContent != null -> subtitleContent()
+                        subtitle != null -> {
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = resolvedSubtitleColor,
+                                fontWeight = resolvedSubtitleWeight,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     }
                 }
                 Text(
@@ -79,15 +83,18 @@ fun SquareGridItem(
                     overflow = TextOverflow.Ellipsis
                 )
                 if (!subtitleOnTop) {
-                    subtitle?.let {
-                        Text(
-                            text = it,
-                            style = MaterialTheme.typography.labelSmall,
-                            color = resolvedSubtitleColor,
-                            fontWeight = resolvedSubtitleWeight,
-                            maxLines = 2,
-                            overflow = TextOverflow.Ellipsis
-                        )
+                    when {
+                        subtitleContent != null -> subtitleContent()
+                        subtitle != null -> {
+                            Text(
+                                text = subtitle,
+                                style = MaterialTheme.typography.labelSmall,
+                                color = resolvedSubtitleColor,
+                                fontWeight = resolvedSubtitleWeight,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis
+                            )
+                        }
                     }
                 }
                 bottomContent?.invoke()

--- a/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
@@ -12,6 +12,7 @@ import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 import java.io.PushbackInputStream
@@ -93,6 +94,12 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
     fun addResponseRecord(characterId: Long, tagId: Long, count: Int = 1) =
         viewModelScope.launch { repo.addResponseRecord(characterId, tagId, count) }
 
+    fun consumeExecutionRemaining() = viewModelScope.launch {
+        val current = uiState.value.executionSettings
+        if (current.remainingValue <= 0) return@launch
+        repo.updateExecutionSettings(current.copy(remainingValue = current.remainingValue - 1))
+    }
+
     fun exportSnapshot(uri: Uri) = viewModelScope.launch(Dispatchers.IO) {
         _transferState.update {
             it.copy(
@@ -108,7 +115,9 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
             val resolver = getApplication<Application>().contentResolver
             val exportPackage = repo.exportSnapshotPackage()
             val snapshotBytes = exportPackage.snapshot.toJsonString().toByteArray(Charset.forName("UTF-8"))
-            val totalBytes = exportPackage.mediaPayloads.values.sumOf { it.size.toLong() } + snapshotBytes.size.toLong()
+            val totalBytes = exportPackage.mediaSources.sumOf { source ->
+                repo.mediaSize(source.originalPath) ?: 0L
+            } + snapshotBytes.size.toLong()
             var processedBytes = 0L
             var outputBytes = 0L
             var lastProgressBytes = 0L
@@ -142,13 +151,16 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
                         updateProgress()
                     }
                     zip.closeEntry()
-                    exportPackage.mediaPayloads.forEach { (fileName, bytes) ->
-                        zip.putNextEntry(ZipEntry("media/$fileName"))
-                        writeChunked(zip, bytes) { written ->
-                            processedBytes += written
-                            updateProgress()
+                    exportPackage.mediaSources.forEach { source ->
+                        val stream = repo.openMediaStream(source.originalPath) ?: return@forEach
+                        stream.use { input ->
+                            zip.putNextEntry(ZipEntry("media/${source.fileName}"))
+                            writeStreamChunked(input, zip) { written ->
+                                processedBytes += written
+                                updateProgress()
+                            }
+                            zip.closeEntry()
                         }
-                        zip.closeEntry()
                     }
                 }
             }
@@ -178,6 +190,7 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
                 outputBytes = null
             )
         }
+        val tempFiles = mutableListOf<File>()
         try {
             val resolver = getApplication<Application>().contentResolver
             val totalBytes = resolver.openAssetFileDescriptor(uri, "r")?.use { it.length }?.takeIf { it > 0 }
@@ -200,7 +213,7 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
             }
             _transferState.update { it.copy(totalBytes = totalBytes) }
             var snapshot: BackupSnapshot? = null
-            val mediaPayloads = mutableMapOf<String, ByteArray>()
+            val mediaPayloads = mutableMapOf<String, com.example.quotepicker.data.MediaPayload>()
             resolver.openInputStream(uri)?.use { input ->
                 val pushbackInput = PushbackInputStream(input, 2)
                 val header = ByteArray(2)
@@ -217,7 +230,7 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
                     ZipInputStream(countingInput).use { zip ->
                         var entry = zip.nextEntry
                         var payload: String? = null
-                        val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+                        val buffer = ByteArray(PROGRESS_UPDATE_BYTES)
                         while (entry != null) {
                             when {
                                 entry.name == BACKUP_JSON_NAME -> {
@@ -225,7 +238,10 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
                                 }
                                 entry.name.startsWith("media/") -> {
                                     val fileName = entry.name.removePrefix("media/")
-                                    mediaPayloads[fileName] = readEntryBytes(zip, buffer)
+                                    val temp = File.createTempFile("media_import_", ".dat", getApplication<Application>().cacheDir)
+                                    tempFiles.add(temp)
+                                    readEntryToFile(zip, temp, buffer)
+                                    mediaPayloads[fileName] = com.example.quotepicker.data.MediaPayload(file = temp)
                                 }
                             }
                             zip.closeEntry()
@@ -246,6 +262,7 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
             }
             snapshot?.let { repo.replaceSnapshot(it, mediaPayloads) }
         } finally {
+            tempFiles.forEach { file -> file.delete() }
             _transferState.update {
                 it.copy(
                     inProgress = false,
@@ -263,7 +280,7 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
         const val BACKUP_JSON_NAME = "backup.json"
         const val ZIP_MAGIC_P: Byte = 0x50
         const val ZIP_MAGIC_K: Byte = 0x4B
-        const val PROGRESS_UPDATE_BYTES = 32 * 1024
+        const val PROGRESS_UPDATE_BYTES = 256 * 1024
     }
 
     private class CountingOutputStream(
@@ -344,6 +361,16 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
         return output.toByteArray()
     }
 
+    private fun readEntryToFile(zip: ZipInputStream, target: File, buffer: ByteArray) {
+        target.outputStream().use { output ->
+            var read = zip.read(buffer)
+            while (read > 0) {
+                output.write(buffer, 0, read)
+                read = zip.read(buffer)
+            }
+        }
+    }
+
     private fun readEntryString(zip: ZipInputStream, buffer: ByteArray): String {
         val output = readEntryBytes(zip, buffer)
         return output.toString(Charset.forName("UTF-8"))
@@ -358,5 +385,15 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
             read = input.read(buffer)
         }
         return output.toString(Charset.forName("UTF-8"))
+    }
+
+    private fun writeStreamChunked(input: InputStream, output: OutputStream, onChunk: (Int) -> Unit) {
+        val buffer = ByteArray(PROGRESS_UPDATE_BYTES)
+        var read = input.read(buffer)
+        while (read > 0) {
+            output.write(buffer, 0, read)
+            onChunk(read)
+            read = input.read(buffer)
+        }
     }
 }


### PR DESCRIPTION
### Motivation
- Expose and persist a new per-character `familiarity` metric and show it in the team grid so users can track familiarity next to level. 
- Increment familiarity when a character is refreshed/refilled (the points refresh action) so familiarity grows after the 30-point reset. 
- Stop deducting execution remaining from response-record quick-buttons and instead deduct when the character-level prayer button is used to match intended UX. 
- Improve import/export performance and memory usage for large backups (100MB+ and up to GBs) by streaming media into/out of zip archives instead of materializing large byte arrays.

### Description
- Added a new field `familiarity: Int = 0` to `CharacterEntity` and wired it into backup serialization/deserialization by bumping `BackupSnapshot` version to `5` and the Room `AppDatabase` version to `6`.
- Surface `familiarity` in the UI by adding `subtitleContent` to `SquareGridItem` and rendering a pink familiarity number to the left of the level label in the team grid in `CharacterScreen`.
- When a character is refreshed (points reset to 30), update the character with `familiarity = familiarity + 1` via `vm.updateCharacter(...)`, and move execution-remaining consumption to the character prayer button by adding `consumeExecutionRemaining()` to `CharacterViewModel` and calling it from `CharacterScreen`, while removing the decrement from the response-record buttons in `RandomScreen`.
- Reworked backup export/import pipeline to stream media: introduced `MediaPayload` and `MediaExportSource`, changed `Repository.exportSnapshotPackage()` to emit `mediaSources` and to test media availability via `openMediaStream()`/`mediaSize()`, updated `CharacterViewModel.exportSnapshot()` to stream source files into the zip via `writeStreamChunked()`, and updated `importSnapshot()` to extract media entries to temporary files and pass file-backed `MediaPayload` into `Repository.replaceSnapshot()` for efficient restoring.
- Switched chunking to larger updates (`PROGRESS_UPDATE_BYTES` increased to 256 KB) and added helpers `readEntryToFile()`, `writeStreamChunked()` and temp-file cleanup to reduce I/O overhead and memory pressure for large backups.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697955d191d8832b8a13bb137ff98900)