### PR TITLE
新增“魔剧”专属预览与全屏播放（MagicDrama）功能

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -1,0 +1,414 @@
+package com.example.quotepicker.ui.components
+
+import android.net.Uri
+import android.widget.VideoView
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.example.quotepicker.data.CharacterEntity
+import com.example.quotepicker.vm.ResourceViewModel
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.json.JSONArray
+
+private sealed interface DramaCommand {
+    data class Narration(val text: String, val delayMs: Long, val important: Boolean) : DramaCommand
+    data class RoleLine(val roleKey: String, val text: String, val delayMs: Long) : DramaCommand
+    data class ShowVideo(val source: String) : DramaCommand
+    data class ShowImage(val source: String) : DramaCommand
+    data class ShowButtons(val options: List<DramaButtonOption>) : DramaCommand
+    data class Countdown(val seconds: Int) : DramaCommand
+}
+
+private data class DramaButtonOption(val text: String, val branchId: String)
+
+private sealed interface DramaMessage {
+    data class Narration(val text: String, val important: Boolean) : DramaMessage
+    data class Role(val role: String, val text: String) : DramaMessage
+}
+
+private sealed interface DramaMedia {
+    data class Image(val source: String) : DramaMedia
+    data class Video(val source: String) : DramaMedia
+}
+
+@Composable
+fun MagicDramaScreen(
+    title: String,
+    script: String,
+    boundCharacters: List<CharacterEntity>,
+    vm: ResourceViewModel,
+    onClose: () -> Unit
+) {
+    val listState = rememberLazyListState()
+    val messages = remember { mutableStateListOf<DramaMessage>() }
+    var currentMedia by remember { mutableStateOf<DramaMedia?>(null) }
+    var countdownSeconds by remember { mutableStateOf<Int?>(null) }
+    var buttonOptions by remember { mutableStateOf<List<DramaButtonOption>>(emptyList()) }
+    var pendingBranch by remember { mutableStateOf<CompletableDeferred<String>?>(null) }
+    var countdownJob by remember { mutableStateOf<Job?>(null) }
+
+    val parsed = remember(script) { parseDramaScript(script) }
+    val coroutineScope = rememberCoroutineScope()
+
+    DisposableEffect(Unit) {
+        onDispose {
+            countdownJob?.cancel()
+            pendingBranch?.cancel()
+        }
+    }
+
+    LaunchedEffect(script) {
+        messages.clear()
+        currentMedia = null
+        countdownSeconds = null
+        buttonOptions = emptyList()
+        pendingBranch = null
+        countdownJob?.cancel()
+        countdownJob = null
+
+        val queue = ArrayDeque(parsed.main)
+        while (queue.isNotEmpty()) {
+            when (val cmd = queue.removeFirst()) {
+                is DramaCommand.Narration -> {
+                    messages += DramaMessage.Narration(text = renderRandomToken(cmd.text), important = cmd.important)
+                    delay(cmd.delayMs)
+                }
+                is DramaCommand.RoleLine -> {
+                    val role = resolveRoleName(cmd.roleKey, boundCharacters)
+                    messages += DramaMessage.Role(role = role, text = cmd.text.replace("nn", "\n"))
+                    delay(cmd.delayMs)
+                }
+                is DramaCommand.ShowImage -> currentMedia = DramaMedia.Image(cmd.source)
+                is DramaCommand.ShowVideo -> currentMedia = DramaMedia.Video(cmd.source)
+                is DramaCommand.Countdown -> {
+                    countdownJob?.cancel()
+                    countdownJob = coroutineScope.launch {
+                        launchCountdown(cmd.seconds) { left -> countdownSeconds = left }
+                    }
+                }
+                is DramaCommand.ShowButtons -> {
+                    buttonOptions = cmd.options
+                    val waiter = CompletableDeferred<String>()
+                    pendingBranch = waiter
+                    val selected = waiter.await()
+                    buttonOptions = emptyList()
+                    pendingBranch = null
+                    parsed.branches[selected]?.asReversed()?.forEach { queue.addFirst(it) }
+                }
+            }
+        }
+    }
+
+    LaunchedEffect(messages.size) {
+        if (messages.isNotEmpty()) {
+            listState.animateScrollToItem(messages.lastIndex)
+        }
+    }
+
+    Dialog(
+        onDismissRequest = onClose,
+        properties = DialogProperties(usePlatformDefaultWidth = false)
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.Black)
+        ) {
+            Column(modifier = Modifier.fillMaxSize()) {
+            Box(
+                modifier = Modifier
+                    .weight(3f)
+                    .fillMaxWidth()
+                    .background(Color(0xFF111111))
+            ) {
+                DramaMediaArea(media = currentMedia, vm = vm)
+                countdownSeconds?.let { left ->
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(12.dp)
+                            .background(Color(0xAA000000), RoundedCornerShape(8.dp))
+                            .padding(horizontal = 10.dp, vertical = 6.dp)
+                    ) {
+                        Text(text = "倒数 ${left}s", color = Color.White, fontWeight = FontWeight.Bold)
+                    }
+                }
+            }
+            Column(
+                modifier = Modifier
+                    .weight(2f)
+                    .fillMaxWidth()
+                    .background(Color(0xFF181818))
+                    .padding(10.dp)
+            ) {
+                Text(text = title, color = Color(0xFFD0B3FF), style = MaterialTheme.typography.labelMedium)
+                Spacer(modifier = Modifier.height(8.dp))
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    state = listState
+                ) {
+                    items(messages) { message ->
+                        when (message) {
+                            is DramaMessage.Narration -> NarrationBubble(message)
+                            is DramaMessage.Role -> RoleBubble(message)
+                        }
+                    }
+                }
+                if (buttonOptions.isNotEmpty()) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        buttonOptions.forEach { option ->
+                            Button(
+                                onClick = { pendingBranch?.complete(option.branchId) },
+                                modifier = Modifier.weight(1f)
+                            ) { Text(option.text) }
+                        }
+                    }
+                }
+            }
+        }
+            IconButton(
+                onClick = onClose,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(10.dp)
+                    .background(Color(0x66000000), CircleShape)
+            ) {
+                Icon(Icons.Default.Close, contentDescription = "关闭", tint = Color.White)
+            }
+        }
+    }
+}
+
+private suspend fun launchCountdown(total: Int, onTick: (Int?) -> Unit) {
+    onTick(total)
+    for (left in total - 1 downTo 0) {
+        delay(1000)
+        onTick(left)
+    }
+    onTick(null)
+}
+
+@Composable
+private fun DramaMediaArea(media: DramaMedia?, vm: ResourceViewModel) {
+    when (media) {
+        is DramaMedia.Image -> {
+            val bitmap = remember(media.source) { decodeImageSource(media.source, vm) }
+            if (bitmap != null) {
+                androidx.compose.foundation.Image(
+                    bitmap = bitmap.asImageBitmap(),
+                    contentDescription = "资源图片",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Fit
+                )
+            }
+        }
+        is DramaMedia.Video -> LoopVideo(uri = Uri.parse(media.source))
+        null -> Box(modifier = Modifier.fillMaxSize())
+    }
+}
+
+@Composable
+private fun LoopVideo(uri: Uri) {
+    val holder = remember { mutableStateOf<VideoView?>(null) }
+    DisposableEffect(Unit) {
+        onDispose { holder.value?.stopPlayback() }
+    }
+    AndroidView(
+        factory = { context ->
+            VideoView(context).apply {
+                setVideoURI(uri)
+                setOnPreparedListener { it.start() }
+                setOnCompletionListener { it.start() }
+                holder.value = this
+            }
+        },
+        update = { view ->
+            if (view.tag != uri) {
+                view.tag = uri
+                view.setVideoURI(uri)
+                view.start()
+            }
+        },
+        modifier = Modifier.fillMaxSize()
+    )
+}
+
+@Composable
+private fun NarrationBubble(message: DramaMessage.Narration) {
+    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        Text(
+            text = message.text,
+            color = if (message.important) Color(0xFFFF4FC3) else Color.White,
+            modifier = Modifier
+                .background(Color.Black, RoundedCornerShape(10.dp))
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        )
+    }
+}
+
+@Composable
+private fun RoleBubble(message: DramaMessage.Role) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.Top
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(CircleShape)
+                .border(1.dp, Color(0xFFAAAAAA), CircleShape),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = message.role.take(4), color = Color.White, style = MaterialTheme.typography.labelSmall)
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(
+            modifier = Modifier
+                .background(Color(0xFF2A2A2A), RoundedCornerShape(10.dp))
+                .padding(8.dp)
+        ) {
+            Text(text = message.role, color = Color(0xFFBDBDBD), style = MaterialTheme.typography.labelSmall)
+            Text(text = message.text, color = Color.White)
+        }
+    }
+}
+
+private data class ParsedDramaScript(
+    val main: List<DramaCommand>,
+    val branches: Map<String, List<DramaCommand>>
+)
+
+private fun parseDramaScript(raw: String): ParsedDramaScript {
+    val main = mutableListOf<DramaCommand>()
+    val branches = mutableMapOf<String, MutableList<DramaCommand>>()
+    raw.lines().forEach { line ->
+        val trimmed = line.trim()
+        if (!trimmed.startsWith("+")) return@forEach
+        val body = trimmed.removePrefix("+")
+        val branchMatch = Regex("^%(\\w+)(.+)$").find(body)
+        if (branchMatch != null) {
+            val branchId = branchMatch.groupValues[1]
+            val cmd = parseDramaCommand(branchMatch.groupValues[2].trimStart(':'))
+            if (cmd != null) branches.getOrPut(branchId) { mutableListOf() }.add(cmd)
+        } else {
+            parseDramaCommand(body)?.let(main::add)
+        }
+    }
+    return ParsedDramaScript(main = main, branches = branches)
+}
+
+private fun parseDramaCommand(raw: String): DramaCommand? {
+    val idx = raw.indexOf(':')
+    if (idx <= 0) return null
+    val key = raw.substring(0, idx).trim()
+    val value = raw.substring(idx + 1).trim()
+    return when {
+        key == "旁白" -> {
+            val (text, delay) = parseDelayText(value)
+            DramaCommand.Narration(text, delay, important = false)
+        }
+        key == "重要" -> {
+            val (text, delay) = parseDelayText(value)
+            DramaCommand.Narration(text, delay, important = true)
+        }
+        key == "视频" -> DramaCommand.ShowVideo(value)
+        key == "图片" -> DramaCommand.ShowImage(value)
+        key == "按钮" -> {
+            val options = value.split("-")
+                .mapNotNull { item ->
+                    val m = Regex("(.+)%([\\w]+)$").find(item.trim()) ?: return@mapNotNull null
+                    DramaButtonOption(m.groupValues[1].trim(), m.groupValues[2].trim())
+                }
+            if (options.isNotEmpty()) DramaCommand.ShowButtons(options) else null
+        }
+        key == "倒数" -> value.toIntOrNull()?.let { DramaCommand.Countdown(it) }
+        else -> {
+            val (text, delay) = parseDelayText(value)
+            DramaCommand.RoleLine(roleKey = key, text = text, delayMs = delay)
+        }
+    }
+}
+
+private fun parseDelayText(raw: String): Pair<String, Long> {
+    val idx = raw.lastIndexOf('-')
+    if (idx > 0) {
+        val text = raw.substring(0, idx).trim()
+        val ms = raw.substring(idx + 1).trim().toLongOrNull()
+        if (ms != null) return text to ms
+    }
+    return raw to 1000L
+}
+
+private fun resolveRoleName(input: String, boundCharacters: List<CharacterEntity>): String {
+    val exact = boundCharacters.firstOrNull { it.name.equals(input, ignoreCase = true) }
+    if (exact != null) return exact.name
+    val contains = boundCharacters.firstOrNull { it.name.contains(input, ignoreCase = true) || input.contains(it.name, ignoreCase = true) }
+    return contains?.name ?: input
+}
+
+private fun renderRandomToken(text: String): String {
+    return Regex("\\[\\[(.+?)]]").replace(text) { match ->
+        val options = match.groupValues[1].split(',').map { it.trim() }.filter { it.isNotBlank() }
+        options.randomOrNull() ?: match.value
+    }
+}
+
+private fun decodeImageSource(source: String, vm: ResourceViewModel): android.graphics.Bitmap? {
+    val trimmed = source.trim()
+    if (trimmed.startsWith("[")) {
+        return runCatching {
+            val arr = JSONArray(trimmed)
+            (0 until arr.length()).firstNotNullOfOrNull { idx -> decodeImageSource(arr.get(idx).toString(), vm) }
+        }.getOrNull()
+    }
+    val uri = Uri.parse(trimmed)
+    return if (uri.scheme != null) vm.decodeUriToBitmap(uri) else vm.decodeBase64ToBitmap(trimmed)
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt
@@ -61,6 +61,7 @@ fun ResourceListRow(
                 text = resource.resource.title,
                 style = MaterialTheme.typography.bodySmall,
                 fontWeight = FontWeight.Bold,
+                color = if (resource.resource.title.contains("魔剧")) Color(0xFF8E24AA) else MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f)

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -270,14 +270,36 @@ fun ResourcePreviewScreen(
                         when (liveResource.resource.type) {
                             ResourceType.TEXT -> {
                                 val quoteText = liveResource.resource.quoteText.orEmpty()
-                                if (quoteText.isNotBlank()) {
-                                    PreviewTextWithInlineFile(
-                                        text = quoteText,
+                                val isMagicDrama = liveResource.resource.title.contains("魔剧")
+                                var showMagicDrama by remember(liveResource.resource.id) { mutableStateOf(false) }
+                                if (showMagicDrama) {
+                                    MagicDramaScreen(
+                                        title = liveResource.resource.title,
+                                        script = quoteText,
+                                        boundCharacters = liveResource.characters,
                                         vm = vm,
-                                        onEventSequence = handleEventSequence
+                                        onClose = { showMagicDrama = false }
                                     )
+                                } else if (isMagicDrama) {
+                                    Column(
+                                        modifier = Modifier.fillMaxWidth(),
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
+                                        TextButton(onClick = { showMagicDrama = true }) {
+                                            Text("开始魔剧")
+                                        }
+                                    }
+                                } else {
+                                    if (quoteText.isNotBlank()) {
+                                        PreviewTextWithInlineFile(
+                                            text = quoteText,
+                                            vm = vm,
+                                            onEventSequence = handleEventSequence
+                                        )
+                                    }
+                                    QuoteImagePager(images = quoteImages)
                                 }
-                                QuoteImagePager(images = quoteImages)
                             }
                             ResourceType.IMAGE -> {
                                 if (quoteImages.isNotEmpty()) {


### PR DESCRIPTION
### Motivation
- 为文本类资源增加专属的“魔剧”交互预览与全屏播放页面，以便在资源标题包含“魔剧”时提供沉浸式演示与脚本驱动的实时控制。
- 在资源列表中高亮此类资源，便于快速识别与进入专属预览。 

### Description
- 在 `ResourceListRow.kt` 中将资源标题渲染逻辑改为：当资源标题包含“魔剧”时使用紫色 `Color(0xFF8E24AA)` 显示标题。
- 在 `ResourcePreviewScreen.kt` 中为文本资源添加“魔剧”入口逻辑：若标题包含“魔剧”则隐藏原有文本预览并显示一个“开始魔剧”按钮，点击后通过 `MagicDramaScreen` 进入全屏播放，关闭后返回预览。
- 新增 `MagicDramaScreen.kt` 实现全屏魔剧模式，特性包括：使用 `Dialog` 做无宽度限制的全屏展示并在右上角提供关闭按钮；页面按 3:2 比例分区，上方为资源展示区（图片/视频，支持循环播放视频），下方为聊天式文本滚动区；实现脚本解析与执行（支持命令：`旁白`、`重要`、`角色*`、`视频`、`图片`、`按钮`、`倒数`），支持 `[[a,b,c]]` 随机替换、`nn` 换行、角色名模糊匹配绑定角色、按钮分支 `%x` 跳转以及倒计时异步执行不阻塞后续命令。
- 实现细节包括安全地解析 JSON 列表或单项的图片/视频源、将倒计时以 coroutine Job 异步运行并支持取消，以及在页面销毁时取消挂起任务以避免泄露。
- 影响文件：
  - `app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt`
  - `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`
  - `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt`（新建）

### Testing
- 尝试运行 Kotlin 编译命令 `bash ./gradlew :app:compileDebugKotlin`，但在当前环境中 Gradle 分发包下载被代理返回 `HTTP/1.1 403 Forbidden`，导致编译无法完成；因此本次变更在 CI/本地构建上未能完成编译验证（失败）。
- 对源文件进行了本地修改与提交操作并成功写入版本库（commit 成功），但未能在该受限环境中通过编译来证明运行时行为。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa84bff044832ba34807d3a67f0f79)