### PR TITLE
Add clickable file tokens and grouped storage management

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -424,7 +424,11 @@ fun CharacterScreen(
                                 if (introText.isBlank()) {
                                     Text("暂无要点", style = MaterialTheme.typography.labelMedium)
                                 } else {
-                                    PreviewTextBlock(text = introText, onEventSequence = {})
+                                    PreviewTextBlock(
+                                        text = introText,
+                                        onEventSequence = {},
+                                        onFilePreview = {}
+                                    )
                                 }
                             }
                         }

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -70,10 +70,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
+import android.widget.Toast
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.ResourceType
@@ -81,6 +84,7 @@ import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.ui.components.CharacterBadge
+import com.example.quotepicker.ui.components.encodeResourceFileInfo
 import com.example.quotepicker.ui.components.ResourceGridCard
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.TagBadge
@@ -128,6 +132,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     if (manageScreen) {
         ManageStorageScreen(
             items = manageItems,
+            resources = allResources,
             vm = vm,
             onBack = { manageScreen = false },
             onRestore = { item ->
@@ -338,21 +343,24 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
 @Composable
 private fun ManageStorageScreen(
     items: List<StoredMediaItem>,
+    resources: List<ResourceWithTagsCharacters>,
     vm: ResourceViewModel,
     onBack: () -> Unit,
     onRestore: (StoredMediaItem) -> Unit,
     onRefresh: () -> Unit
 ) {
     val context = LocalContext.current
+    val clipboard = LocalClipboardManager.current
     val imagesDir = remember { File(context.filesDir, "images").absolutePath }
     val videosDir = remember { File(context.filesDir, "videos").absolutePath }
     val audioDir = remember { File(context.filesDir, "audio").absolutePath }
-    var displayType by remember { mutableStateOf(ResourceType.IMAGE) }
     var actionTarget by remember { mutableStateOf<StoredMediaItem?>(null) }
     var deleteTarget by remember { mutableStateOf<StoredMediaItem?>(null) }
+    var imageExpanded by remember { mutableStateOf(true) }
+    var videoExpanded by remember { mutableStateOf(true) }
+    var soundExpanded by remember { mutableStateOf(true) }
     val coroutineScope = rememberCoroutineScope()
-    val filteredItems = remember(items, displayType) { items.filter { it.type == displayType } }
-    val displayTypes = listOf(ResourceType.IMAGE, ResourceType.VIDEO, ResourceType.SOUND)
+    val groupedItems = remember(items, resources) { buildStoredMediaGroups(items, resources) }
 
     Scaffold(
         topBar = {
@@ -364,18 +372,6 @@ private fun ManageStorageScreen(
                     }
                 },
                 actions = {
-                    TextButton(onClick = {
-                        val index = displayTypes.indexOf(displayType).takeIf { it >= 0 } ?: 0
-                        displayType = displayTypes[(index + 1) % displayTypes.size]
-                    }) {
-                        Text(
-                            when (displayType) {
-                                ResourceType.IMAGE -> "显示视频"
-                                ResourceType.VIDEO -> "显示音频"
-                                else -> "显示图片"
-                            }
-                        )
-                    }
                     TextButton(onClick = onRefresh) { Text("刷新") }
                 }
             )
@@ -394,17 +390,87 @@ private fun ManageStorageScreen(
                 Text("视频目录：$videosDir", style = MaterialTheme.typography.labelSmall)
                 Text("音频目录：$audioDir", style = MaterialTheme.typography.labelSmall)
             }
-            Text("长按文件可选择恢复或删除", style = MaterialTheme.typography.labelSmall)
-            if (filteredItems.isEmpty()) {
-                Text("暂无文件", style = MaterialTheme.typography.labelMedium)
-            } else {
-                LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
-                    items(filteredItems, key = { it.path }) { item ->
-                        StorageMediaRow(
-                            item = item,
-                            vm = vm,
-                            onLongPress = { actionTarget = item }
-                        )
+            Text("长按文件可复制文件信息并管理", style = MaterialTheme.typography.labelSmall)
+            LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                item {
+                    StorageSectionHeader(
+                        title = "图片组",
+                        expanded = imageExpanded,
+                        onToggle = { imageExpanded = !imageExpanded }
+                    )
+                }
+                if (imageExpanded) {
+                    val imageGroups = groupedItems[ResourceType.IMAGE].orEmpty()
+                    if (imageGroups.isEmpty()) {
+                        item { Text("暂无图片文件", style = MaterialTheme.typography.labelMedium) }
+                    } else {
+                        imageGroups.forEach { group ->
+                            item { StorageGroupHeader(title = group.title) }
+                            items(group.items, key = { it.path }) { item ->
+                                StorageMediaRow(
+                                    item = item,
+                                    vm = vm,
+                                    onLongPress = {
+                                        copyFileInfo(item, clipboard, context)
+                                        actionTarget = item
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+                item {
+                    StorageSectionHeader(
+                        title = "视频组",
+                        expanded = videoExpanded,
+                        onToggle = { videoExpanded = !videoExpanded }
+                    )
+                }
+                if (videoExpanded) {
+                    val videoGroups = groupedItems[ResourceType.VIDEO].orEmpty()
+                    if (videoGroups.isEmpty()) {
+                        item { Text("暂无视频文件", style = MaterialTheme.typography.labelMedium) }
+                    } else {
+                        videoGroups.forEach { group ->
+                            item { StorageGroupHeader(title = group.title) }
+                            items(group.items, key = { it.path }) { item ->
+                                StorageMediaRow(
+                                    item = item,
+                                    vm = vm,
+                                    onLongPress = {
+                                        copyFileInfo(item, clipboard, context)
+                                        actionTarget = item
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+                item {
+                    StorageSectionHeader(
+                        title = "声音组",
+                        expanded = soundExpanded,
+                        onToggle = { soundExpanded = !soundExpanded }
+                    )
+                }
+                if (soundExpanded) {
+                    val soundGroups = groupedItems[ResourceType.SOUND].orEmpty()
+                    if (soundGroups.isEmpty()) {
+                        item { Text("暂无声音文件", style = MaterialTheme.typography.labelMedium) }
+                    } else {
+                        soundGroups.forEach { group ->
+                            item { StorageGroupHeader(title = group.title) }
+                            items(group.items, key = { it.path }) { item ->
+                                StorageMediaRow(
+                                    item = item,
+                                    vm = vm,
+                                    onLongPress = {
+                                        copyFileInfo(item, clipboard, context)
+                                        actionTarget = item
+                                    }
+                                )
+                            }
+                        }
                     }
                 }
             }
@@ -532,6 +598,100 @@ private fun StorageMediaRow(
             )
         }
     }
+}
+
+private data class StoredMediaGroup(
+    val title: String,
+    val items: List<StoredMediaItem>
+)
+
+@Composable
+private fun StorageSectionHeader(
+    title: String,
+    expanded: Boolean,
+    onToggle: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onToggle() }
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(title, style = MaterialTheme.typography.titleMedium)
+        Icon(
+            imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
+            contentDescription = if (expanded) "折叠" else "展开"
+        )
+    }
+}
+
+@Composable
+private fun StorageGroupHeader(title: String) {
+    Text(
+        text = title,
+        style = MaterialTheme.typography.labelMedium,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.padding(top = 8.dp)
+    )
+}
+
+private fun buildStoredMediaGroups(
+    items: List<StoredMediaItem>,
+    resources: List<ResourceWithTagsCharacters>
+): Map<ResourceType, List<StoredMediaGroup>> {
+    val imageTitleMap = mutableMapOf<String, String>()
+    val videoTitleMap = mutableMapOf<String, String>()
+    val soundTitleMap = mutableMapOf<String, String>()
+
+    resources.forEach { resource ->
+        when (resource.resource.type) {
+            ResourceType.IMAGE -> {
+                parseImageItems(resource.resource.contentUriOrPath, resource.resource.quoteImageBase64)
+                    .forEach { item ->
+                        item.path?.let { imageTitleMap[it] = resource.resource.title }
+                    }
+            }
+            ResourceType.VIDEO -> {
+                parseVideoItems(resource.resource.contentUriOrPath)
+                    .forEach { item ->
+                        item.path?.let { videoTitleMap[it] = resource.resource.title }
+                    }
+            }
+            ResourceType.SOUND -> {
+                parseSoundItems(resource.resource.contentUriOrPath)
+                    .forEach { item ->
+                        item.path?.let { soundTitleMap[it] = resource.resource.title }
+                    }
+            }
+            else -> Unit
+        }
+    }
+
+    fun groupItems(type: ResourceType, titleMap: Map<String, String>): List<StoredMediaGroup> {
+        val groups = items.filter { it.type == type }
+            .groupBy { titleMap[it.path] ?: "未归档" }
+        return groups.entries.sortedBy { it.key }.map { (title, groupItems) ->
+            StoredMediaGroup(title = title, items = groupItems.sortedBy { it.path })
+        }
+    }
+
+    return mapOf(
+        ResourceType.IMAGE to groupItems(ResourceType.IMAGE, imageTitleMap),
+        ResourceType.VIDEO to groupItems(ResourceType.VIDEO, videoTitleMap),
+        ResourceType.SOUND to groupItems(ResourceType.SOUND, soundTitleMap)
+    )
+}
+
+private fun copyFileInfo(
+    item: StoredMediaItem,
+    clipboard: androidx.compose.ui.platform.ClipboardManager,
+    context: android.content.Context
+) {
+    val info = encodeResourceFileInfo(item.type, Uri.parse(item.path))
+    clipboard.setText(AnnotatedString(info))
+    Toast.makeText(context, "文件信息已复制", Toast.LENGTH_SHORT).show()
 }
 
 private sealed class CreateMode {

--- a/app/src/main/java/com/example/quotepicker/ui/components/PreviewTextBlock.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/PreviewTextBlock.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.ExperimentalLayoutApi
 sealed interface PreviewSegment {
     data class TextSegment(val text: String) : PreviewSegment
     data class EventSegment(val sequence: EventSequence) : PreviewSegment
+    data class FileSegment(val label: String, val fileInfo: String) : PreviewSegment
 }
 
 data class EventSequence(
@@ -39,6 +40,7 @@ sealed interface EventStep {
 
 private val eventTokenRegex = Regex("\\+\\+(.*?)\\+\\+")
 private val eventStepRegex = Regex("\\[(.*?)]")
+private val fileTokenRegex = Regex("@([^@]+)@\\(([^)]*)\\)")
 
 fun parsePreviewSegments(text: String, random: Random = Random.Default): List<PreviewSegment> {
     if (text.isBlank()) return listOf(PreviewSegment.TextSegment(text))
@@ -47,26 +49,22 @@ fun parsePreviewSegments(text: String, random: Random = Random.Default): List<Pr
     eventTokenRegex.findAll(text).forEach { match ->
         if (match.range.first > lastIndex) {
             val raw = text.substring(lastIndex, match.range.first)
-            if (raw.isNotBlank()) {
-                segments.add(PreviewSegment.TextSegment(formatDisplayText(raw, random)))
-            }
+            segments.addAll(parseFileSegments(raw, random))
         }
         val token = match.groupValues.getOrNull(1).orEmpty()
         val sequence = parseEventSequence(token)
         if (sequence != null) {
             segments.add(PreviewSegment.EventSegment(sequence))
         } else if (token.isNotBlank()) {
-            segments.add(PreviewSegment.TextSegment(formatDisplayText(token, random)))
+            segments.addAll(parseFileSegments(token, random))
         }
         lastIndex = match.range.last + 1
     }
     if (lastIndex < text.length) {
         val tail = text.substring(lastIndex)
-        if (tail.isNotBlank()) {
-            segments.add(PreviewSegment.TextSegment(formatDisplayText(tail, random)))
-        }
+        segments.addAll(parseFileSegments(tail, random))
     }
-    return if (segments.isEmpty()) listOf(PreviewSegment.TextSegment(formatDisplayText(text, random))) else segments
+    return if (segments.isEmpty()) parseFileSegments(text, random) else segments
 }
 
 fun parseEventSequence(raw: String): EventSequence? {
@@ -103,6 +101,7 @@ fun parseEventSequence(raw: String): EventSequence? {
 fun PreviewTextBlock(
     text: String,
     onEventSequence: (EventSequence) -> Unit,
+    onFilePreview: (String) -> Unit = {},
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MaterialTheme.typography.bodyMedium
 ) {
@@ -133,8 +132,49 @@ fun PreviewTextBlock(
                             style = textStyle
                         )
                     }
+                    is PreviewSegment.FileSegment -> {
+                        Text(
+                            text = segment.label,
+                            modifier = Modifier
+                                .clickable { onFilePreview(segment.fileInfo) }
+                                .padding(vertical = 2.dp),
+                            color = MaterialTheme.colorScheme.secondary,
+                            fontWeight = FontWeight.SemiBold,
+                            textDecoration = TextDecoration.Underline,
+                            style = textStyle
+                        )
+                    }
                 }
             }
         }
     }
+}
+
+private fun parseFileSegments(text: String, random: Random): List<PreviewSegment> {
+    if (text.isBlank()) return emptyList()
+    val segments = mutableListOf<PreviewSegment>()
+    var lastIndex = 0
+    fileTokenRegex.findAll(text).forEach { match ->
+        if (match.range.first > lastIndex) {
+            val raw = text.substring(lastIndex, match.range.first)
+            if (raw.isNotBlank()) {
+                segments.add(PreviewSegment.TextSegment(formatDisplayText(raw, random)))
+            }
+        }
+        val label = match.groupValues.getOrNull(1).orEmpty().trim()
+        val info = match.groupValues.getOrNull(2).orEmpty()
+        if (label.isNotBlank() && info.isNotBlank()) {
+            segments.add(PreviewSegment.FileSegment(label = "@$label", fileInfo = info))
+        } else if (match.value.isNotBlank()) {
+            segments.add(PreviewSegment.TextSegment(formatDisplayText(match.value, random)))
+        }
+        lastIndex = match.range.last + 1
+    }
+    if (lastIndex < text.length) {
+        val tail = text.substring(lastIndex)
+        if (tail.isNotBlank()) {
+            segments.add(PreviewSegment.TextSegment(formatDisplayText(tail, random)))
+        }
+    }
+    return if (segments.isEmpty()) listOf(PreviewSegment.TextSegment(formatDisplayText(text, random))) else segments
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
@@ -1,0 +1,22 @@
+package com.example.quotepicker.ui.components
+
+import android.net.Uri
+import com.example.quotepicker.data.ResourceType
+
+data class ResourceFileInfo(
+    val type: ResourceType,
+    val uri: Uri
+)
+
+fun encodeResourceFileInfo(type: ResourceType, uri: Uri): String {
+    val encodedUri = Uri.encode(uri.toString())
+    return "type=${type.name};uri=$encodedUri"
+}
+
+fun decodeResourceFileInfo(raw: String): ResourceFileInfo? {
+    val trimmed = raw.trim()
+    val match = Regex("type=([A-Z]+);uri=(.+)").find(trimmed) ?: return null
+    val type = runCatching { ResourceType.valueOf(match.groupValues[1]) }.getOrNull() ?: return null
+    val uriValue = Uri.decode(match.groupValues[2])
+    return ResourceFileInfo(type = type, uri = Uri.parse(uriValue))
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.util.Log
 import android.media.MediaPlayer
 import android.widget.MediaController
+import android.widget.Toast
 import android.widget.VideoView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -35,6 +36,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -56,6 +58,7 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.example.quotepicker.data.ResourceType
@@ -99,6 +102,8 @@ fun ResourcePreviewScreen(
     val scrollState = rememberScrollState()
     val uiState by vm.uiState.collectAsState()
     val allResources by vm.allResources.collectAsState()
+    val context = LocalContext.current
+    var filePreviewInfo by remember { mutableStateOf<ResourceFileInfo?>(null) }
     val sortedTags = remember(resource.tags, uiState.categories) {
         sortTagsForDisplay(resource.tags, uiState.categories)
     }
@@ -106,6 +111,14 @@ fun ResourcePreviewScreen(
         uiState.characters.firstOrNull { it.id == id }?.name
     }
     val eventRunner = rememberEventSequenceRunner()
+    val handleFilePreview: (String) -> Unit = { info ->
+        val decoded = decodeResourceFileInfo(info)
+        if (decoded == null) {
+            Toast.makeText(context, "文件信息无效", Toast.LENGTH_SHORT).show()
+        } else {
+            filePreviewInfo = decoded
+        }
+    }
 
     LaunchedEffect(resource.resource.id, mediaReloadKey, allResources) {
         val res = resource.resource
@@ -232,7 +245,8 @@ fun ResourcePreviewScreen(
                                 if (quoteText.isNotBlank()) {
                                     PreviewTextBlock(
                                         text = quoteText,
-                                        onEventSequence = handleEventSequence
+                                        onEventSequence = handleEventSequence,
+                                        onFilePreview = handleFilePreview
                                     )
                                 }
                                 QuoteImagePager(images = quoteImages)
@@ -275,7 +289,8 @@ fun ResourcePreviewScreen(
                                             SceneBubble(
                                                 message = message,
                                                 highlightedSpeaker = highlightedSpeaker,
-                                                onEventSequence = handleEventSequence
+                                                onEventSequence = handleEventSequence,
+                                                onFilePreview = handleFilePreview
                                             )
                                         }
                                     }
@@ -302,7 +317,8 @@ fun ResourcePreviewScreen(
                                                         ResourceType.TEXT -> {
                                                             PreviewTextBlock(
                                                                 text = item.text,
-                                                                onEventSequence = handleEventSequence
+                                                                onEventSequence = handleEventSequence,
+                                                                onFilePreview = handleFilePreview
                                                             )
                                                         }
                                                         ResourceType.SCENE -> {
@@ -310,7 +326,8 @@ fun ResourcePreviewScreen(
                                                                 SceneBubble(
                                                                     message = message,
                                                                     highlightedSpeaker = highlightedSpeaker,
-                                                                    onEventSequence = handleEventSequence
+                                                                    onEventSequence = handleEventSequence,
+                                                                    onFilePreview = handleFilePreview
                                                                 )
                                                             }
                                                         }
@@ -353,16 +370,27 @@ fun ResourcePreviewScreen(
             }
         }
     }
+    filePreviewInfo?.let { info ->
+        FilePreviewDialog(
+            info = info,
+            vm = vm,
+            onDismiss = { filePreviewInfo = null }
+        )
+    }
 }
 
 @Composable
-private fun MediaPreview(uri: Uri) {
+private fun MediaPreview(uri: Uri, modifier: Modifier = Modifier) {
     val viewHolder = remember { mutableStateOf<VideoView?>(null) }
     DisposableEffect(Unit) {
         onDispose {
             viewHolder.value?.stopPlayback()
         }
     }
+    val baseModifier = Modifier
+        .fillMaxWidth()
+        .height(420.dp)
+        .background(MaterialTheme.colorScheme.surfaceVariant)
     AndroidView(
         factory = { context ->
             VideoView(context).apply {
@@ -391,10 +419,7 @@ private fun MediaPreview(uri: Uri) {
                 view.setVideoURI(uri)
             }
         },
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(420.dp)
-            .background(MaterialTheme.colorScheme.surfaceVariant)
+        modifier = baseModifier.then(modifier)
     )
 }
 
@@ -537,7 +562,8 @@ private fun decodeImageSource(item: String, vm: ResourceViewModel): android.grap
 private fun SceneBubble(
     message: SceneMessage,
     highlightedSpeaker: String?,
-    onEventSequence: (EventSequence) -> Unit
+    onEventSequence: (EventSequence) -> Unit,
+    onFilePreview: (String) -> Unit
 ) {
     val isHighlighted = highlightedSpeaker != null && highlightedSpeaker == message.speaker
     Row(
@@ -565,8 +591,84 @@ private fun SceneBubble(
             PreviewTextBlock(
                 text = message.content,
                 onEventSequence = onEventSequence,
+                onFilePreview = onFilePreview,
                 textStyle = MaterialTheme.typography.bodyMedium
             )
+        }
+    }
+}
+
+@Composable
+private fun FilePreviewDialog(
+    info: ResourceFileInfo,
+    vm: ResourceViewModel,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("文件预览") },
+        text = {
+            when (info.type) {
+                ResourceType.IMAGE -> {
+                    val preview by androidx.compose.runtime.produceState<android.graphics.Bitmap?>(initialValue = null, info.uri) {
+                        value = vm.decodeUriToBitmap(info.uri)
+                    }
+                    if (preview != null) {
+                        Image(
+                            bitmap = preview!!.asImageBitmap(),
+                            contentDescription = "图片预览",
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .aspectRatio(1.3f),
+                            contentScale = ContentScale.Crop
+                        )
+                    } else {
+                        Text("图片加载中…")
+                    }
+                }
+                ResourceType.VIDEO -> {
+                    MediaPreview(
+                        uri = info.uri,
+                        modifier = Modifier.height(220.dp)
+                    )
+                }
+                ResourceType.SOUND -> {
+                    AudioPreviewSingle(uri = info.uri)
+                }
+                else -> Text("暂不支持的文件类型")
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text("关闭") }
+        }
+    )
+}
+
+@Composable
+private fun AudioPreviewSingle(uri: Uri) {
+    val context = LocalContext.current
+    val playerState = remember { mutableStateOf<MediaPlayer?>(null) }
+    DisposableEffect(Unit) {
+        onDispose {
+            playerState.value?.release()
+            playerState.value = null
+        }
+    }
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(text = "音频文件", style = MaterialTheme.typography.labelMedium)
+        TextButton(onClick = {
+            playerState.value?.release()
+            playerState.value = MediaPlayer().apply {
+                setDataSource(context, uri)
+                setOnPreparedListener { it.start() }
+                prepareAsync()
+            }
+        }) {
+            Text("播放")
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Support a new inline file token syntax `@文本@(文件信息)` so previews can include clickable file links that open file previews. 
- Make stored app media easier to manage by grouping files by resource and type in the storage manager and enabling quick copy of file info to the clipboard.

### Description
- Add parsing of file tokens and a `FileSegment` to `PreviewTextBlock` with `parseFileSegments` so `@label@(info)` parts render as clickable labels and propagate clicks via a new `onFilePreview` callback. 
- Add `ResourceFileInfo` and helper functions `encodeResourceFileInfo` / `decodeResourceFileInfo` to encode/decode file metadata (`type` + `uri`) used for clipboard copy and preview handling. 
- Wire file preview handling into `ResourcePreviewScreen`, add `handleFilePreview` to decode the token payload and show a `FilePreviewDialog` that supports image, video (`MediaPreview`), and audio (`AudioPreviewSingle`). 
- Rework storage management in `ManageStorageScreen` (in `ResourceScreen`) to group stored files by type and resource title, present collapsible sections (`StorageSectionHeader`), and long-press copies encoded file info to the clipboard via `copyFileInfo`. 
- Propagate the new `onFilePreview` parameter where `PreviewTextBlock` is used (e.g. `CharacterScreen`) and make `MediaPreview` accept an optional `modifier` for reuse in dialogs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697982f71ec8832bba689a4cf629f4c4)