### PR TITLE
修复分组页刷新问题并支持创建空媒体组

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -133,7 +133,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     var groupLevel1Selected by remember { mutableStateOf(true) }
     var groupLevel2Selected by remember { mutableStateOf(false) }
     var groupLevel3Selected by remember { mutableStateOf(false) }
-    var openedGroup by remember { mutableStateOf<ResourceTitleGroup?>(null) }
+    var openedGroupKey by remember { mutableStateOf<String?>(null) }
     var renameGroupTarget by remember { mutableStateOf<ResourceTitleGroup?>(null) }
     var renameGroupValue by remember { mutableStateOf(TextFieldValue("")) }
     val coroutineScope = rememberCoroutineScope()
@@ -196,14 +196,18 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
         buildResourceGroups(ui.resources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected)
     }
 
-    LaunchedEffect(groupedResources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected) {
+    val openedGroup = remember(groupedResources, openedGroupKey) {
+        groupedResources.firstOrNull { it.key == openedGroupKey }
+    }
+
+    LaunchedEffect(groupedResources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected, openedGroupKey) {
         if (!groupLevel1Selected && !groupLevel2Selected && !groupLevel3Selected) {
-            openedGroup = null
+            openedGroupKey = null
             return@LaunchedEffect
         }
-        val exists = groupedResources.any { it.key == openedGroup?.key }
+        val exists = groupedResources.any { it.key == openedGroupKey }
         if (!exists) {
-            openedGroup = null
+            openedGroupKey = null
         }
     }
 
@@ -267,7 +271,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                         ResourceGroupedPage(
                             group = group,
                             categories = ui.categories,
-                            onBack = { openedGroup = null },
+                            onBack = { openedGroupKey = null },
                             onPreview = { previewTarget = it },
                             onLongClick = { bottomSheetTarget = it }
                         )
@@ -284,7 +288,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                                     name = group.title,
                                     childNames = group.childNames,
                                     count = group.resources.size,
-                                    onClick = { openedGroup = group },
+                                    onClick = { openedGroupKey = group.key },
                                     onLongClick = {
                                         renameGroupTarget = group
                                         renameGroupValue = TextFieldValue(group.title)
@@ -1338,10 +1342,10 @@ private fun ResourceCreateScreen(
     val canSubmit = title.isNotBlank() && selectedCharacters.isNotEmpty() && when (mode) {
         CreateMode.Flow -> flowItems.isNotEmpty()
         CreateMode.Text -> textContent.isNotBlank()
-        CreateMode.ImageGroup -> imageUris.isNotEmpty()
+        CreateMode.ImageGroup -> true
         CreateMode.Scene -> sceneMessages.isNotEmpty()
-        CreateMode.VideoGroup -> videoUris.isNotEmpty()
-        CreateMode.SoundGroup -> soundUris.isNotEmpty()
+        CreateMode.VideoGroup -> true
+        CreateMode.SoundGroup -> true
     }
 
     val selectedSpeakerNames = remember(selectedCharacters, characters) {
@@ -1524,7 +1528,7 @@ private fun ResourceCreateScreen(
                         Spacer(Modifier.width(8.dp))
                         Text("选择图片")
                     }
-                    Text(if (imageUris.isEmpty()) "未选择图片" else "已选择 ${imageUris.size} 张图片")
+                    Text(if (imageUris.isEmpty()) "未选择图片（将创建空图片组）" else "已选择 ${imageUris.size} 张图片")
                 }
                 CreateMode.Scene -> {
                     OutlinedTextField(
@@ -1609,7 +1613,7 @@ private fun ResourceCreateScreen(
                         Spacer(Modifier.width(8.dp))
                         Text("选择视频")
                     }
-                    Text(if (videoUris.isEmpty()) "未选择视频" else "已选择 ${videoUris.size} 个视频")
+                    Text(if (videoUris.isEmpty()) "未选择视频（将创建空视频组）" else "已选择 ${videoUris.size} 个视频")
                 }
                 CreateMode.SoundGroup -> {
                     TextButton(onClick = { soundPicker.launch(arrayOf("audio/*")) }) {
@@ -1617,7 +1621,7 @@ private fun ResourceCreateScreen(
                         Spacer(Modifier.width(8.dp))
                         Text("选择音频")
                     }
-                    Text(if (soundUris.isEmpty()) "未选择音频" else "已选择 ${soundUris.size} 个音频")
+                    Text(if (soundUris.isEmpty()) "未选择音频（将创建空声音组）" else "已选择 ${soundUris.size} 个音频")
                 }
             }
             ResourceTagPickerRow(

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -178,7 +178,6 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                         stored.imagePath
                     }
                 }
-            if (storedPaths.isEmpty()) return@launch
             val payload = org.json.JSONArray(storedPaths).toString()
             repo.addResource(
                 ResourceEntity(type = ResourceType.IMAGE, title = title, contentUriOrPath = payload),
@@ -206,7 +205,6 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch(Dispatchers.IO) {
             if (characterIds.isEmpty()) return@launch
             val storedUris = uris.mapNotNull { uri -> storeVideoToInternal(uri) }
-            if (storedUris.isEmpty()) return@launch
             val payload = org.json.JSONArray(storedUris).toString()
             repo.addResource(
                 ResourceEntity(
@@ -223,7 +221,6 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         viewModelScope.launch(Dispatchers.IO) {
             if (characterIds.isEmpty()) return@launch
             val storedUris = uris.mapNotNull { uri -> storeAudioToInternal(uri) }
-            if (storedUris.isEmpty()) return@launch
             val payload = org.json.JSONArray(storedUris).toString()
             repo.addResource(
                 ResourceEntity(


### PR DESCRIPTION
### Motivation
- 使在分组详情页内编辑资源名/标签后能立即生效，无需返回再进入以提升交互体验。 
- 允许创建空的图片/视频/声音组，方便后续对资源进行拆分与补充。 

### Description
- 将分组页的打开状态从缓存整个 `ResourceTitleGroup` 对象改为仅保存分组 `key`（`openedGroupKey`），并基于最新的 `groupedResources` 通过 `remember` 实时解析当前 `openedGroup`。 
- 调整相关副作用 `LaunchedEffect` 的依赖和重置逻辑以基于 `openedGroupKey` 判断和清理不可用组。 
- 把分组页的返回与进入逻辑改为使用 `openedGroupKey`（`onBack = { openedGroupKey = null }`，点击组时设置 `openedGroupKey = group.key`）。 
- 允许在创建图片/视频/声音组时文件列表为空：将 `CreateMode.ImageGroup/VideoGroup/SoundGroup` 的提交条件改为不再强制选文件，更新界面提示文案以明确“将创建空…组”，并在 `ResourceViewModel` 中移除对空文件列表的直接 `return`，改为保存空数组 payload（`[]`）。 
- 主要修改文件：`app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt` 和 `app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt`。 

### Testing
- 尝试运行 `./gradlew :app:assembleDebug`，但在此环境下 Gradle Wrapper 下载被代理阻断导致构建失败（HTTP 403），因此未能完成 APK 构建验证。 
- 已在代码库中通过编辑和 local linters/inspection 查看变更位置并手动检查关键逻辑路径，未发现明显的语法错误。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a140500b40832b84852f988fc4a309)