### PR TITLE
feat: export/import backups as AES-256-GCM encrypted backup.dat

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -129,7 +129,7 @@ fun CharacterScreen(
             vm.importSnapshot(uri)
         }
     }
-    val exportPicker = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
+    val exportPicker = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/octet-stream")) { uri ->
         if (uri != null) {
             vm.exportSnapshot(uri)
         }
@@ -206,10 +206,10 @@ fun CharacterScreen(
                 actions = {
                     if (selected == null) {
                         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                            TextButton(onClick = { importPicker.launch(arrayOf("application/zip", "application/json", "application/octet-stream")) }) {
+                            TextButton(onClick = { importPicker.launch(arrayOf("application/octet-stream", "application/zip", "application/json")) }) {
                                 Text("导入")
                             }
-                            TextButton(onClick = { exportPicker.launch("quote_backup.zip") }) {
+                            TextButton(onClick = { exportPicker.launch("quote_backup.backup.dat") }) {
                                 Text("导出")
                             }
                         }

--- a/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
@@ -12,14 +12,18 @@ import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
 import java.io.ByteArrayOutputStream
+import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
-import java.io.PushbackInputStream
 import java.nio.charset.Charset
+import java.security.SecureRandom
 import java.util.zip.ZipEntry
 import java.util.zip.ZipInputStream
 import java.util.zip.ZipOutputStream
+import javax.crypto.Cipher
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.SecretKeySpec
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -144,25 +148,30 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
                     outputBytes = bytesWritten
                     updateProgress()
                 }
-                ZipOutputStream(countingOutput).use { zip ->
-                    zip.putNextEntry(ZipEntry(BACKUP_JSON_NAME))
-                    writeChunked(zip, snapshotBytes) { written ->
-                        processedBytes += written
-                        updateProgress()
-                    }
-                    zip.closeEntry()
-                    exportPackage.mediaSources.forEach { source ->
-                        val stream = repo.openMediaStream(source.originalPath) ?: return@forEach
-                        stream.use { input ->
-                            zip.putNextEntry(ZipEntry("media/${source.fileName}"))
-                            writeStreamChunked(input, zip) { written ->
-                                processedBytes += written
-                                updateProgress()
+                val zipBytes = ByteArrayOutputStream().use { zipBuffer ->
+                    ZipOutputStream(zipBuffer).use { zip ->
+                        zip.putNextEntry(ZipEntry(BACKUP_JSON_NAME))
+                        writeChunked(zip, snapshotBytes) { written ->
+                            processedBytes += written
+                            updateProgress()
+                        }
+                        zip.closeEntry()
+                        exportPackage.mediaSources.forEach { source ->
+                            val stream = repo.openMediaStream(source.originalPath) ?: return@forEach
+                            stream.use { input ->
+                                zip.putNextEntry(ZipEntry("media/${source.fileName}"))
+                                writeStreamChunked(input, zip) { written ->
+                                    processedBytes += written
+                                    updateProgress()
+                                }
+                                zip.closeEntry()
                             }
-                            zip.closeEntry()
                         }
                     }
+                    zipBuffer.toByteArray()
                 }
+                val encrypted = encryptBackupPayload(zipBytes)
+                writeChunked(countingOutput, encrypted) { }
             }
             updateProgress(force = true)
         } finally {
@@ -215,19 +224,17 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
             var snapshot: BackupSnapshot? = null
             val mediaPayloads = mutableMapOf<String, com.example.quotepicker.data.MediaPayload>()
             resolver.openInputStream(uri)?.use { input ->
-                val pushbackInput = PushbackInputStream(input, 2)
-                val header = ByteArray(2)
-                val headerSize = pushbackInput.read(header)
-                if (headerSize > 0) {
-                    pushbackInput.unread(header, 0, headerSize)
-                }
-                val countingInput = CountingInputStream(pushbackInput) { bytesRead ->
+                val countingInput = CountingInputStream(input) { bytesRead ->
                     processedBytes = bytesRead
                     updateProgress()
                 }
-                val isZip = headerSize == 2 && header[0] == ZIP_MAGIC_P && header[1] == ZIP_MAGIC_K
+                val sourceBytes = readStreamBytes(countingInput)
+                processedBytes = countingInput.bytesRead
+                updateProgress(force = true)
+                val payloadBytes = decodeBackupPayload(sourceBytes)
+                val isZip = payloadBytes.size >= 2 && payloadBytes[0] == ZIP_MAGIC_P && payloadBytes[1] == ZIP_MAGIC_K
                 if (isZip) {
-                    ZipInputStream(countingInput).use { zip ->
+                    ZipInputStream(ByteArrayInputStream(payloadBytes)).use { zip ->
                         var entry = zip.nextEntry
                         var payload: String? = null
                         val buffer = ByteArray(PROGRESS_UPDATE_BYTES)
@@ -250,14 +257,10 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
                         if (!payload.isNullOrBlank()) {
                             snapshot = BackupSnapshot.fromJson(payload)
                         }
-                        processedBytes = countingInput.bytesRead
-                        updateProgress(force = true)
                     }
                 } else {
-                    val payload = readStreamString(countingInput)
+                    val payload = payloadBytes.toString(Charset.forName("UTF-8"))
                     snapshot = BackupSnapshot.fromJson(payload)
-                    processedBytes = countingInput.bytesRead
-                    updateProgress(force = true)
                 }
             }
             snapshot?.let { repo.replaceSnapshot(it, mediaPayloads) }
@@ -278,9 +281,14 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
 
     private companion object {
         const val BACKUP_JSON_NAME = "backup.json"
+        val BACKUP_MAGIC = byteArrayOf('B'.code.toByte(), 'K'.code.toByte(), 'P'.code.toByte(), '1'.code.toByte())
+        const val BACKUP_VERSION: Byte = 1
+        const val GCM_TAG_BITS = 128
+        const val GCM_IV_LENGTH = 12
         const val ZIP_MAGIC_P: Byte = 0x50
         const val ZIP_MAGIC_K: Byte = 0x4B
         const val PROGRESS_UPDATE_BYTES = 256 * 1024
+        val BACKUP_AES_KEY = "QuotePickerBackupAES256KeyMaterial!".toByteArray(Charset.forName("UTF-8")).copyOf(32)
     }
 
     private class CountingOutputStream(
@@ -376,7 +384,7 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
         return output.toString(Charset.forName("UTF-8"))
     }
 
-    private fun readStreamString(input: InputStream): String {
+    private fun readStreamBytes(input: InputStream): ByteArray {
         val output = ByteArrayOutputStream()
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
         var read = input.read(buffer)
@@ -384,7 +392,7 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
             output.write(buffer, 0, read)
             read = input.read(buffer)
         }
-        return output.toString(Charset.forName("UTF-8"))
+        return output.toByteArray()
     }
 
     private fun writeStreamChunked(input: InputStream, output: OutputStream, onChunk: (Int) -> Unit) {
@@ -395,5 +403,39 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
             onChunk(read)
             read = input.read(buffer)
         }
+    }
+
+    private fun encryptBackupPayload(rawZip: ByteArray): ByteArray {
+        val iv = ByteArray(GCM_IV_LENGTH)
+        SecureRandom().nextBytes(iv)
+        val key = SecretKeySpec(BACKUP_AES_KEY, "AES")
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        val encrypted = cipher.doFinal(rawZip)
+        return ByteArrayOutputStream().use { output ->
+            output.write(BACKUP_MAGIC)
+            output.write(BACKUP_VERSION.toInt())
+            output.write(iv)
+            output.write(encrypted)
+            output.toByteArray()
+        }
+    }
+
+    private fun decodeBackupPayload(input: ByteArray): ByteArray {
+        if (input.size < BACKUP_MAGIC.size + 1 + GCM_IV_LENGTH) {
+            return input
+        }
+        if (!input.copyOfRange(0, BACKUP_MAGIC.size).contentEquals(BACKUP_MAGIC)) {
+            return input
+        }
+        val version = input[BACKUP_MAGIC.size]
+        require(version == BACKUP_VERSION) { "Unsupported backup version: $version" }
+        val ivStart = BACKUP_MAGIC.size + 1
+        val iv = input.copyOfRange(ivStart, ivStart + GCM_IV_LENGTH)
+        val encrypted = input.copyOfRange(ivStart + GCM_IV_LENGTH, input.size)
+        val key = SecretKeySpec(BACKUP_AES_KEY, "AES")
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(GCM_TAG_BITS, iv))
+        return cipher.doFinal(encrypted)
     }
 }


### PR DESCRIPTION
### Motivation
- 为了在现有 zip 打包基础上增加文件安全性，将导出文件改为 AES-256-GCM 加密后的二进制载荷以 `backup.dat` 形式保存。 
- 同时保证导入兼容性，能处理新的加密格式并回退支持历史未加密的 zip/json 备份。 

### Description
- 将导出流程改为先在内存中生成原有的 zip（包含 `backup.json` 和 `media/`），然后使用 AES-256-GCM 对 zip 字节进行加密并写出包含魔数/版本/IV 的载荷。 
- 在导入流程中增加对该载荷头的检测与解密逻辑：检测到自定义魔数则解密后按 zip 解析，否则保留原有直接解析 zip/json 的行为以兼容旧备份。 
- 在 UI 层更新文件选择器：导出 MIME 改为 `application/octet-stream`，默认文件名改为 `quote_backup.backup.dat`，导入时优先允许 `application/octet-stream`（仍保留 `application/zip` / `application/json`）。 
- 主要修改文件：`app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt`（加密/解密及载荷处理、流读写调整）和 `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt`（导入/导出 picker 类型与默认文件名）。 

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 来编译 Kotlin 代码以验证改动，但编译在此环境中未能完成，Gradle wrapper 下载被网络代理阻止并返回 `HTTP/1.1 403 Forbidden`，因此无法在 CI/当前环境完成构建检验。 
- 在本地代码审查及静态检查层面已验证：导出会生成带头部的加密载荷，导入函数能正确识别并在解密后交由现有 zip 解析逻辑处理；未加密的历史文件仍按原逻辑导入。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae1d22fcf8832bb876aaa3a035e38d)