### PR TITLE
Fix unresolved KeyboardOptions reference in CharacterScreen

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.border
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.draw.clip
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -63,7 +64,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.input.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp


### PR DESCRIPTION
### Motivation
- 修复 `CharacterScreen.kt` 中对 `KeyboardOptions` 的未解析引用错误，保证编译器/IDE 能正确解析该类型。 

### Description
- 将 `KeyboardOptions` 的导入从 `androidx.compose.ui.text.input.KeyboardOptions` 移至 `androidx.compose.foundation.text.KeyboardOptions`，修改文件为 `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt`。 

### Testing
- 已将更改加入版本库并提交（`git add` / `git commit` 成功）。
- 尝试运行 `./gradlew :app:compileDebugKotlin` 进行编译验证，但环境因 Gradle Wrapper 下载被代理阻断返回 `403 Forbidden` 导致无法完成编译验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699557cb7ea8832baf5b6e359220908d)