### PR TITLE
Sort team sections alphabetically in character list

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -230,6 +230,8 @@ fun CharacterScreen(
                             )
                         }
                     val groupedTeams = teamEntries.groupBy { it.teamName }
+                        .toList()
+                        .sortedBy { it.first }
                     Column(
                         modifier = Modifier
                             .fillMaxSize()


### PR DESCRIPTION
### Motivation
- Ensure team groups are displayed in a deterministic, alphabetical order in the character list; no Codex skills were used.

### Description
- In `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt` convert the `groupBy` result to a list and sort it with `.toList().sortedBy { it.first }` before rendering team sections.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979c1cbb3a4832b9ad01d4d611eabb9)