### PR TITLE
Show media file sizes in storage list; clear managed media on snapshot replace

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -78,6 +78,7 @@ class Repository private constructor(context: Context) {
     }
 
     suspend fun replaceSnapshot(snapshot: BackupSnapshot, mediaPayloads: Map<String, MediaPayload> = emptyMap()) {
+        clearManagedMediaDirectories()
         val mediaMapping = restoreMedia(snapshot.media, mediaPayloads)
         val restoredResources = snapshot.resources.map { resource ->
             when (resource.type) {
@@ -115,6 +116,17 @@ class Repository private constructor(context: Context) {
         snapshot.executionSettings?.let { executionSettingsDao.upsert(it) }
         if (snapshot.executionResources.isNotEmpty()) {
             snapshot.executionResources.forEach { executionResourceDao.insert(it) }
+        }
+    }
+
+    private fun clearManagedMediaDirectories() {
+        listOf("images", "videos", "audio").forEach { folder ->
+            val dir = File(appContext.filesDir, folder)
+            dir.listFiles()?.forEach { file ->
+                runCatching {
+                    if (file.isDirectory) file.deleteRecursively() else file.delete()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -107,6 +107,7 @@ import com.example.quotepicker.vm.StoredMediaItem
 import com.example.quotepicker.vm.VideoUpdateItem
 import com.example.quotepicker.vm.SoundUpdateItem
 import java.io.File
+import java.util.Locale
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -598,7 +599,10 @@ private fun ManageStorageScreen(
                     label = { Text(selectedCharacter?.name ?: "全部角色") }
                 )
             }
-            LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+            LazyColumn(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                contentPadding = PaddingValues(bottom = 28.dp)
+            ) {
                 val groups = groupedItems[selectedType].orEmpty()
                 if (groups.isEmpty()) {
                     item {
@@ -770,6 +774,11 @@ private fun StorageMediaRow(
                 style = MaterialTheme.typography.labelSmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant
             )
+            Text(
+                text = "大小: ${formatFileSizeInMb(item.path)}",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 
@@ -779,6 +788,16 @@ private data class StoredMediaGroup(
     val title: String,
     val items: List<StoredMediaItem>
 )
+
+private fun formatFileSizeInMb(path: String): String {
+    val sizeBytes = runCatching {
+        val uri = Uri.parse(path)
+        val filePath = uri.path ?: return@runCatching null
+        File(filePath).takeIf { it.exists() }?.length()
+    }.getOrNull()
+    val sizeMb = (sizeBytes ?: 0L).toDouble() / (1024 * 1024)
+    return String.format(Locale.US, "%.1fM", sizeMb)
+}
 
 @Composable
 private fun StorageSectionHeader(


### PR DESCRIPTION
### Motivation
- Ensure users can see each managed media file's size in the storage management UI in megabytes with one decimal place as requested. 
- Prevent duplicate or stale app-managed media when importing a snapshot by clearing previously managed media directories first. 
- Keep the last items in the storage list visible by adding bottom padding to the list.

### Description
- Added a file-size display to each media row in `ManageStorageScreen` by inserting a `Text` showing `大小: X.XM` and importing `Locale` for consistent formatting. 
- Implemented `formatFileSizeInMb(path: String)` in `ResourceScreen.kt` which parses the path URI, reads local file length, and formats the value as `%.1fM`. 
- Called `clearManagedMediaDirectories()` at the start of `Repository.replaceSnapshot(...)` and added the helper that deletes files under `appContext.filesDir` subfolders `images`, `videos`, and `audio`. 
- Added `contentPadding = PaddingValues(bottom = 28.dp)` to the `LazyColumn` in the storage management screen so bottom items are not obscured.

### Testing
- No automated test suite was executed in this environment. 
- An attempt to run `./gradlew :app:compileDebugKotlin` failed due to the Gradle wrapper download being blocked by a network proxy (`HTTP/1.1 403 Forbidden`), so compilation verification could not be completed. 
- Changes were reviewed with local static inspection of the modified Kotlin sources.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d3272c26c832b901e859d347823f9)