### PR TITLE
Show category labels for '+' prefix-grouped tags

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -743,6 +743,7 @@ private fun TagSummarySection(
                 } else {
                     val groupedByPrefix = splitTagsByPrefix(items)
                     val brown = Color(0xFF795548)
+                    Text(category.name, style = MaterialTheme.typography.labelMedium, color = brown)
                     groupedByPrefix.groups.forEach { prefixGroup ->
                         Row(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalAlignment = Alignment.CenterVertically) {
                             CharacterDetailTagLabel(
@@ -1075,6 +1076,7 @@ private fun TagSelectionSection(
                 val groupedByPrefix = splitTagsByPrefix(items)
                 val currentGroup = selectedPrefixGroup.value[category.id]
                 val brown = Color(0xFF795548)
+                Text(category.name, style = MaterialTheme.typography.labelSmall)
                 FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                     groupedByPrefix.groups.forEach { prefixGroup ->
                         FilterChip(


### PR DESCRIPTION
### Motivation
- Prefix-grouped tag categories (category names ending with `+`) were missing their category header in some UI places, causing grouped tags to visually attach to the previous category.
- The intent is to make category boundaries explicit when prefix grouping is used so users can see which category the groups belong to.

### Description
- Added explicit category headers for prefix-grouped categories by inserting `Text(category.name, ...)` in the character detail tag summary section and the tag selection section of the character UI. The change affects `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt` and ensures categories using the `+` suffix still display their name when `isPrefixGroupingCategory(...)` is true.
- The grouping logic still uses `splitTagsByPrefix(...)` and the visual grouping of prefix groups is unchanged; only the missing category label was added.

### Testing
- Attempted to compile Kotlin with `bash ./gradlew :app:compileDebugKotlin`, but the Gradle wrapper failed to download `gradle-8.10-bin.zip` due to a network/proxy `HTTP/1.1 403 Forbidden` error in this environment, so a full build could not be completed.
- Verified the source changes locally by inspection and ensured the added `Text(...)` calls align with existing styling and imports; no automated tests were run successfully due to the build/network restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699664492d58832ba040d33fee63d131)