### PR TITLE
Fix unresolved PaddingValues reference in ResourceScreen

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize


### PR DESCRIPTION
### Motivation
- Resolve a compile error caused by an `Unresolved reference: PaddingValues` used in `ManageStorageScreen` inside `ResourceScreen.kt`.

### Description
- Added the missing import `androidx.compose.foundation.layout.PaddingValues` to `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt` to fix the unresolved reference.

### Testing
- Attempted to run `bash ./gradlew :app:compileDebugKotlin`, but the build could not complete because the Gradle distribution download was blocked by a proxy (`HTTP/1.1 403 Forbidden`), so compilation could not be validated in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d419b40b0832ba4bc2dc32ed66274)