### PR TITLE
Fix ResourceScreen compile issues

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalLayoutApi::class)
+
 package com.example.quotepicker.ui
 
 import android.content.Intent
@@ -36,6 +38,7 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Chat
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DriveFileMove
 import androidx.compose.material.icons.filled.Edit


### PR DESCRIPTION
### Motivation
- Resolve a compile-time/IDE issue in `ResourceScreen.kt` caused by using the experimental `FlowRow` API and a missing icon import. 

### Description
- Add a file-level opt-in `@file:OptIn(ExperimentalLayoutApi::class)` to allow usage of `FlowRow` without warnings in `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`.
- Import the `ContentCopy` material icon (`Icons.Default.ContentCopy`) to restore the copy action button usage in the same file.

### Testing
- No automated tests or CI runs were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69803cb12608832ba2789a0aa09de17b)