### PR TITLE
修复完成时 point 平均值更新逻辑（基于最新 point 计算）

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -3,10 +3,12 @@ package com.example.quotepicker.data
 import android.content.Context
 import android.net.Uri
 import android.util.Base64
+import androidx.room.withTransaction
 import java.io.File
 import java.io.InputStream
 import java.time.LocalDate
 import org.json.JSONArray
+import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 
@@ -270,6 +272,21 @@ class Repository private constructor(context: Context) {
         val characters = characterDao.listAll()
         val target = characters.firstOrNull { it.id == characterId } ?: return
         characterDao.update(target.copy(points = points.coerceIn(0, 30), updatedAt = System.currentTimeMillis()))
+    }
+
+    suspend fun applyExecutionCompletion(characterId: Long, completionScoreSum: Int) {
+        db.withTransaction {
+            val characters = characterDao.listAll()
+            val target = characters.firstOrNull { it.id == characterId } ?: return@withTransaction
+            val nextPoints = ((target.points + completionScoreSum) / 2.0).roundToInt()
+            characterDao.update(
+                target.copy(
+                    points = nextPoints.coerceIn(0, 30),
+                    familiarity = target.familiarity + 1,
+                    updatedAt = System.currentTimeMillis()
+                )
+            )
+        }
     }
 
     suspend fun incrementCharacterFamiliarity(characterId: Long) {

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -46,7 +46,6 @@ import com.example.quotepicker.vm.ExecutionResourceDisplay
 import com.example.quotepicker.vm.ExecutionViewModel
 import com.example.quotepicker.vm.ResourceViewModel
 import java.time.LocalDate
-import kotlin.math.roundToInt
 
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
@@ -229,11 +228,7 @@ fun ExecutionScreen(
             characterName = target.characterName,
             onConfirm = { completion, belonging, emotion ->
                 val sum = completion + belonging + emotion
-                val currentCharacter = ui.characters.firstOrNull { it.id == target.characterId }
-                val currentPoints = currentCharacter?.points ?: 0
-                val newPoints = ((sum + currentPoints) / 2.0).roundToInt()
-                vm.updateCharacterPoints(target.characterId, newPoints)
-                vm.incrementCharacterFamiliarity(target.characterId)
+                vm.applyExecutionCompletion(target.characterId, sum)
                 vm.removeExecutionResource(target.id)
                 completionTarget = null
             },
@@ -302,6 +297,7 @@ private fun CompletionDialog(
     var completionText by remember { mutableStateOf("") }
     var belongingText by remember { mutableStateOf("") }
     var emotionText by remember { mutableStateOf("") }
+    var errorText by remember { mutableStateOf<String?>(null) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -311,29 +307,47 @@ private fun CompletionDialog(
                 Text("$characterName 的完成情况")
                 OutlinedTextField(
                     value = completionText,
-                    onValueChange = { completionText = it },
+                    onValueChange = {
+                        completionText = it
+                        errorText = null
+                    },
                     label = { Text("完成度(0-10)") },
                     modifier = Modifier.fillMaxWidth()
                 )
                 OutlinedTextField(
                     value = belongingText,
-                    onValueChange = { belongingText = it },
+                    onValueChange = {
+                        belongingText = it
+                        errorText = null
+                    },
                     label = { Text("归属感(0-10)") },
                     modifier = Modifier.fillMaxWidth()
                 )
                 OutlinedTextField(
                     value = emotionText,
-                    onValueChange = { emotionText = it },
+                    onValueChange = {
+                        emotionText = it
+                        errorText = null
+                    },
                     label = { Text("情绪值(0-10)") },
                     modifier = Modifier.fillMaxWidth()
                 )
+                errorText?.let {
+                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.labelSmall)
+                }
             }
         },
         confirmButton = {
             TextButton(onClick = {
-                val completion = completionText.toIntOrNull()?.coerceIn(0, 10) ?: 0
-                val belonging = belongingText.toIntOrNull()?.coerceIn(0, 10) ?: 0
-                val emotion = emotionText.toIntOrNull()?.coerceIn(0, 10) ?: 0
+                val completion = completionText.toIntOrNull()
+                val belonging = belongingText.toIntOrNull()
+                val emotion = emotionText.toIntOrNull()
+                val isValid = completion != null && belonging != null && emotion != null &&
+                    completion in 0..10 && belonging in 0..10 && emotion in 0..10
+                if (!isValid) {
+                    errorText = "三个值都必须填写 0-10 之间的整数"
+                    return@TextButton
+                }
                 onConfirm(completion, belonging, emotion)
             }) { Text("完成") }
         },

--- a/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
@@ -130,6 +130,10 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
         repo.updateCharacterPoints(characterId, points)
     }
 
+    fun applyExecutionCompletion(characterId: Long, completionScoreSum: Int) = viewModelScope.launch {
+        repo.applyExecutionCompletion(characterId, completionScoreSum)
+    }
+
     fun incrementCharacterFamiliarity(characterId: Long) = viewModelScope.launch {
         repo.incrementCharacterFamiliarity(characterId)
     }


### PR DESCRIPTION
### Motivation
- 解决完成时 `point` 可能不更新的问题，避免在 UI 层用旧快照数据计算新 `point` 导致覆盖或丢失更新。
- 保证完成操作同时、原子性地更新角色的 `points` 与 `familiarity`（完成时 `familiarity + 1`）。

### Description
- 将完成对话改为只上传“完成三值总和”，`RandomScreen` 不再在 UI 端用快照计算新 `point`，改为调用 `ExecutionViewModel.applyExecutionCompletion`（文件：`app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt` 和 `app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt`）。
- 在 `Repository.applyExecutionCompletion` 中基于数据库最新角色记录计算并写入：`nextPoints = round((currentPoints + completionScoreSum) / 2.0)` 与 `familiarity = familiarity + 1`，并使用 `db.withTransaction` 保证原子性（文件：`app/src/main/java/com/example/quotepicker/data/Repository.kt`）。
- 保留并增强了完成对话的输入校验逻辑，要求三项为 `0-10` 的整数后才能提交（文件：`RandomScreen.kt`）。
- 行为示例：当前 `point=10`、完成三值总和 `28` 时，最终写入 `point = 19`，并且 `familiarity` 加 1。

### Testing
- 尝试运行编译命令 `./gradlew :app:compileDebugKotlin`，在当前环境中下载 Gradle 分发包时被代理阻断返回 `HTTP 403`，导致构建无法完成（自动编译失败）。
- 对代码变更进行了源码检查与差异确认，确认 `Repository.applyExecutionCompletion`、`ExecutionViewModel` 与 `RandomScreen` 的调用链与签名一致。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69956b842704832bbc1be081fb707023)