### PR TITLE
Fix CharacterScreen lazy list imports

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -19,9 +19,8 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.clickable
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts


### PR DESCRIPTION
### Motivation
- The Compose UI file imported `lazy.grid` symbols while the code uses `LazyColumn`/`items`, which produced unresolved symbol/compilation errors.

### Description
- Replaced `androidx.compose.foundation.lazy.grid.GridCells`, `LazyVerticalGrid`, and `androidx.compose.foundation.lazy.grid.items` imports with `androidx.compose.foundation.lazy.LazyColumn` and `androidx.compose.foundation.lazy.items` in `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt`.

### Testing
- Ran `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper download was blocked by a network proxy (`HTTP/1.1 403 Forbidden`), so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951764aa34832ba6b0e39048745796)