### PR TITLE
Use zero WindowInsets for Scaffolds and separate group/keyword chips in Resource filter

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -1,5 +1,6 @@
 package com.example.quotepicker.ui
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -190,6 +191,7 @@ fun CharacterScreen(
     }
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         modifier = modifier,
         topBar = {
             TopAppBar(

--- a/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.Icon
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Casino
 import androidx.compose.material.icons.filled.Folder
@@ -25,6 +26,7 @@ fun MainScreen() {
     var currentTab by remember { mutableIntStateOf(0) }
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         bottomBar = {
             NavigationBar {
                 NavigationBarItem(

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -1,5 +1,6 @@
 package com.example.quotepicker.ui
 
+import androidx.compose.foundation.layout.WindowInsets
 import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -84,6 +85,7 @@ fun ExecutionScreen(
     }
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         modifier = modifier,
         topBar = {
             TopAppBar(

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -2,6 +2,7 @@
 
 package com.example.quotepicker.ui
 
+import androidx.compose.foundation.layout.WindowInsets
 import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
@@ -256,6 +257,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
     }
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         modifier = modifier,
         topBar = {
             TopAppBar(
@@ -296,7 +298,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                 onCharacterDialog = { filterCharacterDialog = true },
                 onTagDialog = { filterTagDialog = true },
                 onGroupDialog = { filterGroupDialog = true },
-                onGroupLongPress = { groupKeywordDialog = true },
+                onKeywordDialog = { groupKeywordDialog = true },
                 groupKeyword = groupKeyword,
                 onToggleLevel1 = { groupLevel1Selected = !groupLevel1Selected },
                 onToggleLevel2 = { groupLevel2Selected = !groupLevel2Selected },
@@ -664,6 +666,7 @@ private fun ManageStorageScreen(
     }
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         modifier = modifier,
         topBar = {
             TopAppBar(
@@ -994,6 +997,7 @@ private sealed class CreateMode {
     data object SoundGroup : CreateMode()
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun FilterBar(
     selectedType: ResourceType?,
@@ -1011,7 +1015,7 @@ private fun FilterBar(
     onCharacterDialog: () -> Unit,
     onTagDialog: () -> Unit,
     onGroupDialog: () -> Unit,
-    onGroupLongPress: () -> Unit,
+    onKeywordDialog: () -> Unit,
     groupKeyword: String,
     onToggleLevel1: () -> Unit,
     onToggleLevel2: () -> Unit,
@@ -1073,14 +1077,18 @@ private fun FilterBar(
             )
 
             val groupCount = selectedGroupPairs.size.takeIf { it > 0 } ?: selectedGroupLevel1.size
-            val groupLabel = if (groupKeyword.isBlank()) "分组筛选($groupCount)" else groupKeyword
-            Box(modifier = Modifier.combinedClickable(onClick = onGroupDialog, onLongClick = onGroupLongPress)) {
-                AssistChip(
-                    modifier = Modifier.height(chipH),
-                    onClick = onGroupDialog,
-                    label = { Text(groupLabel, style = textStyle, maxLines = 1) }
-                )
-            }
+            AssistChip(
+                modifier = Modifier.height(chipH),
+                onClick = onGroupDialog,
+                label = { Text("分组筛选($groupCount)", style = textStyle, maxLines = 1) }
+            )
+
+            val keywordLabel = if (groupKeyword.isBlank()) "关键词" else "关键词:$groupKeyword"
+            AssistChip(
+                modifier = Modifier.height(chipH),
+                onClick = onKeywordDialog,
+                label = { Text(keywordLabel, style = textStyle, maxLines = 1) }
+            )
         }
 
         // ---- Row 3: Level + Mode + Mark ----

--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -1,5 +1,6 @@
 package com.example.quotepicker.ui
 
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -132,6 +133,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     }
 
     Scaffold(
+        contentWindowInsets = WindowInsets(0, 0, 0, 0),
         modifier = modifier,
         topBar = {
             TopAppBar(


### PR DESCRIPTION
### Motivation
- Ensure scaffolds don't apply default system/window insets so layout padding is controlled by the inner padding only. 
- Simplify and clarify the resource FilterBar UI by removing the long-press combined chip and exposing an explicit keyword chip/action.

### Description
- Added `contentWindowInsets = WindowInsets(0, 0, 0, 0)` to multiple `Scaffold` usages and imported `WindowInsets` in `CharacterScreen.kt`, `MainScreen.kt`, `RandomScreen.kt` (ExecutionScreen), `ResourceScreen.kt`, and `TagScreen.kt` to disable automatic window inset application. 
- Refactored the group/keyword UI in the resource filter: replaced the `combinedClickable` long-press group chip with two separate `AssistChip`s (one for group filter and one for keyword), and renamed the callback parameter from `onGroupLongPress` to `onKeywordDialog` in `FilterBar`. 
- Updated the `ResourceScreen` call site to pass `onKeywordDialog = { groupKeywordDialog = true }` and adjusted labels to show the current keyword (`"关键词"`/`"关键词:..."`).
- Added `@OptIn(ExperimentalFoundationApi::class)` annotation to the `FilterBar` composable where needed and removed the previous combined long-press handling.

### Testing
- Built the app with Gradle using `./gradlew assembleDebug`, which completed successfully. 
- Ran unit tests with `./gradlew test`, and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8f87ccca4832b8ef1931460d034ee)