### PR TITLE
Add pinch-to-zoom and panning for full-screen media previews

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -9,6 +9,8 @@ import android.widget.VideoView
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.rememberTransformableState
+import androidx.compose.foundation.gestures.transformable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -57,6 +59,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.platform.LocalContext
@@ -913,6 +916,13 @@ private fun QuoteImagePager(images: List<ImagePreviewItem>) {
 
 @Composable
 private fun FullScreenImageDialog(bitmap: android.graphics.Bitmap, onDismiss: () -> Unit) {
+    val maxScale = 8f
+    var scale by remember { mutableStateOf(1f) }
+    var offset by remember { mutableStateOf(Offset.Zero) }
+    val transformState = rememberTransformableState { zoomChange, panChange, _ ->
+        scale = (scale * zoomChange).coerceIn(1f, maxScale)
+        offset += panChange
+    }
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
@@ -921,13 +931,21 @@ private fun FullScreenImageDialog(bitmap: android.graphics.Bitmap, onDismiss: ()
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.Black)
+                .transformable(state = transformState)
                 .clickable(onClick = onDismiss)
         ) {
             Image(
                 bitmap = bitmap.asImageBitmap(),
                 contentDescription = null,
                 contentScale = ContentScale.Fit,
-                modifier = Modifier.fillMaxSize()
+                modifier = Modifier
+                    .fillMaxSize()
+                    .graphicsLayer {
+                        scaleX = scale
+                        scaleY = scale
+                        translationX = offset.x
+                        translationY = offset.y
+                    }
             )
             IconButton(
                 onClick = onDismiss,
@@ -941,16 +959,24 @@ private fun FullScreenImageDialog(bitmap: android.graphics.Bitmap, onDismiss: ()
 
 @Composable
 private fun FullScreenVideoDialog(uri: Uri, onDismiss: () -> Unit) {
+    val maxScale = 8f
     Dialog(
         onDismissRequest = onDismiss,
         properties = DialogProperties(usePlatformDefaultWidth = false)
     ) {
         var landscape by remember { mutableStateOf(false) }
         var aspectRatio by remember { mutableStateOf(0f) }
+        var scale by remember { mutableStateOf(1f) }
+        var offset by remember { mutableStateOf(Offset.Zero) }
+        val transformState = rememberTransformableState { zoomChange, panChange, _ ->
+            scale = (scale * zoomChange).coerceIn(1f, maxScale)
+            offset += panChange
+        }
         Box(
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.Black)
+                .transformable(state = transformState)
         ) {
             val viewHolder = remember { mutableStateOf<VideoView?>(null) }
             DisposableEffect(Unit) {
@@ -1000,6 +1026,10 @@ private fun FullScreenVideoDialog(uri: Uri, onDismiss: () -> Unit) {
                     )
                     .graphicsLayer {
                         rotationZ = if (landscape) 90f else 0f
+                        scaleX = scale
+                        scaleY = scale
+                        translationX = offset.x
+                        translationY = offset.y
                     }
             )
             Row(


### PR DESCRIPTION
### Motivation
- Make full-screen image and video previews manually zoomable and pannable so users can inspect high-resolution media.
- Prevent runaway scaling by capping zoom so large/high-res images and videos remain usable and do not become effectively infinite.

### Description
- Enable gesture support by importing and using `rememberTransformableState` and `transformable` and adding `Offset` state for pan in both `FullScreenImageDialog` and `FullScreenVideoDialog`.
- Add `scale` and `offset` states and a `transformState` that applies pinch-to-zoom and pan, bounded by `maxScale` (set to `8f`).
- Apply the zoom and pan via `graphicsLayer` on the displayed `Image` and the `AndroidView` `VideoView` container so both images and videos respect the transform.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c4b2e9190832b8a8ffed638d54882)