### PR TITLE
feat: 长按重命名资源组并批量更新资源标题前缀

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -78,6 +78,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
@@ -131,6 +132,8 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     var groupLevel2Selected by remember { mutableStateOf(false) }
     var groupLevel3Selected by remember { mutableStateOf(false) }
     var openedGroup by remember { mutableStateOf<ResourceTitleGroup?>(null) }
+    var renameGroupTarget by remember { mutableStateOf<ResourceTitleGroup?>(null) }
+    var renameGroupValue by remember { mutableStateOf(TextFieldValue("")) }
     val coroutineScope = rememberCoroutineScope()
     val restorePicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
         val target = restoreTarget
@@ -278,7 +281,11 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                                     name = group.title,
                                     childNames = group.childNames,
                                     count = group.resources.size,
-                                    onClick = { openedGroup = group }
+                                    onClick = { openedGroup = group },
+                                    onLongClick = {
+                                        renameGroupTarget = group
+                                        renameGroupValue = TextFieldValue(group.title)
+                                    }
                                 )
                             }
                         }
@@ -488,6 +495,46 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                 }) { Text("删除") }
             },
             dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text("取消") } }
+        )
+    }
+
+    if (renameGroupTarget != null) {
+        AlertDialog(
+            onDismissRequest = { renameGroupTarget = null },
+            title = { Text("编辑组名") },
+            text = {
+                OutlinedTextField(
+                    value = renameGroupValue,
+                    onValueChange = { renameGroupValue = it },
+                    label = { Text("组名") },
+                    singleLine = true
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val target = renameGroupTarget ?: return@TextButton
+                        val updates = buildGroupRenameUpdates(
+                            resources = target.resources,
+                            newGroupName = renameGroupValue.text,
+                            level1 = groupLevel1Selected,
+                            level2 = groupLevel2Selected,
+                            level3 = groupLevel3Selected
+                        )
+                        if (updates.isNotEmpty()) {
+                            vm.updateResourceTitles(updates)
+                        }
+                        renameGroupTarget = null
+                    }
+                ) {
+                    Text("保存")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { renameGroupTarget = null }) {
+                    Text("取消")
+                }
+            }
         )
     }
 }
@@ -727,6 +774,7 @@ private fun StorageMediaRow(
             )
         }
     }
+
 }
 
 private data class StoredMediaGroup(
@@ -953,14 +1001,15 @@ private fun GroupListRow(
     name: String,
     childNames: String,
     count: Int,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    onLongClick: () -> Unit
 ) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
             .border(1.dp, MaterialTheme.colorScheme.outlineVariant)
             .clip(MaterialTheme.shapes.small)
-            .clickable(onClick = onClick)
+            .combinedClickable(onClick = onClick, onLongClick = onLongClick)
             .padding(horizontal = 8.dp, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(2.dp)
     ) {
@@ -975,6 +1024,36 @@ private fun GroupListRow(
         if (childNames.isNotBlank()) {
             Text(childNames, style = MaterialTheme.typography.labelSmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
         }
+    }
+}
+
+private fun buildGroupRenameUpdates(
+    resources: List<ResourceWithTagsCharacters>,
+    newGroupName: String,
+    level1: Boolean,
+    level2: Boolean,
+    level3: Boolean
+): List<Pair<com.example.quotepicker.data.ResourceEntity, String>> {
+    val renameParts = newGroupName.split("-").map { it.trim() }.filter { it.isNotEmpty() }
+    val selectedIndexes = buildList {
+        if (level1) add(0)
+        if (level2) add(1)
+        if (level3) add(2)
+    }
+    if (selectedIndexes.isEmpty() || renameParts.isEmpty()) return emptyList()
+    return resources.mapNotNull { item ->
+        val oldParts = item.resource.title.split("-").map { it.trim() }.toMutableList()
+        val nextParts = oldParts.toMutableList()
+        val requiredSize = (selectedIndexes.maxOrNull() ?: 0) + 1
+        while (nextParts.size < requiredSize) {
+            nextParts.add("")
+        }
+        selectedIndexes.forEachIndexed { index, partIndex ->
+            val renamed = renameParts.getOrNull(index) ?: return@forEachIndexed
+            nextParts[partIndex] = renamed
+        }
+        val nextTitle = nextParts.joinToString("-").trim('-').ifBlank { item.resource.title }
+        if (nextTitle != item.resource.title) item.resource to nextTitle else null
     }
 }
 

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -258,6 +258,15 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     fun updateResource(resource: ResourceEntity) =
         viewModelScope.launch { repo.updateResource(resource) }
 
+    fun updateResourceTitles(updates: List<Pair<ResourceEntity, String>>) =
+        viewModelScope.launch {
+            updates.forEach { (resource, newTitle) ->
+                if (newTitle.isNotBlank() && newTitle != resource.title) {
+                    repo.updateResource(resource.copy(title = newTitle))
+                }
+            }
+        }
+
     fun updateTextResource(
         resource: ResourceEntity,
         title: String,


### PR DESCRIPTION
### Motivation
- 在按资源名分组的列表中增加通过长按编辑组名的能力，保存后按当前分组级别批量更新该组下所有资源的标题前缀以便重命名分组。 

### Description
- 在 `ResourceScreen` 中新增状态 `renameGroupTarget` / `renameGroupValue`，并在分组列表项支持长按以打开预填组名的弹窗进行编辑。 
- 将分组行 `GroupListRow` 的点击交互由 `clickable` 改为 `combinedClickable` 以同时支持点击进入与长按编辑。 
- 添加 `buildGroupRenameUpdates` 函数，按当前 1/2/3 级分组开关计算替换那些标题层级（以 `-` 分段），只生成实际变化的更新项。 
- 在 `ResourceViewModel` 新增 `updateResourceTitles` 方法以批量提交标题更改到仓库并避免空或无变更写库。 

### Testing
- 进行了代码搜索以确认新符号的引用（`renameGroupTarget`、`buildGroupRenameUpdates`、`updateResourceTitles`、`GroupListRow`），搜索结果正常。 
- 尝试执行 `./gradlew :app:compileDebugKotlin` 进行本地编译验证，但环境中下载 Gradle 发行包被代理拦截返回 `403`，因此无法完成编译验证。 
- 变更主要为 UI 交互与 ViewModel 写库调用，现有逻辑已在代码层面完成连通性处理（仅更新标题，不修改关联数据）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f6042f2c832b9da0a49691af2a5d)