### PR TITLE
feat: 为魔剧播放新增可配置朗读开关

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -60,6 +60,7 @@ import java.util.Locale
 
 data class MagicDramaSettings(
     val defaultDelayMs: Long = 1000L,
+    val enableSpeech: Boolean = true,
     val speechRate: Float = 1.0f,
     val speechPitch: Float = 1.0f
 )
@@ -121,7 +122,7 @@ fun MagicDramaScreen(
         }
     }
 
-    LaunchedEffect(script, settings.defaultDelayMs, settings.speechRate, settings.speechPitch) {
+    LaunchedEffect(script, settings.defaultDelayMs, settings.enableSpeech, settings.speechRate, settings.speechPitch) {
         messages.clear()
         currentMedia = null
         countdownSeconds = null
@@ -129,9 +130,13 @@ fun MagicDramaScreen(
         pendingBranch = null
         countdownJob?.cancel()
         countdownJob = null
-        tts.language = Locale.CHINA
-        tts.setSpeechRate(settings.speechRate)
-        tts.setPitch(settings.speechPitch)
+        if (settings.enableSpeech) {
+            tts.language = Locale.CHINA
+            tts.setSpeechRate(settings.speechRate)
+            tts.setPitch(settings.speechPitch)
+        } else {
+            tts.stop()
+        }
 
         val queue = ArrayDeque(parsed.main)
         while (queue.isNotEmpty()) {
@@ -139,7 +144,7 @@ fun MagicDramaScreen(
                 is DramaCommand.Narration -> {
                     val text = renderRandomToken(cmd.text)
                     messages += DramaMessage.Narration(text = text, important = cmd.important)
-                    if (ttsReady) {
+                    if (settings.enableSpeech && ttsReady) {
                         tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "narration_${messages.size}")
                     }
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
@@ -148,7 +153,7 @@ fun MagicDramaScreen(
                     val role = resolveRoleName(cmd.roleKey, boundCharacters)
                     val text = cmd.text.replace("nn", "\n")
                     messages += DramaMessage.Role(role = role, text = text)
-                    if (ttsReady) {
+                    if (settings.enableSpeech && ttsReady) {
                         tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "role_${messages.size}")
                     }
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -274,6 +275,7 @@ fun ResourcePreviewScreen(
                                 val isMagicDrama = liveResource.resource.title.contains("魔剧")
                                 var showMagicDrama by remember(liveResource.resource.id) { mutableStateOf(false) }
                                 var defaultDelayInput by remember(liveResource.resource.id) { mutableStateOf("1000") }
+                                var enableSpeech by remember(liveResource.resource.id) { mutableStateOf(true) }
                                 var speechRateInput by remember(liveResource.resource.id) { mutableStateOf("1.0") }
                                 var speechPitchInput by remember(liveResource.resource.id) { mutableStateOf("1.0") }
                                 if (showMagicDrama) {
@@ -283,6 +285,7 @@ fun ResourcePreviewScreen(
                                         boundCharacters = liveResource.characters,
                                         settings = MagicDramaSettings(
                                             defaultDelayMs = defaultDelayInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 1000L,
+                                            enableSpeech = enableSpeech,
                                             speechRate = speechRateInput.toFloatOrNull()?.coerceIn(0.5f, 2.0f) ?: 1.0f,
                                             speechPitch = speechPitchInput.toFloatOrNull()?.coerceIn(0.5f, 2.0f) ?: 1.0f
                                         ),
@@ -299,10 +302,21 @@ fun ResourcePreviewScreen(
                                             Text("开始魔剧")
                                         }
                                         Text(
-                                            text = "播放设置（默认值可编辑）",
+                                            text = "播放设置（开始前设置）",
                                             style = MaterialTheme.typography.labelMedium,
                                             color = Color(0xFF5F6280)
                                         )
+                                        Row(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            horizontalArrangement = Arrangement.SpaceBetween,
+                                            verticalAlignment = Alignment.CenterVertically
+                                        ) {
+                                            Text("文本显示时朗读")
+                                            Switch(
+                                                checked = enableSpeech,
+                                                onCheckedChange = { enableSpeech = it }
+                                            )
+                                        }
                                         OutlinedTextField(
                                             value = defaultDelayInput,
                                             onValueChange = { defaultDelayInput = it },
@@ -310,21 +324,23 @@ fun ResourcePreviewScreen(
                                             label = { Text("文本默认停留毫秒(300-10000)") },
                                             modifier = Modifier.fillMaxWidth()
                                         )
-                                        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                            OutlinedTextField(
-                                                value = speechRateInput,
-                                                onValueChange = { speechRateInput = it },
-                                                singleLine = true,
-                                                label = { Text("语速0.5-2") },
-                                                modifier = Modifier.weight(1f)
-                                            )
-                                            OutlinedTextField(
-                                                value = speechPitchInput,
-                                                onValueChange = { speechPitchInput = it },
-                                                singleLine = true,
-                                                label = { Text("音调0.5-2") },
-                                                modifier = Modifier.weight(1f)
-                                            )
+                                        if (enableSpeech) {
+                                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                                OutlinedTextField(
+                                                    value = speechRateInput,
+                                                    onValueChange = { speechRateInput = it },
+                                                    singleLine = true,
+                                                    label = { Text("语速0.5-2") },
+                                                    modifier = Modifier.weight(1f)
+                                                )
+                                                OutlinedTextField(
+                                                    value = speechPitchInput,
+                                                    onValueChange = { speechPitchInput = it },
+                                                    singleLine = true,
+                                                    label = { Text("音调0.5-2") },
+                                                    modifier = Modifier.weight(1f)
+                                                )
+                                            }
                                         }
                                     }
                                 } else {


### PR DESCRIPTION
### Motivation
- 为魔剧类型的文本资源在展示时增加可选的朗读（TTS）功能，且把朗读相关参数放到“开始魔剧”按钮下方开始前配置，方便使用者开关与调节语速/音调。

### Description
- 在 `MagicDramaSettings` 中新增 `enableSpeech` 布尔开关，默认为 `true`，并将其传入播放页面。
- 在 `MagicDramaScreen.kt` 中根据 `enableSpeech` 决定是否初始化/设置 TTS 属性，并在播放各条文本时通过 `if (settings.enableSpeech && ttsReady)` 控制是否调用 `tts.speak(...)`；当 `enableSpeech` 为 `false` 时会调用 `tts.stop()` 避免继续播报。 
- 在资源预览页 `ResourcePreviewScreen.kt` 的魔剧设置区域新增 `Switch` 开关 `enableSpeech`，位于“开始魔剧”按钮下方，并在传入 `MagicDramaSettings` 时包含该值。 
- 当朗读关闭时隐藏语速/音调输入框；开启时才显示并允许编辑，保留原有的“文本默认停留毫秒”设置。 
- 修改文件：
  - `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt`（新增 `enableSpeech` 并在播放逻辑中使用）
  - `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`（新增开关 UI，并将其传递给 `MagicDramaScreen`）

### Testing
- 试图在本地运行 `./gradlew :app:compileDebugKotlin` 以编译验证变更，但首次运行因 `gradlew` 无执行权限返回 `Permission denied`，随后 `chmod +x gradlew` 后再次执行时因环境网络/代理限制在下载 Gradle 分发包阶段返回 `HTTP/1.1 403 Forbidden` 导致无法完成编译；因此编译未能在当前环境通过。 
- 已通过 `git` 操作提交改动，提交信息为 `feat: 魔剧文本显示新增可配置朗读功能`，所有代码变更已记录在提交中。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa9d84f090832ba6dff967b353ff29)