### PR TITLE
优化资源一览筛选分组逻辑与资源详情标记实时联动

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -128,6 +128,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     var regroupTarget by remember { mutableStateOf<ResourceWithTagsCharacters?>(null) }
     var filterTagDialog by remember { mutableStateOf(false) }
     var filterCharacterDialog by remember { mutableStateOf(false) }
+    var filterGroupDialog by remember { mutableStateOf(false) }
     var manageScreen by remember { mutableStateOf(false) }
     var manageItems by remember { mutableStateOf<List<StoredMediaItem>>(emptyList()) }
     var restoreTarget by remember { mutableStateOf<StoredMediaItem?>(null) }
@@ -135,10 +136,12 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     var groupLevel2Selected by remember { mutableStateOf(false) }
     var groupLevel3Selected by remember { mutableStateOf(false) }
     var groupByTitleSelected by remember { mutableStateOf(false) }
-    var hierarchicalGroupMode by remember { mutableStateOf(false) }
+    var hierarchicalGroupMode by remember { mutableStateOf(true) }
     var openedGroupPath by remember { mutableStateOf<List<String>>(emptyList()) }
     var renameGroupTarget by remember { mutableStateOf<ResourceTitleGroup?>(null) }
     var renameGroupValue by remember { mutableStateOf(TextFieldValue("")) }
+    var selectedGroupLevel1 by remember { mutableStateOf<Set<String>>(emptySet()) }
+    var selectedGroupPairs by remember { mutableStateOf<Set<Pair<String, String>>>(emptySet()) }
     val coroutineScope = rememberCoroutineScope()
     val restorePicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
         val target = restoreTarget
@@ -169,10 +172,18 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
         return
     }
 
-    val groupedResources = remember(ui.resources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected, groupByTitleSelected, hierarchicalGroupMode, openedGroupPath) {
+    val groupedFilterResources = remember(ui.resources, selectedGroupLevel1, selectedGroupPairs) {
+        applyGroupFilter(
+            resources = ui.resources,
+            selectedLevel1 = selectedGroupLevel1,
+            selectedPairs = selectedGroupPairs
+        )
+    }
+
+    val groupedResources = remember(groupedFilterResources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected, groupByTitleSelected, hierarchicalGroupMode, openedGroupPath) {
         if (hierarchicalGroupMode) {
             buildNestedResourceGroups(
-                resources = ui.resources,
+                resources = groupedFilterResources,
                 level1 = groupLevel1Selected,
                 level2 = groupLevel2Selected,
                 level3 = groupLevel3Selected,
@@ -180,7 +191,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                 path = openedGroupPath
             )
         } else {
-            buildResourceGroups(ui.resources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected, groupByTitleSelected)
+            buildResourceGroups(groupedFilterResources, groupLevel1Selected, groupLevel2Selected, groupLevel3Selected, groupByTitleSelected)
         }
     }
 
@@ -270,23 +281,27 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                 characters = ui.characters,
                 selectedCharacterId = ui.filters.selectedCharacterId,
                 selectedMarkState = ui.filters.selectedMarkState,
+                selectedGroupLevel1 = selectedGroupLevel1,
+                selectedGroupPairs = selectedGroupPairs,
                 groupLevel1Selected = groupLevel1Selected,
                 groupLevel2Selected = groupLevel2Selected,
                 groupLevel3Selected = groupLevel3Selected,
                 groupByTitleSelected = groupByTitleSelected,
                 hierarchicalGroupMode = hierarchicalGroupMode,
+                openedGroupPath = openedGroupPath,
                 onTypeChange = vm::updateTypeFilter,
                 onCharacterDialog = { filterCharacterDialog = true },
                 onTagDialog = { filterTagDialog = true },
+                onGroupDialog = { filterGroupDialog = true },
                 onToggleLevel1 = { groupLevel1Selected = !groupLevel1Selected },
                 onToggleLevel2 = { groupLevel2Selected = !groupLevel2Selected },
                 onToggleLevel3 = { groupLevel3Selected = !groupLevel3Selected },
                 onToggleGroupByTitle = { groupByTitleSelected = !groupByTitleSelected; openedGroupPath = emptyList() },
-                onToggleHierarchicalMode = { hierarchicalGroupMode = !hierarchicalGroupMode; openedGroupPath = emptyList() },
+                onNavigateUp = { if (openedGroupPath.isNotEmpty()) openedGroupPath = openedGroupPath.dropLast(1) },
                 onMarkStateChange = vm::updateMarkStateFilter
             )
             when {
-                ui.resources.isEmpty() -> {
+                groupedFilterResources.isEmpty() -> {
                     Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
                         Text("暂无资源，点击右下角添加")
                     }
@@ -306,7 +321,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                             group = groupedResources.first(),
                             categories = ui.categories,
                             onBack = { if (openedGroupPath.isNotEmpty()) openedGroupPath = openedGroupPath.dropLast(1) },
-                            backLabel = openedGroupPath.lastOrNull() ?: "上一层",
+                            backLabel = openedGroupPath.dropLast(1).lastOrNull() ?: "根分组",
                             onPreview = { previewTarget = it },
                             onLongClick = { bottomSheetTarget = it }
                         )
@@ -318,7 +333,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                             if (hierarchicalGroupMode && openedGroupPath.isNotEmpty()) {
                                 item {
                                     TextButton(onClick = { openedGroupPath = openedGroupPath.dropLast(1) }) {
-                                        Text("返回上一层")
+                                        Text("返回 ${openedGroupPath.dropLast(1).lastOrNull() ?: "根分组"}")
                                     }
                                 }
                             }
@@ -345,19 +360,6 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                                     }
                                 )
                             }
-                            if (!hierarchicalGroupMode) {
-                                groupedResources.firstOrNull()?.takeIf { groupedResources.size == 1 }?.let { single ->
-                                    items(single.resources, key = { it.resource.id }) { res ->
-                                        ResourceListRow(
-                                            resource = res,
-                                            categories = ui.categories,
-                                            roleText = res.characters.joinToString("/") { it.name }.ifBlank { "无角色" },
-                                            onClick = { previewTarget = res },
-                                            onLongClick = { bottomSheetTarget = res }
-                                        )
-                                    }
-                                }
-                            }
                         }
                     }
                 }
@@ -366,7 +368,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                         contentPadding = androidx.compose.foundation.layout.PaddingValues(12.dp),
                         verticalArrangement = Arrangement.spacedBy(8.dp)
                     ) {
-                        items(ui.resources, key = { it.resource.id }) { res ->
+                        items(groupedFilterResources, key = { it.resource.id }) { res ->
                             ResourceListRow(
                                 resource = res,
                                 categories = ui.categories,
@@ -433,6 +435,18 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
             selectedId = ui.filters.selectedCharacterId,
             onConfirm = { vm.updateCharacterFilter(it) },
             onDismiss = { filterCharacterDialog = false }
+        )
+    }
+    if (filterGroupDialog) {
+        FilterGroupDialog(
+            resources = allResources,
+            selectedLevel1 = selectedGroupLevel1,
+            selectedPairs = selectedGroupPairs,
+            onConfirm = { level1, pairs ->
+                selectedGroupLevel1 = level1
+                selectedGroupPairs = pairs
+            },
+            onDismiss = { filterGroupDialog = false }
         )
     }
 
@@ -970,23 +984,27 @@ private fun FilterBar(
     characters: List<CharacterEntity>,
     selectedCharacterId: Long?,
     selectedMarkState: ResourceMarkState?,
+    selectedGroupLevel1: Set<String>,
+    selectedGroupPairs: Set<Pair<String, String>>,
     groupLevel1Selected: Boolean,
     groupLevel2Selected: Boolean,
     groupLevel3Selected: Boolean,
     groupByTitleSelected: Boolean,
     hierarchicalGroupMode: Boolean,
+    openedGroupPath: List<String>,
     onTypeChange: (ResourceType?) -> Unit,
     onCharacterDialog: () -> Unit,
     onTagDialog: () -> Unit,
+    onGroupDialog: () -> Unit,
     onToggleLevel1: () -> Unit,
     onToggleLevel2: () -> Unit,
     onToggleLevel3: () -> Unit,
     onToggleGroupByTitle: () -> Unit,
-    onToggleHierarchicalMode: () -> Unit,
+    onNavigateUp: () -> Unit,
     onMarkStateChange: (ResourceMarkState?) -> Unit
 ) {
-    Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Column(Modifier.fillMaxWidth().padding(horizontal = 12.dp, vertical = 4.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
             val orderedTypes = listOf(
                 ResourceType.FLOW,
                 ResourceType.TEXT,
@@ -1003,13 +1021,19 @@ private fun FilterBar(
                 )
             }
         }
-        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
             AssistChip(onClick = onTagDialog, label = { Text("标签筛选(${selectedTagIds.size})") })
             val selectedCharacter = characters.firstOrNull { it.id == selectedCharacterId }
             AssistChip(
                 onClick = onCharacterDialog,
                 label = { Text(selectedCharacter?.name ?: "全部角色") }
             )
+            AssistChip(
+                onClick = onGroupDialog,
+                label = { Text("分组筛选(${selectedGroupPairs.size.takeIf { it > 0 } ?: selectedGroupLevel1.size})") }
+            )
+        }
+        FlowRow(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalArrangement = Arrangement.spacedBy(2.dp)) {
             FilterChip(
                 selected = groupLevel1Selected,
                 onClick = onToggleLevel1,
@@ -1021,7 +1045,11 @@ private fun FilterBar(
                 label = { Text("2") }
             )
             FilterChip(selected = groupLevel3Selected, onClick = onToggleLevel3, label = { Text("3") })
-            FilterChip(selected = hierarchicalGroupMode, onClick = onToggleHierarchicalMode, label = { Text("+") })
+            FilterChip(
+                selected = openedGroupPath.isNotEmpty(),
+                onClick = onNavigateUp,
+                label = { Text(openedGroupPath.dropLast(1).lastOrNull() ?: "+") }
+            )
             FilterChip(selected = groupByTitleSelected, onClick = onToggleGroupByTitle, label = { Text("资源名分组") })
             FilterChip(
                 selected = selectedMarkState == ResourceMarkState.NONE,
@@ -1107,7 +1135,19 @@ private fun buildNestedResourceGroups(
         }
     }
     return grouped.entries.map { (k,v) ->
-        ResourceTitleGroup(k, k, if (depth + 1 < indexes.size) "子组" else "", v)
+        val childNames = if (depth + 1 < indexes.size) {
+            val childIndex = indexes[depth + 1]
+            v.mapNotNull { child ->
+                if (childIndex == -1) {
+                    child.resource.title
+                } else {
+                    child.resource.title.split("-").map { it.trim() }.filter { it.isNotEmpty() }.getOrNull(childIndex)
+                }
+            }.distinct().sorted().joinToString("・")
+        } else {
+            ""
+        }
+        ResourceTitleGroup(k, k, childNames, v)
     }.sortedBy { it.title }
 }
 
@@ -1279,6 +1319,104 @@ private fun ResourceGroupedPage(
             }
         }
     }
+}
+
+
+private fun titleParts(title: String): List<String> = title.split("-").map { it.trim() }.filter { it.isNotEmpty() }
+
+private fun applyGroupFilter(
+    resources: List<ResourceWithTagsCharacters>,
+    selectedLevel1: Set<String>,
+    selectedPairs: Set<Pair<String, String>>
+): List<ResourceWithTagsCharacters> {
+    if (selectedLevel1.isEmpty() && selectedPairs.isEmpty()) return resources
+    return resources.filter { item ->
+        val parts = titleParts(item.resource.title)
+        val first = parts.getOrNull(0)
+        val second = parts.getOrNull(1)
+        val matchLevel1 = first != null && selectedLevel1.contains(first)
+        val matchPair = first != null && second != null && selectedPairs.contains(first to second)
+        matchLevel1 || matchPair
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun FilterGroupDialog(
+    resources: List<ResourceWithTagsCharacters>,
+    selectedLevel1: Set<String>,
+    selectedPairs: Set<Pair<String, String>>,
+    onConfirm: (Set<String>, Set<Pair<String, String>>) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val allLevel1 = remember(resources) {
+        resources.mapNotNull { titleParts(it.resource.title).getOrNull(0) }.distinct().sorted()
+    }
+    var level1Selected by remember { mutableStateOf(selectedLevel1.toMutableSet()) }
+    var pairSelected by remember { mutableStateOf(selectedPairs.toMutableSet()) }
+    val secondLevelMap = remember(resources, level1Selected) {
+        level1Selected.associateWith { first ->
+            resources.mapNotNull { item ->
+                val parts = titleParts(item.resource.title)
+                if (parts.getOrNull(0) == first) parts.getOrNull(1) else null
+            }.distinct().sorted()
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("分组筛选") },
+        text = {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 420.dp)
+                    .verticalScroll(rememberScrollState()),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                Text("第一层分组")
+                FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    allLevel1.forEach { first ->
+                        FilterChip(
+                            selected = level1Selected.contains(first),
+                            onClick = {
+                                if (!level1Selected.add(first)) {
+                                    level1Selected.remove(first)
+                                    pairSelected.removeAll { it.first == first }
+                                }
+                            },
+                            label = { Text(first) }
+                        )
+                    }
+                }
+                if (level1Selected.isNotEmpty()) {
+                    Text("第二层分组")
+                    level1Selected.sorted().forEach { first ->
+                        Text(first, style = MaterialTheme.typography.labelMedium)
+                        FlowRow(horizontalArrangement = Arrangement.spacedBy(6.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                            secondLevelMap[first].orEmpty().forEach { second ->
+                                val pair = first to second
+                                FilterChip(
+                                    selected = pairSelected.contains(pair),
+                                    onClick = {
+                                        if (!pairSelected.add(pair)) pairSelected.remove(pair)
+                                    },
+                                    label = { Text(second) }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onConfirm(level1Selected.toSet(), pairSelected.toSet())
+                onDismiss()
+            }) { Text("确定") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
 }
 
 private fun typeLabel(type: ResourceType): String = when (type) {

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -111,8 +111,11 @@ fun ResourcePreviewScreen(
     val scrollState = rememberScrollState()
     val uiState by vm.uiState.collectAsState()
     val allResources by vm.allResources.collectAsState()
-    val sortedTags = remember(resource.tags, uiState.categories) {
-        sortTagsForDisplay(resource.tags, uiState.categories)
+    val liveResource = remember(uiState.resources, resource.resource.id) {
+        uiState.resources.firstOrNull { it.resource.id == resource.resource.id } ?: resource
+    }
+    val sortedTags = remember(liveResource.tags, uiState.categories) {
+        sortTagsForDisplay(liveResource.tags, uiState.categories)
     }
     val highlightedSpeaker = uiState.filters.selectedCharacterId?.let { id ->
         uiState.characters.firstOrNull { it.id == id }?.name
@@ -120,7 +123,7 @@ fun ResourcePreviewScreen(
     val eventRunner = rememberEventSequenceRunner()
 
     LaunchedEffect(resource.resource.id, mediaReloadKey, allResources) {
-        val res = resource.resource
+        val res = liveResource.resource
         quoteImages = emptyList()
         mediaLoadFailed = false
         flowItems = emptyList()
@@ -194,7 +197,7 @@ fun ResourcePreviewScreen(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 Text(
-                    text = resource.resource.title,
+                    text = liveResource.resource.title,
                     style = MaterialTheme.typography.headlineSmall,
                     fontWeight = FontWeight.Bold
                 )
@@ -202,22 +205,29 @@ fun ResourcePreviewScreen(
                 Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
                     MarkCircleButton(
                         color = Color(0xFF2E7D32),
-                        selected = resource.resource.markState == ResourceMarkState.CHECKED,
+                        selected = liveResource.resource.markState == ResourceMarkState.CHECKED,
+                        enabled = liveResource.tags.isNotEmpty(),
                         onClick = {
-                            val next = if (resource.resource.markState == ResourceMarkState.CHECKED) ResourceMarkState.NONE else ResourceMarkState.CHECKED
-                            vm.updateResource(resource.resource.copy(markState = next))
+                            if (liveResource.tags.isNotEmpty()) {
+                                val next = if (liveResource.resource.markState == ResourceMarkState.CHECKED) ResourceMarkState.NONE else ResourceMarkState.CHECKED
+                                vm.updateResource(liveResource.resource.copy(markState = next))
+                            }
                         }
                     )
                     MarkCircleButton(
                         color = Color(0xFFC62828),
-                        selected = resource.resource.markState == ResourceMarkState.FAVORITE,
+                        selected = liveResource.resource.markState == ResourceMarkState.FAVORITE,
+                        enabled = liveResource.tags.isNotEmpty() && liveResource.resource.markState != ResourceMarkState.NONE,
                         onClick = {
-                            val next = if (resource.resource.markState == ResourceMarkState.FAVORITE) ResourceMarkState.NONE else ResourceMarkState.FAVORITE
-                            vm.updateResource(resource.resource.copy(markState = next))
+                            if (liveResource.tags.isNotEmpty() && liveResource.resource.markState == ResourceMarkState.CHECKED) {
+                                vm.updateResource(liveResource.resource.copy(markState = ResourceMarkState.FAVORITE))
+                            } else if (liveResource.resource.markState == ResourceMarkState.FAVORITE) {
+                                vm.updateResource(liveResource.resource.copy(markState = ResourceMarkState.CHECKED))
+                            }
                         }
                     )
                 }
-                if (resource.resource.type != ResourceType.FLOW) {
+                if (liveResource.resource.type != ResourceType.FLOW) {
                     ResourceMetaRow(label = "标签") {
                         if (sortedTags.isNotEmpty()) {
                             FlowRow(
@@ -233,12 +243,12 @@ fun ResourcePreviewScreen(
                         }
                     }
                     ResourceMetaRow(label = "角色") {
-                        if (resource.characters.isNotEmpty()) {
+                        if (liveResource.characters.isNotEmpty()) {
                             FlowRow(
                                 horizontalArrangement = Arrangement.spacedBy(6.dp),
                                 verticalArrangement = Arrangement.spacedBy(6.dp)
                             ) {
-                                resource.characters.forEach { character ->
+                                liveResource.characters.forEach { character ->
                                     CharacterBadge(name = character.name)
                                 }
                             }
@@ -257,9 +267,9 @@ fun ResourcePreviewScreen(
                             .padding(16.dp),
                         verticalArrangement = Arrangement.spacedBy(12.dp)
                     ) {
-                        when (resource.resource.type) {
+                        when (liveResource.resource.type) {
                             ResourceType.TEXT -> {
-                                val quoteText = resource.resource.quoteText.orEmpty()
+                                val quoteText = liveResource.resource.quoteText.orEmpty()
                                 if (quoteText.isNotBlank()) {
                                     PreviewTextWithInlineFile(
                                         text = quoteText,
@@ -313,7 +323,7 @@ fun ResourcePreviewScreen(
                                         }
                                     }
                                 } else {
-                                    Text(resource.resource.sceneJson.orEmpty())
+                                    Text(liveResource.resource.sceneJson.orEmpty())
                                 }
                             }
                             ResourceType.FLOW -> {
@@ -857,15 +867,16 @@ private suspend fun flowPreviewItemFromResource(
 private fun MarkCircleButton(
     color: Color,
     selected: Boolean,
+    enabled: Boolean = true,
     onClick: () -> Unit
 ) {
     Box(
         modifier = Modifier
             .size(28.dp)
             .clip(CircleShape)
-            .background(if (selected) color else color.copy(alpha = 0.18f))
-            .border(1.dp, color, CircleShape)
-            .clickable(onClick = onClick)
+            .background(if (selected) color else color.copy(alpha = if (enabled) 0.18f else 0.08f))
+            .border(1.dp, if (enabled) color else color.copy(alpha = 0.45f), CircleShape)
+            .clickable(enabled = enabled, onClick = onClick)
     )
 }
 


### PR DESCRIPTION
### Motivation
- 缩小资源一览顶部三行按钮的垂直间距并按需求重排类型/标签/角色/分组/分组级别/标记按钮以改善可视布局和交互。 
- 支持按第一层或第一层-第二层分组筛选并在筛选后基于剩余资源进行分组展示以避免重复资源显示。 
- 修复红圈/绿圈过滤导致的重复展示问题，并确保分组、子组名称与“上一层”文字能动态反映当前层级。 
- 在资源详情页实现标记按钮的实时联动与状态约束（只有有标签可切绿色，且仅在绿色时可切红色）。

### Description
- 收紧 `FilterBar` 垂直间距并将控件拆分为三行展示，添加“分组筛选”入口与动态“+ / 上一层”行为；相关调整在 `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`。 
- 新增 `FilterGroupDialog` 与 `applyGroupFilter`（基于第一层/第一层-第二层多选）以先对资源进行组合过滤再做分组展示；实现位于 `ResourceScreen.kt` 并接入现有分组流程。 
- 修改分组构建逻辑以展示真实子组名称（不再固定显示“子组”），并改为对已过滤结果进行 `buildNestedResourceGroups` / `buildResourceGroups` 处理，避免“组+同一资源重复显示”的冗余分支。 
- 资源详情页改为以 `vm.uiState` 的实时数据为来源（`liveResource`），并扩展 `MarkCircleButton` 支持 `enabled`，在 `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt` 中加入：只有有标签允许切绿色、只有绿色可切红色、红色取消后回退到绿色，且按钮可用性视觉即时反映。 

### Testing
- 尝试执行 `./gradlew :app:compileDebugKotlin` 进行编译验证，但环境中 Gradle 分发包下载被代理阻断（HTTP 403），因此编译无法完成。 
- 已通过 local edits / static inspection（代码编译请求发起、文件变更和 lint/grep 浏览）验证行为改动点和调用链的合理性, 但未能在该环境下完成实际 APK 编译或运行时测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8d2dfb248832ba18a20557c6e55e1)