### PR TITLE
Fix resource completion stat handling and add familiarity edit field

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -63,6 +63,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
@@ -653,6 +655,7 @@ private fun CharacterEditDialog(
     onDismiss: () -> Unit
 ) {
     var name by remember { mutableStateOf(character.name) }
+    var familiarityInput by remember { mutableStateOf(character.familiarity.toString()) }
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("编辑角色") },
@@ -670,11 +673,25 @@ private fun CharacterEditDialog(
                     label = { Text("角色名") },
                     modifier = Modifier.fillMaxWidth()
                 )
+                OutlinedTextField(
+                    value = familiarityInput,
+                    onValueChange = { value ->
+                        if (value.all { it.isDigit() }) {
+                            familiarityInput = value
+                        }
+                    },
+                    label = { Text("熟悉度") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                    modifier = Modifier.fillMaxWidth()
+                )
             }
         },
         confirmButton = {
             TextButton(onClick = {
-                if (name.isNotBlank()) onConfirm(character.copy(name = name.trim()))
+                if (name.isNotBlank()) {
+                    val familiarity = familiarityInput.toIntOrNull()?.coerceAtLeast(0) ?: character.familiarity
+                    onConfirm(character.copy(name = name.trim(), familiarity = familiarity))
+                }
                 onDismiss()
             }) { Text("确定") }
         },

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -231,11 +231,9 @@ fun ExecutionScreen(
                 val sum = completion + belonging + emotion
                 val currentCharacter = ui.characters.firstOrNull { it.id == target.characterId }
                 val currentPoints = currentCharacter?.points ?: 0
-                val currentFamiliarity = currentCharacter?.familiarity ?: 0
                 val newPoints = ((sum + currentPoints) / 2.0).roundToInt()
-                val newFamiliarity = ((sum + currentFamiliarity) / 2.0).roundToInt()
                 vm.updateCharacterPoints(target.characterId, newPoints)
-                vm.updateCharacterFamiliarity(target.characterId, newFamiliarity)
+                vm.incrementCharacterFamiliarity(target.characterId)
                 vm.removeExecutionResource(target.id)
                 completionTarget = null
             },


### PR DESCRIPTION
### Motivation
- 修复完成一次资源时把平均值错误写入角色“熟悉度”的问题，并恢复为按规则将平均值写回角色“次数（points）”且熟悉度固定递增 1。 
- 允许在角色编辑对话框中手动设置/调整熟悉度，以便纠正或初始化数值。 

### Description
- 在 `app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt` 中，完成资源时计算 `newPoints` 为 `(sum of 3 inputs + current points)/2` 并写回 `points`，同时用 `incrementCharacterFamiliarity` 将熟悉度加 1（不再把平均值写入熟悉度）。
- 在 `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt` 中为角色编辑弹窗增加了一个数字输入框 `熟悉度`，并添加了 `KeyboardOptions`/`KeyboardType.Number` 的导入与配置；输入进行了数字校验并在保存时应用非负保护后写回实体。 
- 仅对 UI 层变化进行了最小修改，不改变数据模型或后端逻辑接口。 

### Testing
- 尝试执行 `bash ./gradlew :app:compileDebugKotlin` 进行编译验证，但环境在下载 Gradle 分发包时因代理/网络限制返回 `403 Forbidden`，因此无法完成编译检查（失败）。
- 已在源码层检查并比对差异以确认所需修改已应用，未运行额外自动化测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69954c1b069c832ba080e95c4ed29d84)