### PR TITLE
Improve backup stream handling and error reporting; update export UI label

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -179,7 +179,7 @@ fun CharacterScreen(
                         )
                     }
                     if (transferState.mode == TransferMode.EXPORT && outputBytes != null) {
-                        Text("文件大小：${formatBytes(outputBytes)}")
+                        Text("已写入：${formatBytes(outputBytes)}")
                     }
                     transferState.progress?.let { progress ->
                         LinearProgressIndicator(progress = { progress }, modifier = Modifier.fillMaxWidth())

--- a/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/CharacterViewModel.kt
@@ -16,6 +16,7 @@ import java.io.ByteArrayOutputStream
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.io.InputStream
+import java.io.IOException
 import java.io.OutputStream
 import java.nio.charset.Charset
 import java.security.SecureRandom
@@ -148,7 +149,9 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
                 }
             }
             _transferState.update { it.copy(totalBytes = totalBytes) }
-            resolver.openOutputStream(uri)?.use { output ->
+            val exportOutput = resolver.openOutputStream(uri)
+                ?: throw IOException("Unable to open output stream for export uri: $uri")
+            exportOutput.use { output ->
                 val countingOutput = CountingOutputStream(output) { bytesWritten ->
                     outputBytes = bytesWritten
                     updateProgress()
@@ -283,6 +286,7 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
         const val ZIP_MAGIC_P: Byte = 0x50
         const val ZIP_MAGIC_K: Byte = 0x4B
         const val PROGRESS_UPDATE_BYTES = 256 * 1024
+        const val MAX_ZERO_READ_RETRIES = 1024
         val BACKUP_AES_KEY = "QuotePickerBackupAES256KeyMaterial!".toByteArray(Charset.forName("UTF-8")).copyOf(32)
     }
 
@@ -356,21 +360,13 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
 
     private fun readEntryBytes(zip: ZipInputStream, buffer: ByteArray): ByteArray {
         val output = ByteArrayOutputStream()
-        var read = zip.read(buffer)
-        while (read > 0) {
-            output.write(buffer, 0, read)
-            read = zip.read(buffer)
-        }
+        copyStreamChunked(zip, output, buffer) { }
         return output.toByteArray()
     }
 
     private fun readEntryToFile(zip: ZipInputStream, target: File, buffer: ByteArray) {
         target.outputStream().use { output ->
-            var read = zip.read(buffer)
-            while (read > 0) {
-                output.write(buffer, 0, read)
-                read = zip.read(buffer)
-            }
+            copyStreamChunked(zip, output, buffer) { }
         }
     }
 
@@ -382,21 +378,39 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
     private fun readStreamBytes(input: InputStream): ByteArray {
         val output = ByteArrayOutputStream()
         val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
-        var read = input.read(buffer)
-        while (read > 0) {
-            output.write(buffer, 0, read)
-            read = input.read(buffer)
-        }
+        copyStreamChunked(input, output, buffer) { }
         return output.toByteArray()
     }
 
     private fun writeStreamChunked(input: InputStream, output: OutputStream, onChunk: (Int) -> Unit) {
         val buffer = ByteArray(PROGRESS_UPDATE_BYTES)
-        var read = input.read(buffer)
-        while (read > 0) {
+        copyStreamChunked(input, output, buffer, onChunk)
+    }
+
+    private fun copyStreamChunked(
+        input: InputStream,
+        output: OutputStream,
+        buffer: ByteArray,
+        onChunk: (Int) -> Unit
+    ) {
+        var zeroReadCount = 0
+        while (true) {
+            val read = input.read(buffer)
+            if (read < 0) break
+            if (read == 0) {
+                zeroReadCount += 1
+                if (zeroReadCount >= MAX_ZERO_READ_RETRIES) {
+                    throw IOException("Input stream returned 0 bytes repeatedly")
+                }
+                val singleByte = input.read()
+                if (singleByte < 0) break
+                output.write(singleByte)
+                onChunk(1)
+                continue
+            }
+            zeroReadCount = 0
             output.write(buffer, 0, read)
             onChunk(read)
-            read = input.read(buffer)
         }
     }
 
@@ -413,11 +427,15 @@ class CharacterViewModel(app: Application) : AndroidViewModel(app) {
                 writeChunked(zip, snapshotBytes, onChunkWritten)
                 zip.closeEntry()
                 mediaSources.forEach { source ->
-                    val stream = repo.openMediaStream(source.originalPath) ?: return@forEach
+                    val stream = repo.openMediaStream(source.originalPath)
+                        ?: throw IOException("Failed to open media stream: ${source.originalPath}")
                     stream.use { input ->
                         zip.putNextEntry(ZipEntry("media/${source.fileName}"))
-                        writeStreamChunked(input, zip, onChunkWritten)
-                        zip.closeEntry()
+                        try {
+                            writeStreamChunked(input, zip, onChunkWritten)
+                        } finally {
+                            zip.closeEntry()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Motivation
- Prevent hangs and silent failures when reading/writing backup streams by handling zero-byte reads and reporting I/O errors. 
- Ensure failures opening export target or media streams surface as errors instead of being ignored. 
- Make the export dialog text clearer about what is being shown.

### Description
- Added `MAX_ZERO_READ_RETRIES` constant and `IOException` import and implemented a new `copyStreamChunked` helper to robustly copy streams while handling repeated zero-length reads and failing after a threshold. 
- Replaced ad-hoc read loops in `readEntryBytes`, `readEntryToFile`, and `readStreamBytes` with `copyStreamChunked`, and refactored `writeStreamChunked` to delegate to it. 
- Improved error handling by throwing an `IOException` if `resolver.openOutputStream(uri)` or `repo.openMediaStream(...)` returns null during export, and ensured each ZIP entry is closed in a `finally` block. 
- Updated the export dialog text in `CharacterScreen.kt` from `文件大小：` to `已写入：` to reflect written bytes rather than file size.

### Testing
- Ran unit tests with `./gradlew test` and they passed. 
- Built the debug APK with `./gradlew assembleDebug` to validate compilation and packaging and the build succeeded. 
- Ran lint via `./gradlew lint` and no new lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae23dceb94832ba594d2df04bff7c1)