### PR TITLE
Fix Compose API usage in ResourceListRow

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -26,7 +26,7 @@ import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
 import org.json.JSONArray
 
-@OptIn(ExperimentalFoundationApi::class)
+@OptIn(ExperimentalFoundationApi::class, ExperimentalLayoutApi::class)
 @Composable
 fun ResourceListRow(
     resource: ResourceWithTagsCharacters,


### PR DESCRIPTION
### Motivation
- 修复 `ResourceListRow.kt` 中由于错误/缺失的 Compose 导入和实验性 API 导入导致的编译错误与警告。

### Description
- 从 `app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt` 中移除对 `foundation.layout.weight` 的显式导入并添加对 `ExperimentalLayoutApi` 的导入与 `@OptIn(ExperimentalLayoutApi::class)`，以允许使用 `FlowRow` 并保留 `Modifier.weight(1f)` 的正常使用。

### Testing
- 运行了自动化编译命令 `bash ./gradlew :app:compileDebugKotlin` 作为验证步骤，但在当前环境中 Gradle Wrapper 下载被代理拦截，出现 `HTTP/1.1 403 Forbidden`，因此自动化编译验证未能完成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995187fc438832bb89d9e83d21a8994)