### PR TITLE
Fix fullscreen media pinch zoom interactions

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -938,7 +938,6 @@ private fun FullScreenImageDialog(bitmap: android.graphics.Bitmap, onDismiss: ()
                 .fillMaxSize()
                 .background(Color.Black)
                 .transformable(state = transformState)
-                .clickable(onClick = onDismiss)
         ) {
             Image(
                 bitmap = bitmap.asImageBitmap(),
@@ -982,7 +981,6 @@ private fun FullScreenVideoDialog(uri: Uri, onDismiss: () -> Unit) {
             modifier = Modifier
                 .fillMaxSize()
                 .background(Color.Black)
-                .transformable(state = transformState)
         ) {
             val viewHolder = remember { mutableStateOf<VideoView?>(null) }
             DisposableEffect(Unit) {
@@ -1020,6 +1018,7 @@ private fun FullScreenVideoDialog(uri: Uri, onDismiss: () -> Unit) {
                     }
                 },
                 modifier = Modifier
+                    .transformable(state = transformState)
                     .fillMaxSize()
                     .then(
                         if (aspectRatio > 0f) {


### PR DESCRIPTION
### Motivation

- Users reported that fullscreen image and video views no longer supported free pinch-zoom and pan gestures because touch events were being intercepted by container modifiers.

### Description

- Removed the top-level `clickable(onClick = onDismiss)` from the `FullScreenImageDialog` container so tap-to-dismiss no longer interrupts transform gestures.
- Moved the `transformable` modifier out of the fullscreen video `Box` and onto the `AndroidView` `VideoView`'s `Modifier` so pinch/pan gestures are delivered to the actual video view.
- Kept the close controls intact and preserved existing scale limits (`maxScale = 8f`) and translation logic in both dialogs.
- Modified file `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt` to apply these changes.

### Testing

- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, but the build failed to start because the Gradle wrapper download was blocked by a network/proxy error (`HTTP/1.1 403 Forbidden`), so no local compilation results are available.
- No automated unit or instrumentation tests were run in this environment due to the network-restricted build failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698548c89c18832b99f36e4dad05f1ac)