### PR TITLE
支持标签类别复制与资源存储默认折叠

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -617,7 +617,7 @@ private fun ManageStorageScreen(
                     }
                 } else {
                     groups.forEach { group ->
-                        val expanded = groupExpandedState.getOrPut("${selectedType.name}-${group.title}") { true }
+                        val expanded = groupExpandedState.getOrPut("${selectedType.name}-${group.title}") { false }
                         item {
                             StorageSectionHeader(
                                 title = group.title,

--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -65,13 +65,19 @@ import com.example.quotepicker.vm.TagViewModel
 import androidx.compose.runtime.collectAsState
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.sp
+import android.widget.Toast
+import androidx.compose.ui.platform.LocalContext
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     val ui by vm.uiState.collectAsState()
+    val clipboard = LocalClipboardManager.current
+    val context = LocalContext.current
     var showCategoryDialog by remember { mutableStateOf(false) }
     var showTagDialog by remember { mutableStateOf(false) }
     var editCategory by remember { mutableStateOf<TagCategoryEntity?>(null) }
@@ -361,6 +367,19 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                     Icon(Icons.Default.Delete, contentDescription = null)
                     Spacer(Modifier.width(8.dp))
                     Text("删除")
+                }
+                if (target is TagCategoryEntity) {
+                    TextButton(onClick = {
+                        val tagsText = ui.allTags
+                            .filter { it.categoryId == target.id }
+                            .sortedBy { it.name.lowercase() }
+                            .joinToString("\n") { formatTagLabel(it.name) }
+                        clipboard.setText(AnnotatedString(tagsText))
+                        Toast.makeText(context, "已复制${target.name}全部标签", Toast.LENGTH_SHORT).show()
+                        bottomSheetTarget = null
+                    }) {
+                        Text("复制标签")
+                    }
                 }
                 TextButton(onClick = { bottomSheetTarget = null }) {
                     Text("关闭")


### PR DESCRIPTION
### Motivation
- 实现“长按标签类别可复制该类别所有标签到剪贴板”的交互，方便批量导出标签文本。 
- 资源存储页面按名称分组后默认全部闭合以减少界面噪声，用户点击组标题时再展开。

### Description
- 在 `TagScreen.kt` 中引入 `LocalClipboardManager`、`AnnotatedString`、`LocalContext` 和 `Toast`，并在标签类别的底部操作面板中新增“复制标签”按钮，按钮会筛选 `ui.allTags` 中属于该类别的标签、按名称排序、逐行拼接并写入剪贴板，同时显示 Toast 提示。 
- 在 `ResourceScreen.kt` 中将按名称分组的折叠项默认状态由展开改为闭合（将 `getOrPut(...){ true }` 改为 `getOrPut(...){ false }`），实现初始全部折叠的行为。 
- 变更影响文件：`app/src/main/java/com/example/quotepicker/ui/TagScreen.kt`、`app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`。

### Testing
- 尝试运行 `bash ./gradlew :app:compileDebugKotlin` 进行编译验证，但在当前环境中 Gradle 包下载受代理限制返回 `403` 导致构建失败。 
- 未运行其他自动化测试；代码修改已成功添加并提交到本地仓库。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e8731cc64832b9c4956415bb22f3f)