### PR TITLE
Persist execution resources and avoid consuming records when no match

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
@@ -31,9 +31,10 @@ class Converters {
         CharacterTagCrossRef::class,
         ResourceCharacterCrossRef::class,
         ResponseRecordEntity::class,
-        ExecutionSettingsEntity::class
+        ExecutionSettingsEntity::class,
+        ExecutionResourceEntity::class
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -45,6 +46,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun crossRefDao(): CrossRefDao
     abstract fun responseRecordDao(): ResponseRecordDao
     abstract fun executionSettingsDao(): ExecutionSettingsDao
+    abstract fun executionResourceDao(): ExecutionResourceDao
 
     companion object {
         @Volatile private var INSTANCE: AppDatabase? = null

--- a/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
+++ b/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
@@ -13,13 +13,14 @@ data class BackupSnapshot(
     val resourceCharacterRefs: List<ResourceCharacterCrossRef>,
     val responseRecords: List<ResponseRecordEntity> = emptyList(),
     val executionSettings: ExecutionSettingsEntity? = null,
+    val executionResources: List<ExecutionResourceEntity> = emptyList(),
     val media: List<MediaBackupItem> = emptyList()
 ) {
     fun toJsonString(): String = toJson().toString()
 
     fun toJson(): JSONObject {
         return JSONObject().apply {
-            put("version", 5)
+            put("version", 6)
             put("categories", JSONArray(categories.map(::categoryToJson)))
             put("tags", JSONArray(tags.map(::tagToJson)))
             put("characters", JSONArray(characters.map(::characterToJson)))
@@ -29,6 +30,7 @@ data class BackupSnapshot(
             put("resourceCharacterRefs", JSONArray(resourceCharacterRefs.map(::resourceCharacterToJson)))
             put("responseRecords", JSONArray(responseRecords.map(::responseRecordToJson)))
             executionSettings?.let { put("executionSettings", executionSettingsToJson(it)) }
+            put("executionResources", JSONArray(executionResources.map(::executionResourceToJson)))
             put("media", JSONArray(media.map(::mediaToJson)))
         }
     }
@@ -46,6 +48,7 @@ data class BackupSnapshot(
                 resourceCharacterRefs = parseArray(obj, "resourceCharacterRefs", ::resourceCharacterFromJson),
                 responseRecords = parseArray(obj, "responseRecords", ::responseRecordFromJson),
                 executionSettings = obj.optJSONObject("executionSettings")?.let(::executionSettingsFromJson),
+                executionResources = parseArray(obj, "executionResources", ::executionResourceFromJson),
                 media = parseArray(obj, "media", ::mediaFromJson)
             )
         }
@@ -135,6 +138,17 @@ private fun executionSettingsToJson(settings: ExecutionSettingsEntity): JSONObje
         .put("lastExecutionDate", settings.lastExecutionDate)
         .put("createdAt", settings.createdAt)
         .put("updatedAt", settings.updatedAt)
+
+
+private fun executionResourceToJson(item: ExecutionResourceEntity): JSONObject =
+    JSONObject()
+        .put("id", item.id)
+        .put("resourceId", item.resourceId)
+        .put("characterId", item.characterId)
+        .put("tagId", item.tagId)
+        .put("characterName", item.characterName)
+        .put("tagName", item.tagName)
+        .put("createdAt", item.createdAt)
 
 private fun mediaToJson(item: MediaBackupItem): JSONObject =
     JSONObject().apply {
@@ -228,6 +242,18 @@ private fun executionSettingsFromJson(obj: JSONObject): ExecutionSettingsEntity 
         lastExecutionDate = readNullableString(obj, "lastExecutionDate"),
         createdAt = obj.optLong("createdAt", System.currentTimeMillis()),
         updatedAt = obj.optLong("updatedAt", System.currentTimeMillis())
+    )
+
+
+private fun executionResourceFromJson(obj: JSONObject): ExecutionResourceEntity =
+    ExecutionResourceEntity(
+        id = obj.optLong("id", 0),
+        resourceId = obj.getLong("resourceId"),
+        characterId = obj.getLong("characterId"),
+        tagId = obj.getLong("tagId"),
+        characterName = obj.optString("characterName", "角色"),
+        tagName = obj.optString("tagName", "标签"),
+        createdAt = obj.optLong("createdAt", System.currentTimeMillis())
     )
 
 private fun mediaFromJson(obj: JSONObject): MediaBackupItem =

--- a/app/src/main/java/com/example/quotepicker/data/Dao.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Dao.kt
@@ -214,3 +214,21 @@ interface ExecutionSettingsDao {
     @Query("DELETE FROM execution_settings")
     suspend fun deleteAll()
 }
+
+@Dao
+interface ExecutionResourceDao {
+    @Query("SELECT * FROM execution_resources ORDER BY createdAt ASC")
+    fun observeItems(): Flow<List<ExecutionResourceEntity>>
+
+    @Query("SELECT * FROM execution_resources ORDER BY createdAt ASC")
+    suspend fun listAll(): List<ExecutionResourceEntity>
+
+    @Insert
+    suspend fun insert(item: ExecutionResourceEntity)
+
+    @Query("DELETE FROM execution_resources WHERE id = :id")
+    suspend fun deleteById(id: Long)
+
+    @Query("DELETE FROM execution_resources")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/example/quotepicker/data/Entities.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Entities.kt
@@ -77,6 +77,17 @@ data class ExecutionSettingsEntity(
     val updatedAt: Long = System.currentTimeMillis()
 )
 
+@Entity(tableName = "execution_resources")
+data class ExecutionResourceEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val resourceId: Long,
+    val characterId: Long,
+    val tagId: Long,
+    val characterName: String,
+    val tagName: String,
+    val createdAt: Long = System.currentTimeMillis()
+)
+
 @Entity(tableName = "resources")
 data class ResourceEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -20,6 +20,7 @@ class Repository private constructor(context: Context) {
     private val crossRefDao = db.crossRefDao()
     private val responseRecordDao = db.responseRecordDao()
     private val executionSettingsDao = db.executionSettingsDao()
+    private val executionResourceDao = db.executionResourceDao()
 
     fun observeCategories(): Flow<List<TagCategoryEntity>> = categoryDao.observeCategories()
     fun observeTagsByCategory(categoryId: Long): Flow<List<TagEntity>> = tagDao.observeTagsByCategory(categoryId)
@@ -39,6 +40,7 @@ class Repository private constructor(context: Context) {
         (resourceTagIds + characterTagIds + responseTagIds).toSet()
     }
     fun observeExecutionSettings(): Flow<ExecutionSettingsEntity?> = executionSettingsDao.observeSettings()
+    fun observeExecutionResources(): Flow<List<ExecutionResourceEntity>> = executionResourceDao.observeItems()
 
     data class ExportPackage(
         val snapshot: BackupSnapshot,
@@ -67,6 +69,7 @@ class Repository private constructor(context: Context) {
             resourceCharacterRefs = crossRefDao.listResourceCharacters(),
             responseRecords = responseRecordDao.listAll(),
             executionSettings = executionSettingsDao.getSettings(),
+            executionResources = executionResourceDao.listAll(),
             media = mediaItems
         )
         return ExportPackage(snapshot = snapshot, mediaSources = mediaSources)
@@ -89,6 +92,7 @@ class Repository private constructor(context: Context) {
         }
         responseRecordDao.deleteAll()
         executionSettingsDao.deleteAll()
+        executionResourceDao.deleteAll()
         crossRefDao.deleteAllResourceTags()
         crossRefDao.deleteAllCharacterTags()
         crossRefDao.deleteAllResourceCharacters()
@@ -107,6 +111,9 @@ class Repository private constructor(context: Context) {
             snapshot.responseRecords.forEach { responseRecordDao.upsert(it) }
         }
         snapshot.executionSettings?.let { executionSettingsDao.upsert(it) }
+        if (snapshot.executionResources.isNotEmpty()) {
+            snapshot.executionResources.forEach { executionResourceDao.insert(it) }
+        }
     }
 
     suspend fun addCategory(name: String, type: TagCategoryType) =
@@ -231,6 +238,33 @@ class Repository private constructor(context: Context) {
 
     suspend fun resourceIdsForCharacter(characterId: Long) = crossRefDao.resourceIdsForCharacter(characterId)
     suspend fun resourceIdsForTags(tagIds: List<Long>) = crossRefDao.resourceIdsForTags(tagIds)
+
+
+    suspend fun addExecutionResource(
+        resourceId: Long,
+        characterId: Long,
+        tagId: Long,
+        characterName: String,
+        tagName: String
+    ) {
+        executionResourceDao.insert(
+            ExecutionResourceEntity(
+                resourceId = resourceId,
+                characterId = characterId,
+                tagId = tagId,
+                characterName = characterName,
+                tagName = tagName
+            )
+        )
+    }
+
+    suspend fun removeExecutionResource(id: Long) {
+        executionResourceDao.deleteById(id)
+    }
+
+    suspend fun clearExecutionResources() {
+        executionResourceDao.deleteAll()
+    }
 
     suspend fun updateCharacterPoints(characterId: Long, points: Int) {
         val characters = characterDao.listAll()

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -42,17 +42,12 @@ import com.example.quotepicker.data.ExecutionSettingsEntity
 import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.ui.components.ResourceListRow
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
+import com.example.quotepicker.vm.ExecutionResourceDisplay
 import com.example.quotepicker.vm.ExecutionViewModel
 import com.example.quotepicker.vm.ResourceViewModel
 import java.time.LocalDate
 import kotlin.math.roundToInt
 
-private data class ExecutionResourceItem(
-    val resource: ResourceWithTagsCharacters,
-    val characterId: Long,
-    val characterName: String,
-    val tagName: String
-)
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -65,14 +60,13 @@ fun ExecutionScreen(
     var showSettings by remember { mutableStateOf(false) }
     var showPreview by remember { mutableStateOf(false) }
     var previewTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
-    var executionItems by remember { mutableStateOf<List<ExecutionResourceItem>>(emptyList()) }
-    var completionTarget by remember { mutableStateOf<ExecutionResourceItem?>(null) }
+    var completionTarget by remember { mutableStateOf<ExecutionResourceDisplay?>(null) }
     var showDailyInputDialog by rememberSaveable { mutableStateOf(false) }
     val context = LocalContext.current
     val today = LocalDate.now().toString()
     val shouldPromptDailyInput = ui.settings.lastExecutionDate != today
     val isExecutionAvailable = ui.settings.remainingValue > 0
-    val executionSlotsAvailable = executionItems.size < 5
+    val executionSlotsAvailable = ui.executionItems.size < 5
 
     LaunchedEffect(shouldPromptDailyInput) {
         showDailyInputDialog = shouldPromptDailyInput
@@ -172,22 +166,16 @@ fun ExecutionScreen(
                                     Toast.makeText(context, "执行资源最多保留5个，请先完成", Toast.LENGTH_SHORT).show()
                                     return@Button
                                 }
-                                vm.consumeRecord(record.characterId, record.tagId)
                                 val candidates = ui.resources.filter { res ->
                                     res.characters.any { it.id == record.characterId } &&
                                         res.tags.any { it.id == record.tagId }
                                 }
                                 val picked = candidates.randomOrNull()
                                 if (picked == null) {
-                                    Toast.makeText(context, "未找到匹配资源", Toast.LENGTH_SHORT).show()
+                                    Toast.makeText(context, "未找到匹配资源，请先补充资源信息", Toast.LENGTH_SHORT).show()
                                     return@Button
                                 }
-                                executionItems = executionItems + ExecutionResourceItem(
-                                    resource = picked,
-                                    characterId = record.characterId,
-                                    characterName = record.characterName,
-                                    tagName = record.tagName
-                                )
+                                vm.consumeRecordAndAddExecutionResource(record, picked)
                             },
                                 enabled = isExecutionAvailable && !shouldPromptDailyInput && executionSlotsAvailable,
                                 shape = MaterialTheme.shapes.small
@@ -200,11 +188,11 @@ fun ExecutionScreen(
             }
             Column(verticalArrangement = Arrangement.spacedBy(12.dp), modifier = Modifier.weight(1f, fill = false)) {
                 Text("执行资源", style = MaterialTheme.typography.titleMedium)
-                if (executionItems.isEmpty()) {
+                if (ui.executionItems.isEmpty()) {
                     Text("暂无执行资源", style = MaterialTheme.typography.labelMedium)
                 } else {
                     LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-                        items(executionItems) { item ->
+                        items(ui.executionItems, key = { it.id }) { item ->
                             ResourceListRow(
                                 resource = item.resource,
                                 categories = emptyList(),
@@ -245,7 +233,7 @@ fun ExecutionScreen(
                 val newPoints = ((sum + currentPoints) / 2.0).roundToInt()
                 vm.updateCharacterPoints(target.characterId, newPoints)
                 vm.incrementCharacterFamiliarity(target.characterId)
-                executionItems = executionItems.filterNot { it == target }
+                vm.removeExecutionResource(target.id)
                 completionTarget = null
             },
             onDismiss = { completionTarget = null }

--- a/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.ExecutionSettingsEntity
+import com.example.quotepicker.data.ExecutionResourceEntity
 import com.example.quotepicker.data.Repository
 import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.data.TagEntity
@@ -29,9 +30,18 @@ data class ResponseRecordDisplay(
 data class ExecutionUiState(
     val records: List<ResponseRecordDisplay> = emptyList(),
     val settings: ExecutionSettingsEntity = ExecutionSettingsEntity(),
+    val executionItems: List<ExecutionResourceDisplay> = emptyList(),
     val resources: List<ResourceWithTagsCharacters> = emptyList(),
     val characters: List<CharacterEntity> = emptyList(),
     val tags: List<TagEntity> = emptyList()
+)
+
+data class ExecutionResourceDisplay(
+    val id: Long,
+    val resource: ResourceWithTagsCharacters,
+    val characterId: Long,
+    val characterName: String,
+    val tagName: String
 )
 
 class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
@@ -48,10 +58,12 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
         repo.observeCharacters(),
         repo.observeAllTags(),
         repo.observeResourcesWithRelations(),
-        repo.observeExecutionSettings()
-    ) { records, characters, tags, resources, settings ->
+        repo.observeExecutionSettings(),
+        repo.observeExecutionResources()
+    ) { records, characters, tags, resources, settings, executionItems ->
         val characterMap = characters.associateBy { it.id }
         val tagMap = tags.associateBy { it.id }
+        val resourcesById = resources.associateBy { it.resource.id }
         val displayRecords = records.map { record ->
             ResponseRecordDisplay(
                 characterId = record.characterId,
@@ -61,9 +73,14 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
                 tagName = tagMap[record.tagId]?.name ?: "标签"
             )
         }
+        val displayExecutionItems = executionItems.mapNotNull { item ->
+            val resource = resourcesById[item.resourceId] ?: return@mapNotNull null
+            item.toDisplay(resource)
+        }
         ExecutionUiState(
             records = displayRecords,
             settings = settings ?: ExecutionSettingsEntity(),
+            executionItems = displayExecutionItems,
             resources = resources,
             characters = characters,
             tags = tags
@@ -72,6 +89,24 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
 
     fun consumeRecord(characterId: Long, tagId: Long) = viewModelScope.launch {
         repo.consumeResponseRecord(characterId, tagId)
+    }
+
+    fun consumeRecordAndAddExecutionResource(
+        record: ResponseRecordDisplay,
+        resource: ResourceWithTagsCharacters
+    ) = viewModelScope.launch {
+        repo.addExecutionResource(
+            resourceId = resource.resource.id,
+            characterId = record.characterId,
+            tagId = record.tagId,
+            characterName = record.characterName,
+            tagName = record.tagName
+        )
+        repo.consumeResponseRecord(record.characterId, record.tagId)
+    }
+
+    fun removeExecutionResource(id: Long) = viewModelScope.launch {
+        repo.removeExecutionResource(id)
     }
 
     fun updateSettings(settings: ExecutionSettingsEntity) = viewModelScope.launch {
@@ -125,3 +160,12 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
         repo.updateExecutionSettings(current.copy(remainingValue = current.remainingValue - 1))
     }
 }
+
+private fun ExecutionResourceEntity.toDisplay(resource: ResourceWithTagsCharacters): ExecutionResourceDisplay =
+    ExecutionResourceDisplay(
+        id = id,
+        resource = resource,
+        characterId = characterId,
+        characterName = characterName,
+        tagName = tagName
+    )


### PR DESCRIPTION
### Motivation

- Fix two UX/data issues: clicking a response record consumed it even when no matching resource existed, and execution items disappeared after navigating away because they were only kept in composable state.
- Ensure execution items are durable across app sessions and included in backups so users don't lose them when leaving the screen or restoring snapshots.

### Description

- Add a new Room entity `ExecutionResourceEntity` and table `execution_resources`, plus `ExecutionResourceDao`, and bump DB schema to `version = 7` to persist execution items.
- Wire persistence into the repository with `observeExecutionResources()`, `addExecutionResource()`, `removeExecutionResource()` and `clearExecutionResources()`, and include `executionResources` in `BackupSnapshot` export/import handling.
- Move execution item state from a local composable list to `ExecutionViewModel.uiState.executionItems` by observing `repo.observeExecutionResources()` and mapping DB rows to `ExecutionResourceDisplay` so the UI renders `ui.executionItems`.
- Change the record button flow in `RandomScreen` to first select a matching resource and only then call the combined `vm.consumeRecordAndAddExecutionResource(...)`, showing a toast and returning early if no matching resource is found to avoid prematurely consuming the response record.

### Testing

- Attempted to compile with `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper download was blocked by the environment proxy (HTTP 403), so an in-environment build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995427de548832b9d1d04816b5dde73)