### PR TITLE
修复：完成记录后角色熟悉度按平均值更新

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -278,6 +278,12 @@ class Repository private constructor(context: Context) {
         characterDao.update(target.copy(familiarity = target.familiarity + 1, updatedAt = System.currentTimeMillis()))
     }
 
+    suspend fun updateCharacterFamiliarity(characterId: Long, familiarity: Int) {
+        val characters = characterDao.listAll()
+        val target = characters.firstOrNull { it.id == characterId } ?: return
+        characterDao.update(target.copy(familiarity = familiarity.coerceAtLeast(0), updatedAt = System.currentTimeMillis()))
+    }
+
     suspend fun updateCharacterProbability(characterId: Long, probability: Int, date: String) {
         val characters = characterDao.listAll()
         val target = characters.firstOrNull { it.id == characterId } ?: return

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -229,10 +229,13 @@ fun ExecutionScreen(
             characterName = target.characterName,
             onConfirm = { completion, belonging, emotion ->
                 val sum = completion + belonging + emotion
-                val currentPoints = ui.characters.firstOrNull { it.id == target.characterId }?.points ?: 0
+                val currentCharacter = ui.characters.firstOrNull { it.id == target.characterId }
+                val currentPoints = currentCharacter?.points ?: 0
+                val currentFamiliarity = currentCharacter?.familiarity ?: 0
                 val newPoints = ((sum + currentPoints) / 2.0).roundToInt()
+                val newFamiliarity = ((sum + currentFamiliarity) / 2.0).roundToInt()
                 vm.updateCharacterPoints(target.characterId, newPoints)
-                vm.incrementCharacterFamiliarity(target.characterId)
+                vm.updateCharacterFamiliarity(target.characterId, newFamiliarity)
                 vm.removeExecutionResource(target.id)
                 completionTarget = null
             },

--- a/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
@@ -134,6 +134,10 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
         repo.incrementCharacterFamiliarity(characterId)
     }
 
+    fun updateCharacterFamiliarity(characterId: Long, familiarity: Int) = viewModelScope.launch {
+        repo.updateCharacterFamiliarity(characterId, familiarity)
+    }
+
     fun applyDailyInput(input: Int) = viewModelScope.launch {
         val current = uiState.value.settings
         val today = LocalDate.now()


### PR DESCRIPTION
### Motivation
- 修复在执行资源完成后对角色“次数/熟悉度”未按算法用平均值更新的问题，导致界面仍显示旧值或只做了 +1 操作。 

### Description
- 在完成确认逻辑中读取当前角色的 `familiarity` 并按 `((completion + belonging + emotion) + currentFamiliarity) / 2` 计算新的熟悉度，替换原先仅调用自增的实现（修改文件 `RandomScreen.kt`）。
- 在仓库层新增 `Repository.updateCharacterFamiliarity(characterId: Long, familiarity: Int)`，并在写回时做非负保护（新增于 `Repository.kt`）。
- 在视图模型 `ExecutionViewModel` 中新增 `updateCharacterFamiliarity` 方法以暴露仓库接口供 UI 使用（修改文件 `ExecutionViewModel.kt`）。
- 变更影响的文件：`app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt`, `app/src/main/java/com/example/quotepicker/data/Repository.kt`, `app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt`。

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 进行 Kotlin 编译验证，但在当前环境中 Gradle 分发包下载被代理返回 `403 Forbidden`，因此编译未能完成。
- 已对修改位置进行了静态代码替换和 repository 层逻辑检查以保证调用链一致性，未发现明显的类型或调用错误。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699548d60e80832b99bb740d653040c0)