### PR TITLE
Fix compose layout opt-ins

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -341,7 +341,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 private fun ManageStorageScreen(
     items: List<StoredMediaItem>,

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll


### PR DESCRIPTION
### Motivation
- Ensure experimental Compose layout APIs are properly opted-in so `FlowRow` usage compiles and add the missing `heightIn` import used by the file preview dialog to fix layout/preview issues.

### Description
- Opted in to `ExperimentalLayoutApi` for the Manage Storage screen by updating `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`, and added the `heightIn` import in `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt` to resolve the missing reference.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979958cf780832bb5ebf995752f1d15)