### PR TITLE
调整长按资源弹窗：移除移动，新增按 1/2/3 层级改组

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -122,7 +122,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     var editTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var bottomSheetTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var deleteTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
-    var moveTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
+    var regroupTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var filterTagDialog by remember { mutableStateOf(false) }
     var filterCharacterDialog by remember { mutableStateOf(false) }
     var manageScreen by remember { mutableStateOf(false) }
@@ -381,12 +381,12 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                     Text("编辑")
                 }
                 TextButton(onClick = {
-                    moveTarget = target
+                    regroupTarget = target
                     bottomSheetTarget = null
                 }) {
                     Icon(Icons.Default.DriveFileMove, contentDescription = null)
                     Spacer(Modifier.width(8.dp))
-                    Text("移动")
+                    Text("改组")
                 }
                 TextButton(onClick = {
                     deleteTarget = target
@@ -402,26 +402,36 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
         }
     }
 
-    moveTarget?.let { target ->
-        val targetCharacterIds = remember(target) { target.characters.map { it.id }.toSet() }
-        val candidateGroups = remember(allResources, targetCharacterIds, target) {
-            allResources
-                .filter {
-                    it.resource.type == target.resource.type &&
-                        it.resource.id != target.resource.id &&
-                        it.characters.map { character -> character.id }.toSet() == targetCharacterIds
-                }
-                .map { it.resource.title }
-                .distinct()
-                .sorted()
+    regroupTarget?.let { target ->
+        val selectedIndexes = remember(groupLevel1Selected, groupLevel2Selected, groupLevel3Selected) {
+            buildList {
+                if (groupLevel1Selected) add(0)
+                if (groupLevel2Selected) add(1)
+                if (groupLevel3Selected) add(2)
+            }
         }
-        var selectedGroup by remember(target) { mutableStateOf(candidateGroups.firstOrNull()) }
-        var newGroupName by remember(target) { mutableStateOf("") }
-        val canConfirm = newGroupName.isNotBlank() || selectedGroup != null
+        val candidateGroups = remember(allResources, target, selectedIndexes) {
+            if (selectedIndexes.isEmpty()) {
+                emptyList()
+            } else {
+                allResources
+                    .asSequence()
+                    .filter { it.resource.type == target.resource.type }
+                    .mapNotNull { candidate ->
+                        groupedPartsForIndexes(candidate.resource.title, selectedIndexes)
+                            ?.takeIf { it.isNotBlank() }
+                    }
+                    .distinct()
+                    .sorted()
+                    .toList()
+            }
+        }
+        var selectedGroup by remember(target, candidateGroups) { mutableStateOf(candidateGroups.firstOrNull()) }
+        val canConfirm = selectedGroup != null && selectedIndexes.isNotEmpty()
 
         AlertDialog(
-            onDismissRequest = { moveTarget = null },
-            title = { Text("移动资源") },
+            onDismissRequest = { regroupTarget = null },
+            title = { Text("改组") },
             text = {
                 Column(
                     modifier = Modifier
@@ -430,10 +440,12 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                         .verticalScroll(rememberScrollState()),
                     verticalArrangement = Arrangement.spacedBy(12.dp)
                 ) {
-                    if (candidateGroups.isEmpty()) {
-                        Text("暂无可移动的同角色资源组", style = MaterialTheme.typography.labelMedium)
+                    if (selectedIndexes.isEmpty()) {
+                        Text("请先选择 1/2/3 分组按钮", style = MaterialTheme.typography.labelMedium)
+                    } else if (candidateGroups.isEmpty()) {
+                        Text("暂无可用组名", style = MaterialTheme.typography.labelMedium)
                     } else {
-                        Text("选择目标组", style = MaterialTheme.typography.labelMedium)
+                        Text("选择目标组名", style = MaterialTheme.typography.labelMedium)
                         FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                             candidateGroups.forEach { title ->
                                 FilterChip(
@@ -447,39 +459,32 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                             }
                         }
                     }
-                    OutlinedTextField(
-                        value = newGroupName,
-                        onValueChange = { newGroupName = it },
-                        label = { Text("或输入新组名称") },
-                        singleLine = true
-                    )
                 }
             },
             confirmButton = {
                 TextButton(
                     onClick = {
-                        val destinationTitle = if (newGroupName.isNotBlank()) {
-                            newGroupName.trim()
-                        } else {
-                            selectedGroup.orEmpty()
+                        val nextTitle = buildRegroupedTitle(
+                            originalTitle = target.resource.title,
+                            selectedIndexes = selectedIndexes,
+                            selectedGroupName = selectedGroup
+                        )
+                        if (nextTitle != null && nextTitle != target.resource.title) {
+                            vm.updateResource(
+                                target.resource,
+                                title = nextTitle,
+                                content = target.resource.contentUriOrPath,
+                                type = target.resource.type,
+                                tags = target.tags,
+                                characters = target.characters
+                            )
                         }
-                        if (destinationTitle.isNotBlank()) {
-                            val groupResources = allResources.filter {
-                                it.resource.type == target.resource.type &&
-                                    it.resource.title == destinationTitle &&
-                                    it.characters.map { character -> character.id }.toSet() == targetCharacterIds &&
-                                    it.resource.id != target.resource.id
-                            }
-                            val minCreatedAt = groupResources.minOfOrNull { it.resource.createdAt }
-                            val newCreatedAt = minCreatedAt?.minus(1) ?: System.currentTimeMillis()
-                            vm.moveResourceToGroup(target.resource, destinationTitle, newCreatedAt)
-                        }
-                        moveTarget = null
+                        regroupTarget = null
                     },
                     enabled = canConfirm
-                ) { Text("移动") }
+                ) { Text("确定") }
             },
-            dismissButton = { TextButton(onClick = { moveTarget = null }) { Text("取消") } }
+            dismissButton = { TextButton(onClick = { regroupTarget = null }) { Text("取消") } }
         )
     }
 
@@ -1055,6 +1060,32 @@ private fun buildGroupRenameUpdates(
         val nextTitle = nextParts.joinToString("-").trim('-').ifBlank { item.resource.title }
         if (nextTitle != item.resource.title) item.resource to nextTitle else null
     }
+}
+
+private fun groupedPartsForIndexes(title: String, selectedIndexes: List<Int>): String? {
+    if (selectedIndexes.isEmpty()) return null
+    val parts = title.split("-").map { it.trim() }.filter { it.isNotEmpty() }
+    val selected = selectedIndexes.mapNotNull { index -> parts.getOrNull(index) }
+    return selected.takeIf { it.isNotEmpty() }?.joinToString("-")
+}
+
+private fun buildRegroupedTitle(
+    originalTitle: String,
+    selectedIndexes: List<Int>,
+    selectedGroupName: String?
+): String? {
+    if (selectedIndexes.isEmpty() || selectedGroupName.isNullOrBlank()) return null
+    val originalParts = originalTitle.split("-").map { it.trim() }.filter { it.isNotEmpty() }.toMutableList()
+    val replacementParts = selectedGroupName.split("-").map { it.trim() }.filter { it.isNotEmpty() }
+    if (replacementParts.isEmpty()) return null
+    val requiredSize = (selectedIndexes.maxOrNull() ?: 0) + 1
+    while (originalParts.size < requiredSize) {
+        originalParts.add("")
+    }
+    selectedIndexes.forEachIndexed { position, partIndex ->
+        replacementParts.getOrNull(position)?.let { originalParts[partIndex] = it }
+    }
+    return originalParts.filter { it.isNotBlank() }.joinToString("-").ifBlank { null }
 }
 
 @Composable


### PR DESCRIPTION
### Motivation
- 用户希望长按资源时移除底部弹窗中的“移动”功能，但保留资源详情中单个图片/视频/声音的移动功能。
- 需要新增按当前 1/2/3 分组按钮状态的“改组”操作，使长按可按选定层级批量替换资源标题中的对应段落。

### Description
- 将长按底部弹窗的 `moveTarget` 流程替换为 `regroupTarget`，并把按钮标签从“移动”改为“改组”。
- 新增层级索引计算：根据 `groupLevel1Selected`/`groupLevel2Selected`/`groupLevel3Selected` 生成 `selectedIndexes`，支持 `1`、`2`、`3`、`1+2`、`2+3` 等组合。
- 通过 `groupedPartsForIndexes(title, selectedIndexes)` 收集候选组名，并在对话框中用 `FilterChip` 列表展示可选组名。
- 选定组名后使用 `buildRegroupedTitle(...)` 构建新的标题，仅替换被选中的层级片段并调用 `vm.updateResource(...)` 更新资源信息（保留其余层级和元数据）。
- 新增辅助函数 `groupedPartsForIndexes` 和 `buildRegroupedTitle`，并在 `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt` 中实现所有改动，资源详情的“移动或复制”对话框逻辑未改动。

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 作为自动化验证，但由于脚本执行权限问题返回“Permission denied”，构建未执行成功（失败）。
- 尝试通过 `bash ./gradlew :app:compileDebugKotlin` 下载 Gradle 后进行编译，但运行时环境无法访问 Gradle 分发（代理返回 HTTP 403），导致构建下载失败并中止（失败）。
- 未能在当前环境完成成功的自动化编译验证，所以仅提交了静态代码变更并已提交至本地仓库。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699cf310f078832bbbd6702f9a9a1ec7)