### PR TITLE
Fix ResourceScreen openedGroup unresolved reference

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -166,6 +166,25 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
         return
     }
 
+    val groupedResources = remember(ui.resources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected) {
+        buildResourceGroups(ui.resources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected)
+    }
+
+    val openedGroup = remember(groupedResources, openedGroupKey) {
+        groupedResources.firstOrNull { it.key == openedGroupKey }
+    }
+
+    LaunchedEffect(groupedResources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected, openedGroupKey) {
+        if (!groupLevel1Selected && !groupLevel2Selected && !groupLevel3Selected) {
+            openedGroupKey = null
+            return@LaunchedEffect
+        }
+        val exists = groupedResources.any { it.key == openedGroupKey }
+        if (!exists) {
+            openedGroupKey = null
+        }
+    }
+
     createMode?.let { mode ->
         ResourceCreateScreen(
             mode = mode,
@@ -196,25 +215,6 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             onBack = { editTarget = null }
         )
         return
-    }
-
-    val groupedResources = remember(ui.resources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected) {
-        buildResourceGroups(ui.resources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected)
-    }
-
-    val openedGroup = remember(groupedResources, openedGroupKey) {
-        groupedResources.firstOrNull { it.key == openedGroupKey }
-    }
-
-    LaunchedEffect(groupedResources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected, openedGroupKey) {
-        if (!groupLevel1Selected && !groupLevel2Selected && !groupLevel3Selected) {
-            openedGroupKey = null
-            return@LaunchedEffect
-        }
-        val exists = groupedResources.any { it.key == openedGroupKey }
-        if (!exists) {
-            openedGroupKey = null
-        }
     }
 
     if (previewTarget != null) {


### PR DESCRIPTION
### Motivation
- `ResourceCreateScreen` used `openedGroup` via `initialTitle = buildCreateTitlePreset(openedGroupTitle = openedGroup?.title, ...)` before `openedGroup` (and `groupedResources`) were defined, causing an `Unresolved reference: openedGroup` compile error.

### Description
- Move the derivation of `groupedResources`, `openedGroup`, and the related `LaunchedEffect` earlier in `ResourceScreen` so they are defined before the `createMode` branch.
- Remove the duplicated block that previously appeared after the `editTarget` branch to avoid the unresolved reference and redundant state computation.
- Change applied to `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`.

### Testing
- Executed `bash ./gradlew :app:compileDebugKotlin`, but the build could not complete because the Gradle wrapper download was blocked by a proxy (`HTTP 403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a154f567d4832ba832e995c41fb6e3)