### PR TITLE
feat: 按分组层级预填新建资源名称

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -173,6 +173,12 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             tags = ui.tags,
             characters = ui.characters,
             availableResources = allResources,
+            initialTitle = buildCreateTitlePreset(
+                openedGroupTitle = openedGroup?.title,
+                level1 = groupLevel1Selected,
+                level2 = groupLevel2Selected,
+                level3 = groupLevel3Selected
+            ),
             vm = vm,
             onBack = { createMode = null }
         )
@@ -1021,6 +1027,29 @@ private fun resourceTitleGroupKey(title: String, level1: Boolean, level2: Boolea
     }
 }
 
+private fun buildCreateTitlePreset(
+    openedGroupTitle: String?,
+    level1: Boolean,
+    level2: Boolean,
+    level3: Boolean
+): String {
+    if (openedGroupTitle.isNullOrBlank()) return ""
+    val selectedIndexes = buildList {
+        if (level1) add(0)
+        if (level2) add(1)
+        if (level3) add(2)
+    }
+    if (selectedIndexes.isEmpty()) return ""
+    val selectedParts = openedGroupTitle.split("-").map { it.trim() }.filter { it.isNotEmpty() }
+    if (selectedParts.isEmpty()) return ""
+    val maxIndex = selectedIndexes.maxOrNull() ?: return ""
+    val baseParts = MutableList(maxIndex + 1) { "" }
+    selectedIndexes.forEachIndexed { position, index ->
+        selectedParts.getOrNull(position)?.let { baseParts[index] = it }
+    }
+    return baseParts.joinToString("-") + "-"
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun GroupListRow(
@@ -1271,10 +1300,11 @@ private fun ResourceCreateScreen(
     tags: List<TagEntity>,
     characters: List<CharacterEntity>,
     availableResources: List<ResourceWithTagsCharacters>,
+    initialTitle: String,
     vm: ResourceViewModel,
     onBack: () -> Unit
 ) {
-    var title by remember { mutableStateOf("") }
+    var title by remember(mode, initialTitle) { mutableStateOf(initialTitle) }
     var textContent by remember { mutableStateOf("") }
     var description by remember { mutableStateOf("") }
     var sceneMessages by remember { mutableStateOf<List<SceneMessageDraft>>(emptyList()) }


### PR DESCRIPTION
### Motivation
- 在资源列表进入分组详情后点击“新增”时，希望资源名自动填写为当前分组的层级前缀，减少手动输入并确保命名一致性。

### Description
- 在 `ResourceScreen` 中打开创建页面时传入 `initialTitle`，由新函数 `buildCreateTitlePreset(...)` 根据当前打开的分组名与 1/2/3 层选择生成预设前缀并补齐末尾连字符。 
- 新增函数 `buildCreateTitlePreset(openedGroupTitle, level1, level2, level3)`，将分组名按所选层级映射到对应段位并返回类似 `摄影-`、`-四季-`、`--秋天-` 的字符串。 
- 修改 `ResourceCreateScreen` 签名增加 `initialTitle: String` 参数，并将标题输入框的初始状态改为 `remember(mode, initialTitle) { mutableStateOf(initialTitle) }` 以在打开创建页时填充预设值。
- 变更文件：`app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`（新增逻辑与参数传递，及界面状态初始化）。

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 进行本地 Kotlin 编译验证但失败，原因是运行环境无法下载 Gradle 发行包（代理返回 HTTP 403），因此未能完成编译验证。 
- 已用静态检查命令查看并确认变更被应用（`git status` / `git commit` 成功提交变更）。 
- 未修改或添加自动化单元测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1520925cc832bab2a8e0cd42dc132)