### PR TITLE
新增标签“使用中”视觉标记并完善资源分组与标签可见性

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Dao.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Dao.kt
@@ -145,6 +145,12 @@ interface CrossRefDao {
     @Query("SELECT * FROM resource_character_cross_ref")
     suspend fun listResourceCharacters(): List<ResourceCharacterCrossRef>
 
+    @Query("SELECT DISTINCT tagId FROM resource_tag_cross_ref")
+    fun observeUsedResourceTagIds(): Flow<List<Long>>
+
+    @Query("SELECT DISTINCT tagId FROM character_tag_cross_ref")
+    fun observeUsedCharacterTagIds(): Flow<List<Long>>
+
     @Query("DELETE FROM resource_tag_cross_ref WHERE resourceId = :resourceId")
     suspend fun clearResourceTags(resourceId: Long)
 
@@ -177,6 +183,9 @@ interface ResponseRecordDao {
 
     @Query("SELECT * FROM response_records")
     suspend fun listAll(): List<ResponseRecordEntity>
+
+    @Query("SELECT DISTINCT tagId FROM response_records")
+    fun observeUsedTagIds(): Flow<List<Long>>
 
     @Query("SELECT * FROM response_records WHERE characterId = :characterId AND tagId = :tagId LIMIT 1")
     suspend fun findRecord(characterId: Long, tagId: Long): ResponseRecordEntity?

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -8,6 +8,7 @@ import java.io.InputStream
 import java.time.LocalDate
 import org.json.JSONArray
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 
 class Repository private constructor(context: Context) {
     private val appContext = context.applicationContext
@@ -30,6 +31,13 @@ class Repository private constructor(context: Context) {
     fun observeResources(): Flow<List<ResourceEntity>> = resourceDao.observeResources()
     fun observeResourcesWithRelations(): Flow<List<ResourceWithTagsCharacters>> = resourceDao.observeResourcesWithRelations()
     fun observeResponseRecords(): Flow<List<ResponseRecordEntity>> = responseRecordDao.observeRecords()
+    fun observeUsedTagIds(): Flow<Set<Long>> = combine(
+        crossRefDao.observeUsedResourceTagIds(),
+        crossRefDao.observeUsedCharacterTagIds(),
+        responseRecordDao.observeUsedTagIds()
+    ) { resourceTagIds, characterTagIds, responseTagIds ->
+        (resourceTagIds + characterTagIds + responseTagIds).toSet()
+    }
     fun observeExecutionSettings(): Flow<ExecutionSettingsEntity?> = executionSettingsDao.observeSettings()
 
     data class ExportPackage(

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -189,7 +190,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
 
     openedGroup?.let { target ->
         ResourceGroupScreen(
-            title = target.key,
+            title = target.title,
             resources = target.resources,
             categories = ui.categories,
             onBack = { openedGroup = null },
@@ -259,7 +260,8 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                     ) {
                         items(groupedResources, key = { it.key }) { group ->
                             GroupListRow(
-                                name = group.key,
+                                name = group.title,
+                                childNames = group.childNames,
                                 count = group.resources.size,
                                 onClick = { openedGroup = group }
                             )
@@ -866,6 +868,8 @@ private fun FilterBar(
 
 private data class ResourceTitleGroup(
     val key: String,
+    val title: String,
+    val childNames: String,
     val resources: List<ResourceWithTagsCharacters>
 )
 
@@ -875,41 +879,66 @@ private fun buildResourceGroups(
     level2: Boolean
 ): List<ResourceTitleGroup> {
     if (!level1 && !level2) return emptyList()
-    val grouped = resources.groupBy { resourceTitleGroupKey(it.resource.title, level1, level2) }
+    val grouped = resources.groupBy { resourceTitleGroupKey(it.resource.title, level1, level2).first }
     return grouped.entries
         .sortedWith(compareByDescending<Map.Entry<String, List<ResourceWithTagsCharacters>>> { it.value.size }.thenBy { it.key })
-        .map { ResourceTitleGroup(it.key, it.value) }
+        .map { entry ->
+            val childNames = entry.value
+                .mapNotNull { resourceTitleGroupKey(it.resource.title, level1, level2).second }
+                .distinct()
+                .joinToString("・")
+            ResourceTitleGroup(
+                key = entry.key,
+                title = entry.key,
+                childNames = childNames,
+                resources = entry.value
+            )
+        }
 }
 
-private fun resourceTitleGroupKey(title: String, level1: Boolean, level2: Boolean): String {
+private fun resourceTitleGroupKey(title: String, level1: Boolean, level2: Boolean): Pair<String, String?> {
     val parts = title.split("-").map { it.trim() }.filter { it.isNotEmpty() }
     val p1 = parts.getOrNull(0)
     val p2 = parts.getOrNull(1)
+    val p3 = parts.getOrNull(2)
     return when {
-        level1 && level2 -> listOfNotNull(p1, p2).joinToString("-").ifBlank { "未分组" }
-        level1 -> p1 ?: "未分组"
-        level2 -> p2 ?: "未分组"
-        else -> title
+        level1 && level2 -> {
+            val name = listOfNotNull(p1, p2).joinToString("-").ifBlank { "未分组" }
+            name to p3
+        }
+        level1 -> (p1 ?: "未分组") to p2
+        level2 -> (p2 ?: "未分组") to p3
+        else -> title to null
     }
 }
 
 @Composable
 private fun GroupListRow(
     name: String,
+    childNames: String,
     count: Int,
     onClick: () -> Unit
 ) {
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
+            .border(1.dp, MaterialTheme.colorScheme.outlineVariant)
             .clip(MaterialTheme.shapes.small)
             .clickable(onClick = onClick)
             .padding(horizontal = 8.dp, vertical = 10.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
+        verticalArrangement = Arrangement.spacedBy(2.dp)
     ) {
-        Text(name, style = MaterialTheme.typography.bodyMedium, fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
-        Text("${count}个资源", color = Color(0xFF1565C0), style = MaterialTheme.typography.labelMedium)
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(name, style = MaterialTheme.typography.bodyMedium, fontWeight = androidx.compose.ui.text.font.FontWeight.Bold)
+            Text("${count}个资源", color = Color(0xFF1565C0), style = MaterialTheme.typography.labelMedium)
+        }
+        if (childNames.isNotBlank()) {
+            Text(childNames, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
+        }
     }
 }
 

--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -180,10 +180,12 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                         items(tags, key = { it.id }) { tag ->
                             val bg = Color(tag.colorArgb)
                             val textColor = if (bg.luminance() < 0.5f) Color.White else Color.Black
+                            val isUsed = tag.id in ui.usedTagIds
                             SquareGridItem(
                                 title = formatTagLabel(tag.name),
                                 backgroundColor = bg,
                                 contentColor = textColor,
+                                borderColor = if (isUsed) Color.Black else null,
                                 onClick = {},
                                 onLongClick = { bottomSheetTarget = tag }
                             )

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt
@@ -3,6 +3,7 @@ package com.example.quotepicker.ui.components
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.border
 import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.FlowRow
@@ -100,6 +101,7 @@ private fun CompactTagLabel(tag: TagEntity) {
         fontSize = 10.sp,
         lineHeight = 10.sp,
         modifier = Modifier
+            .background(bgColor)
             .border(0.5.dp, bgColor)
             .padding(horizontal = 4.dp, vertical = 1.dp)
     )

--- a/app/src/main/java/com/example/quotepicker/vm/TagViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/TagViewModel.kt
@@ -19,7 +19,8 @@ data class TagUiState(
     val categories: List<TagCategoryEntity> = emptyList(),
     val currentCategory: TagCategoryEntity? = null,
     val tags: List<TagEntity> = emptyList(),
-    val allTags: List<TagEntity> = emptyList()
+    val allTags: List<TagEntity> = emptyList(),
+    val usedTagIds: Set<Long> = emptySet()
 )
 
 class TagViewModel(app: Application) : AndroidViewModel(app) {
@@ -38,10 +39,17 @@ class TagViewModel(app: Application) : AndroidViewModel(app) {
         repo.observeCategories(),
         selectedCategoryId,
         tagsFlow,
-        repo.observeAllTags()
-    ) { categories, selectedId, tags, allTags ->
+        repo.observeAllTags(),
+        repo.observeUsedTagIds()
+    ) { categories, selectedId, tags, allTags, usedTagIds ->
         val current = categories.firstOrNull { it.id == selectedId }
-        TagUiState(categories = categories, currentCategory = current, tags = tags, allTags = allTags)
+        TagUiState(
+            categories = categories,
+            currentCategory = current,
+            tags = tags,
+            allTags = allTags,
+            usedTagIds = usedTagIds
+        )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, TagUiState())
 
     fun selectCategory(id: Long?) { selectedCategoryId.value = id }


### PR DESCRIPTION
### Motivation
- 修复资源列表中紧凑标签在浅色主题下不可读的问题并恢复标签背景色以提高可识别性。 
- 改善按名称分组时的组卡片展示，显示与资源项一致的边框并在第二行展示下一级名称以便快速识别子分类。 
- 增加标签“是否正在被使用”的视觉标记，已被使用的标签边框变黑，便于快速判断可删除/可合并的标签。 

### Description
- 在 `ResourceListRow.CompactTagLabel` 恢复并使用 `background`，同时保留边框以修复浅色主题下白字不可见的问题（文件：`ResourceListRow.kt`）。
- 重构分组数据结构并展示：`resourceTitleGroupKey` 改为返回 `Pair<String, String?>` 以同时提供组键与下一级名；`ResourceTitleGroup` 增加 `title` 与 `childNames` 字段；`buildResourceGroups` 聚合逻辑修改以生成去重的下级名并作为第二行显示；`GroupListRow` 从单行 `Row` 改为 `Column`，并增加与资源项一致的边框与第二行渲染（文件：`ResourceScreen.kt`）。
- 在 DAO 层新增用于监听“正在被使用的标签 ID”的查询：`observeUsedResourceTagIds()`、`observeUsedCharacterTagIds()` 与 `observeUsedTagIds()`（文件：`Dao.kt`）。
- 在 `Repository` 新增 `observeUsedTagIds(): Flow<Set<Long>>`，将资源标签、角色标签和响应记录来源的 ID 聚合并去重（文件：`Repository.kt`）。
- 在 VM/UI 层传递并使用该信息：`TagUiState` 新增 `usedTagIds` 字段，`TagViewModel` 在 `combine` 中接入 `repo.observeUsedTagIds()`，`TagScreen` 渲染时根据 `tag.id in ui.usedTagIds` 将 `SquareGridItem` 的 `borderColor` 设为 `Color.Black`（文件：`TagViewModel.kt`、`TagScreen.kt`）。

### Testing
- 尝试构建应用：运行 `bash ./gradlew :app:assembleDebug`，构建未完成（本地环境 `gradlew` 权限问题后续通过代理下载 Gradle 分发包时遭遇 HTTP 403，导致构建失败）。
- 尝试通过 Playwright 截图页面（`page.goto('http://localhost:8080')`）以做端到端可视化验证，因目标服务不可用返回 `ERR_EMPTY_RESPONSE`，未能取得截图。 
- 未能在当前受限网络/执行环境下完成二进制构建或运行时验证，变更已通过静态代码修改与文本检查（搜索/替换、编译级 API 使用检查）进行本地校验。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69951d20577c832bba02b18210f14e36)