### PR TITLE
Fix storage page content being obscured by bottom navigation bar

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -149,6 +149,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
 
     if (manageScreen) {
         ManageStorageScreen(
+            modifier = modifier,
             items = manageItems,
             resources = allResources,
             vm = vm,
@@ -542,6 +543,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
 private fun ManageStorageScreen(
+    modifier: Modifier = Modifier,
     items: List<StoredMediaItem>,
     resources: List<ResourceWithTagsCharacters>,
     vm: ResourceViewModel,
@@ -564,6 +566,7 @@ private fun ManageStorageScreen(
     }
 
     Scaffold(
+        modifier = modifier,
         topBar = {
             TopAppBar(
                 title = { Text("资源存储") },


### PR DESCRIPTION
### Motivation
- Ensure the resource storage management screen respects outer `Scaffold` insets/padding so the last item is not covered by the bottom navigation bar.

### Description
- Pass the parent `modifier` into `ManageStorageScreen`, add a `modifier: Modifier = Modifier` parameter to `ManageStorageScreen`, and apply it to its `Scaffold` in `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`.

### Testing
- Attempted to compile with `bash ./gradlew :app:compileDebugKotlin`, but the environment could not download the Gradle distribution due to a proxy/network `403 Forbidden`, so compilation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e5a8c8f70832badcd4e265cf834ec)