### PR TITLE
Add quote models, MainViewModel, AddQuoteDialog and MagicDrama TTS/UI enhancements

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/QuoteModels.kt
+++ b/app/src/main/java/com/example/quotepicker/data/QuoteModels.kt
@@ -1,0 +1,18 @@
+package com.example.quotepicker.data
+
+enum class QuoteType { TEXT, IMAGE }
+
+data class GroupEntity(
+    val id: Long,
+    val name: String
+)
+
+data class QuoteEntity(
+    val id: Long,
+    val groupId: Long,
+    val type: QuoteType,
+    val text: String? = null,
+    val imageBase64: String? = null,
+    val weight: Int = 1,
+    val enabled: Boolean = true
+)

--- a/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/MainScreen.kt
@@ -1,25 +1,25 @@
 package com.example.quotepicker.ui
 
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Casino
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.LocalOffer
+import androidx.compose.material.icons.filled.Person
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.Icon
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Casino
-import androidx.compose.material.icons.filled.Folder
-import androidx.compose.material.icons.filled.LocalOffer
-import androidx.compose.material.icons.filled.Person
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.foundation.layout.padding
 
 @Composable
 fun MainScreen() {

--- a/app/src/main/java/com/example/quotepicker/ui/components/AddQuoteDialog.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/AddQuoteDialog.kt
@@ -1,0 +1,89 @@
+package com.example.quotepicker.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.quotepicker.data.GroupEntity
+import com.example.quotepicker.vm.MainViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddQuoteDialog(
+    groups: List<GroupEntity>,
+    onDismiss: () -> Unit,
+    onAddText: (Long, String, Int) -> Unit,
+    onAddImage: (Long, String, Int) -> Unit,
+    vm: MainViewModel
+) {
+    var selectedGroupId by remember(groups) { mutableStateOf(groups.firstOrNull()?.id ?: 0L) }
+    var content by remember { mutableStateOf("") }
+    var weightText by remember { mutableStateOf("1") }
+    var asImage by remember { mutableStateOf(false) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("添加语录") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(10.dp)) {
+                OutlinedTextField(
+                    value = selectedGroupId.toString(),
+                    onValueChange = { selectedGroupId = it.toLongOrNull() ?: 0L },
+                    label = { Text("分组ID") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = content,
+                    onValueChange = { content = it },
+                    label = { Text(if (asImage) "图片(base64或uri)" else "文本") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = weightText,
+                    onValueChange = { weightText = it },
+                    label = { Text("权重") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    TextButton(onClick = { asImage = false }) { Text("文本") }
+                    TextButton(onClick = { asImage = true }) { Text("图片") }
+                }
+                if (groups.isEmpty()) {
+                    Text("请先添加分组")
+                }
+            }
+        },
+        confirmButton = {
+            val w = weightText.toIntOrNull() ?: 1
+            Button(
+                enabled = groups.isNotEmpty() && selectedGroupId > 0 && content.isNotBlank(),
+                onClick = {
+                    if (asImage) {
+                        onAddImage(selectedGroupId, content.trim(), w)
+                    } else {
+                        onAddText(selectedGroupId, content.trim(), w)
+                    }
+                }
+            ) {
+                Text("确定")
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -1,6 +1,7 @@
 package com.example.quotepicker.ui.components
 
 import android.net.Uri
+import android.speech.tts.TextToSpeech
 import android.widget.VideoView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -42,6 +43,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -54,6 +56,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.json.JSONArray
+import java.util.Locale
+
+data class MagicDramaSettings(
+    val defaultDelayMs: Long = 1000L,
+    val speechRate: Float = 1.0f,
+    val speechPitch: Float = 1.0f
+)
 
 private sealed interface DramaCommand {
     data class Narration(val text: String, val delayMs: Long, val important: Boolean) : DramaCommand
@@ -81,6 +90,7 @@ fun MagicDramaScreen(
     title: String,
     script: String,
     boundCharacters: List<CharacterEntity>,
+    settings: MagicDramaSettings,
     vm: ResourceViewModel,
     onClose: () -> Unit
 ) {
@@ -94,15 +104,24 @@ fun MagicDramaScreen(
 
     val parsed = remember(script) { parseDramaScript(script) }
     val coroutineScope = rememberCoroutineScope()
+    val context = LocalContext.current
+    var ttsReady by remember { mutableStateOf(false) }
+    val tts = remember {
+        TextToSpeech(context) { status ->
+            ttsReady = status == TextToSpeech.SUCCESS
+        }
+    }
 
     DisposableEffect(Unit) {
         onDispose {
             countdownJob?.cancel()
             pendingBranch?.cancel()
+            tts.stop()
+            tts.shutdown()
         }
     }
 
-    LaunchedEffect(script) {
+    LaunchedEffect(script, settings.defaultDelayMs, settings.speechRate, settings.speechPitch) {
         messages.clear()
         currentMedia = null
         countdownSeconds = null
@@ -110,18 +129,29 @@ fun MagicDramaScreen(
         pendingBranch = null
         countdownJob?.cancel()
         countdownJob = null
+        tts.language = Locale.CHINA
+        tts.setSpeechRate(settings.speechRate)
+        tts.setPitch(settings.speechPitch)
 
         val queue = ArrayDeque(parsed.main)
         while (queue.isNotEmpty()) {
             when (val cmd = queue.removeFirst()) {
                 is DramaCommand.Narration -> {
-                    messages += DramaMessage.Narration(text = renderRandomToken(cmd.text), important = cmd.important)
-                    delay(cmd.delayMs)
+                    val text = renderRandomToken(cmd.text)
+                    messages += DramaMessage.Narration(text = text, important = cmd.important)
+                    if (ttsReady) {
+                        tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "narration_${messages.size}")
+                    }
+                    delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
                 }
                 is DramaCommand.RoleLine -> {
                     val role = resolveRoleName(cmd.roleKey, boundCharacters)
-                    messages += DramaMessage.Role(role = role, text = cmd.text.replace("nn", "\n"))
-                    delay(cmd.delayMs)
+                    val text = cmd.text.replace("nn", "\n")
+                    messages += DramaMessage.Role(role = role, text = text)
+                    if (ttsReady) {
+                        tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "role_${messages.size}")
+                    }
+                    delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
                 }
                 is DramaCommand.ShowImage -> currentMedia = DramaMedia.Image(cmd.source)
                 is DramaCommand.ShowVideo -> currentMedia = DramaMedia.Video(cmd.source)
@@ -157,14 +187,14 @@ fun MagicDramaScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(Color.Black)
+                .background(Color(0xFFF5F7FB))
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
             Box(
                 modifier = Modifier
                     .weight(3f)
                     .fillMaxWidth()
-                    .background(Color(0xFF111111))
+                    .background(Color(0xFFE8EEFF))
             ) {
                 DramaMediaArea(media = currentMedia, vm = vm)
                 countdownSeconds?.let { left ->
@@ -172,7 +202,7 @@ fun MagicDramaScreen(
                         modifier = Modifier
                             .align(Alignment.BottomEnd)
                             .padding(12.dp)
-                            .background(Color(0xAA000000), RoundedCornerShape(8.dp))
+                            .background(Color(0xCC2E3A59), RoundedCornerShape(8.dp))
                             .padding(horizontal = 10.dp, vertical = 6.dp)
                     ) {
                         Text(text = "倒数 ${left}s", color = Color.White, fontWeight = FontWeight.Bold)
@@ -183,10 +213,10 @@ fun MagicDramaScreen(
                 modifier = Modifier
                     .weight(2f)
                     .fillMaxWidth()
-                    .background(Color(0xFF181818))
+                    .background(Color(0xFFFDF7EA))
                     .padding(10.dp)
             ) {
-                Text(text = title, color = Color(0xFFD0B3FF), style = MaterialTheme.typography.labelMedium)
+                Text(text = title, color = Color(0xFF2D3561), style = MaterialTheme.typography.labelMedium)
                 Spacer(modifier = Modifier.height(8.dp))
                 LazyColumn(
                     modifier = Modifier.weight(1f),
@@ -218,7 +248,7 @@ fun MagicDramaScreen(
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(10.dp)
-                    .background(Color(0x66000000), CircleShape)
+                    .background(Color(0xAA2E3A59), CircleShape)
             ) {
                 Icon(Icons.Default.Close, contentDescription = "关闭", tint = Color.White)
             }
@@ -285,9 +315,9 @@ private fun NarrationBubble(message: DramaMessage.Narration) {
     Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
         Text(
             text = message.text,
-            color = if (message.important) Color(0xFFFF4FC3) else Color.White,
+            color = if (message.important) Color(0xFFB33985) else Color(0xFF2B2F3A),
             modifier = Modifier
-                .background(Color.Black, RoundedCornerShape(10.dp))
+                .background(Color(0xFFEAF1FF), RoundedCornerShape(10.dp))
                 .padding(horizontal = 12.dp, vertical = 8.dp)
         )
     }
@@ -306,16 +336,16 @@ private fun RoleBubble(message: DramaMessage.Role) {
                 .border(1.dp, Color(0xFFAAAAAA), CircleShape),
             contentAlignment = Alignment.Center
         ) {
-            Text(text = message.role.take(4), color = Color.White, style = MaterialTheme.typography.labelSmall)
+            Text(text = message.role.take(4), color = Color(0xFF2B2F3A), style = MaterialTheme.typography.labelSmall)
         }
         Spacer(modifier = Modifier.width(8.dp))
         Column(
             modifier = Modifier
-                .background(Color(0xFF2A2A2A), RoundedCornerShape(10.dp))
+                .background(Color(0xFFFFFFFF), RoundedCornerShape(10.dp))
                 .padding(8.dp)
         ) {
-            Text(text = message.role, color = Color(0xFFBDBDBD), style = MaterialTheme.typography.labelSmall)
-            Text(text = message.text, color = Color.White)
+            Text(text = message.role, color = Color(0xFF5C647A), style = MaterialTheme.typography.labelSmall)
+            Text(text = message.text, color = Color(0xFF1F2433))
         }
     }
 }
@@ -383,7 +413,7 @@ private fun parseDelayText(raw: String): Pair<String, Long> {
         val ms = raw.substring(idx + 1).trim().toLongOrNull()
         if (ms != null) return text to ms
     }
-    return raw to 1000L
+    return raw to 0L
 }
 
 private fun resolveRoleName(input: String, boundCharacters: List<CharacterEntity>): String {

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -41,6 +41,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -272,22 +273,58 @@ fun ResourcePreviewScreen(
                                 val quoteText = liveResource.resource.quoteText.orEmpty()
                                 val isMagicDrama = liveResource.resource.title.contains("魔剧")
                                 var showMagicDrama by remember(liveResource.resource.id) { mutableStateOf(false) }
+                                var defaultDelayInput by remember(liveResource.resource.id) { mutableStateOf("1000") }
+                                var speechRateInput by remember(liveResource.resource.id) { mutableStateOf("1.0") }
+                                var speechPitchInput by remember(liveResource.resource.id) { mutableStateOf("1.0") }
                                 if (showMagicDrama) {
                                     MagicDramaScreen(
                                         title = liveResource.resource.title,
                                         script = quoteText,
                                         boundCharacters = liveResource.characters,
+                                        settings = MagicDramaSettings(
+                                            defaultDelayMs = defaultDelayInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 1000L,
+                                            speechRate = speechRateInput.toFloatOrNull()?.coerceIn(0.5f, 2.0f) ?: 1.0f,
+                                            speechPitch = speechPitchInput.toFloatOrNull()?.coerceIn(0.5f, 2.0f) ?: 1.0f
+                                        ),
                                         vm = vm,
                                         onClose = { showMagicDrama = false }
                                     )
                                 } else if (isMagicDrama) {
                                     Column(
                                         modifier = Modifier.fillMaxWidth(),
-                                        verticalArrangement = Arrangement.Center,
+                                        verticalArrangement = Arrangement.spacedBy(10.dp),
                                         horizontalAlignment = Alignment.CenterHorizontally
                                     ) {
                                         TextButton(onClick = { showMagicDrama = true }) {
                                             Text("开始魔剧")
+                                        }
+                                        Text(
+                                            text = "播放设置（默认值可编辑）",
+                                            style = MaterialTheme.typography.labelMedium,
+                                            color = Color(0xFF5F6280)
+                                        )
+                                        OutlinedTextField(
+                                            value = defaultDelayInput,
+                                            onValueChange = { defaultDelayInput = it },
+                                            singleLine = true,
+                                            label = { Text("文本默认停留毫秒(300-10000)") },
+                                            modifier = Modifier.fillMaxWidth()
+                                        )
+                                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                            OutlinedTextField(
+                                                value = speechRateInput,
+                                                onValueChange = { speechRateInput = it },
+                                                singleLine = true,
+                                                label = { Text("语速0.5-2") },
+                                                modifier = Modifier.weight(1f)
+                                            )
+                                            OutlinedTextField(
+                                                value = speechPitchInput,
+                                                onValueChange = { speechPitchInput = it },
+                                                singleLine = true,
+                                                label = { Text("音调0.5-2") },
+                                                modifier = Modifier.weight(1f)
+                                            )
                                         }
                                     }
                                 } else {

--- a/app/src/main/java/com/example/quotepicker/vm/MainViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/MainViewModel.kt
@@ -1,0 +1,130 @@
+package com.example.quotepicker.vm
+
+import android.app.Application
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.util.Base64
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.quotepicker.data.GroupEntity
+import com.example.quotepicker.data.QuoteEntity
+import com.example.quotepicker.data.QuoteType
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import java.io.ByteArrayOutputStream
+
+data class MainUiState(
+    val groups: List<GroupEntity> = emptyList(),
+    val currentGroupId: Long? = null,
+    val quotes: List<QuoteEntity> = emptyList(),
+    val randomResult: QuoteEntity? = null
+)
+
+class MainViewModel(app: Application) : AndroidViewModel(app) {
+    private val _state = MutableStateFlow(
+        MainUiState(
+            groups = listOf(GroupEntity(id = 1, name = "默认分组")),
+            currentGroupId = null,
+            quotes = emptyList(),
+            randomResult = null
+        )
+    )
+    val uiState: StateFlow<MainUiState> = _state.asStateFlow()
+
+    private var nextGroupId = 2L
+    private var nextQuoteId = 1L
+
+    fun setGroup(id: Long?) {
+        _state.value = _state.value.copy(currentGroupId = id)
+    }
+
+    fun addGroup(name: String) {
+        val group = GroupEntity(id = nextGroupId++, name = name)
+        _state.value = _state.value.copy(groups = _state.value.groups + group)
+    }
+
+    fun deleteGroup(group: GroupEntity) {
+        val remainingGroups = _state.value.groups.filterNot { it.id == group.id }
+        val remainingQuotes = _state.value.quotes.filterNot { it.groupId == group.id }
+        val current = if (_state.value.currentGroupId == group.id) null else _state.value.currentGroupId
+        _state.value = _state.value.copy(groups = remainingGroups, quotes = remainingQuotes, currentGroupId = current)
+    }
+
+    fun addTextQuote(groupId: Long, text: String, weight: Int) {
+        val quote = QuoteEntity(
+            id = nextQuoteId++,
+            groupId = groupId,
+            type = QuoteType.TEXT,
+            text = text,
+            weight = weight.coerceAtLeast(1),
+            enabled = true
+        )
+        _state.value = _state.value.copy(quotes = _state.value.quotes + quote)
+    }
+
+    fun addImageQuote(groupId: Long, base64: String, weight: Int) {
+        val quote = QuoteEntity(
+            id = nextQuoteId++,
+            groupId = groupId,
+            type = QuoteType.IMAGE,
+            imageBase64 = base64,
+            weight = weight.coerceAtLeast(1),
+            enabled = true
+        )
+        _state.value = _state.value.copy(quotes = _state.value.quotes + quote)
+    }
+
+    fun deleteQuote(q: QuoteEntity) {
+        _state.value = _state.value.copy(quotes = _state.value.quotes.filterNot { it.id == q.id })
+    }
+
+    fun updateQuote(q: QuoteEntity) {
+        _state.value = _state.value.copy(
+            quotes = _state.value.quotes.map { if (it.id == q.id) q else it }
+        )
+    }
+
+    fun pickRandom() = viewModelScope.launch {
+        val gid = _state.value.currentGroupId
+        val candidates = _state.value.quotes
+            .filter { it.enabled && it.weight > 0 }
+            .filter { gid == null || it.groupId == gid }
+        val picked = weightedPick(candidates) { it.weight }
+        _state.value = _state.value.copy(randomResult = picked)
+    }
+
+    fun clearRandom() {
+        _state.value = _state.value.copy(randomResult = null)
+    }
+
+    private fun <T> weightedPick(items: List<T>, weightOf: (T) -> Int): T? {
+        val list = items.filter { weightOf(it) > 0 }
+        if (list.isEmpty()) return null
+        val total = list.sumOf { weightOf(it) }
+        val r = (1..total).random()
+        var acc = 0
+        for (e in list) {
+            acc += weightOf(e)
+            if (r <= acc) return e
+        }
+        return list.first()
+    }
+
+    fun encodeImageToBase64(uri: Uri): String {
+        val cr = getApplication<Application>().contentResolver
+        cr.openInputStream(uri).use { input ->
+            val bmp = BitmapFactory.decodeStream(input)
+            val baos = ByteArrayOutputStream()
+            bmp.compress(Bitmap.CompressFormat.JPEG, 85, baos)
+            return Base64.encodeToString(baos.toByteArray(), Base64.NO_WRAP)
+        }
+    }
+
+    fun decodeBase64ToBitmap(b64: String): Bitmap {
+        val bytes = Base64.decode(b64, Base64.DEFAULT)
+        return BitmapFactory.decodeByteArray(bytes, 0, bytes.size)
+    }
+}


### PR DESCRIPTION
### Motivation
- Define core data models and state management for quotes and groups to support adding, listing and random selection of quotes.
- Provide a composable dialog for adding text/image quotes and wire up a simple in-memory view model for interactive UI flows.
- Improve the MagicDrama playback experience by adding Text-to-Speech, playback settings, and visual/theme refinements.

### Description
- Added `QuoteModels.kt` with `QuoteType`, `GroupEntity`, and `QuoteEntity` to represent groups and quotes.
- Implemented `MainViewModel.kt` providing `MainUiState`, in-memory group/quote management, weighted random pick, and helper functions to encode/decode images to/from Base64.
- Added `AddQuoteDialog.kt` composable to collect group ID, content, weight and toggle between text/image input, and wired callback handlers for add actions.
- Enhanced `MagicDramaScreen.kt` to support `MagicDramaSettings`, initialize and use Android `TextToSpeech` for narration and role lines, allow configurable speech rate/pitch and default delays, and updated several UI colors/backgrounds and countdown behavior; `ResourcePreviewScreen.kt` was updated to expose editable playback settings and pass them into the magic drama dialog.

### Testing
- Built the Android app with `./gradlew assembleDebug` and the build completed successfully.
- Ran `./gradlew test` for JVM unit tests where present and the task completed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa89bd84e0832bbc772c5b3a6b9cb1)