### PR TITLE
修复资源页底部空白遮挡与分组筛选长按失效

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.Folder
@@ -25,6 +26,7 @@ fun MainScreen() {
     var currentTab by remember { mutableIntStateOf(0) }
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         bottomBar = {
             NavigationBar {
                 NavigationBarItem(

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -1074,13 +1074,13 @@ private fun FilterBar(
 
             val groupCount = selectedGroupPairs.size.takeIf { it > 0 } ?: selectedGroupLevel1.size
             val groupLabel = if (groupKeyword.isBlank()) "分组筛选($groupCount)" else groupKeyword
-            Box(modifier = Modifier.combinedClickable(onClick = onGroupDialog, onLongClick = onGroupLongPress)) {
-                AssistChip(
-                    modifier = Modifier.height(chipH),
-                    onClick = onGroupDialog,
-                    label = { Text(groupLabel, style = textStyle, maxLines = 1) }
-                )
-            }
+            AssistChip(
+                modifier = Modifier
+                    .height(chipH)
+                    .combinedClickable(onClick = onGroupDialog, onLongClick = onGroupLongPress),
+                onClick = onGroupDialog,
+                label = { Text(groupLabel, style = textStyle, maxLines = 1) }
+            )
         }
 
         // ---- Row 3: Level + Mode + Mark ----


### PR DESCRIPTION
### Motivation
- 修复主页面与子页面 `Scaffold` inset 叠加导致底部菜单上方出现空白区域，影响画面显示与交互。 
- 修复资源页“分组筛选”按钮的长按交互无效，无法弹出关键字编辑对话框的问题。

### Description
- 在 `MainScreen` 的外层 `Scaffold` 中加入 `contentWindowInsets = WindowInsets(0, 0, 0, 0)` 以避免与子页面 inset 叠加（文件：`app/src/main/java/com/example/quotepicker/ui/MainScreen.kt`）。
- 将资源页分组筛选控件的长按手势从外层 `Box` 移到 `AssistChip` 本身，使用 `Modifier.combinedClickable(onClick = ..., onLongClick = ...)` 来确保点击和长按都能正确响应（文件：`app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`）。
- 保持原有点击行为不变，长按将触发 `onGroupLongPress` 回调以打开关键字编辑对话框，同时点击仍然调用 `onGroupDialog`。 

### Testing
- 尝试使用 `./gradlew :app:assembleDebug` 构建以验证改动，但在当前环境 Gradle 发行包下载被代理拒绝，导致构建失败（代理返回 `HTTP/1.1 403 Forbidden`），因此无法完成本地 APK 构建验证。 
- 已在代码中用 `git diff` / 本地检查确认目标文件内容变更符合预期，未运行其他自动化测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8f87ccca4832b8ef1931460d034ee)