### PR TITLE
删除未分类类别时同步清空其标签

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Dao.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Dao.kt
@@ -62,6 +62,9 @@ interface TagDao {
     @Delete
     suspend fun delete(tag: TagEntity)
 
+    @Query("DELETE FROM tags WHERE categoryId = :categoryId")
+    suspend fun deleteByCategoryId(categoryId: Long)
+
     @Query("UPDATE tags SET categoryId = :newCategoryId WHERE categoryId = :oldCategoryId")
     suspend fun reassignCategory(oldCategoryId: Long, newCategoryId: Long)
 

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -136,7 +136,11 @@ class Repository private constructor(context: Context) {
     suspend fun updateCategory(category: TagCategoryEntity) =
         categoryDao.update(category.copy(updatedAt = System.currentTimeMillis()))
     suspend fun deleteCategory(category: TagCategoryEntity) {
-        if (category.name == ORPHAN_CATEGORY_NAME) return
+        if (category.name == ORPHAN_CATEGORY_NAME) {
+            tagDao.deleteByCategoryId(category.id)
+            categoryDao.delete(category)
+            return
+        }
         val orphan = ensureOrphanCategory(category.type)
         tagDao.reassignCategory(category.id, orphan.id)
         categoryDao.delete(category)


### PR DESCRIPTION
### Motivation
- 当删除标签类别时，现有逻辑会把标签统一移动到“未分类”（`ORPHAN_CATEGORY_NAME`），但当用户删除“未分类”类别时应当一并清除该类别下的所有标签，避免留下孤立标签。

### Description
- 新增 `TagDao.deleteByCategoryId(categoryId: Long)`，并在 `Repository.deleteCategory` 中加入针对 `ORPHAN_CATEGORY_NAME` 的分支：若删除的是“未分类”则先调用 `tagDao.deleteByCategoryId(category.id)` 再删除该类别，其他类别仍按原逻辑将标签重分配到“未分类”。

### Testing
- 尝试运行 `bash ./gradlew :app:compileDebugKotlin` 进行编译验证，但环境中 Gradle wrapper 无法下载发行包（代理返回 `403 Forbidden`），因此编译验证未能完成，变更已提交到本地（修改文件：`app/src/main/java/com/example/quotepicker/data/Dao.kt`、`app/src/main/java/com/example/quotepicker/data/Repository.kt`）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e9a0edbac832b88aafd362b5439d1)