### PR TITLE
Compact resource-file encoding and add MagicDrama image/video group carousel support

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -3435,7 +3435,9 @@ private fun buildMagicDramaDefaultScript(
     val roleA = characters.getOrNull(0)?.name ?: "角色A"
     val roleB = characters.getOrNull(1)?.name ?: "角色B"
     val imageSource = pickFirstImageSource(availableResources)
+    val imageGroupSource = pickFirstImageGroupSource(availableResources)
     val videoSource = pickFirstVideoSource(availableResources)
+    val videoGroupSource = pickFirstVideoGroupSource(availableResources)
 
     return buildString {
         appendLine("+旁白:魔剧自动样例开始，包含所有常用case。-1200")
@@ -3444,12 +3446,23 @@ private fun buildMagicDramaDefaultScript(
         appendLine("+$roleA:收到，我先展示图片。nn如果你看到这句说明角色台词正常。-1600")
         videoSource?.let { appendLine("+视频:$it") }
         appendLine("+$roleB:现在切到视频，准备倒计时。-1600")
+        imageGroupSource?.let { appendLine("+图片组:$it") }
+        appendLine("+$roleA:这里是图片组轮播。-1200")
+        videoGroupSource?.let { appendLine("+视频组:$it") }
+        appendLine("+$roleB:这里是视频组轮播。-1200")
         appendLine("+倒计时:5")
         appendLine("+按钮:继续%go-结束%end")
         appendLine("+%go:旁白:你选择了继续分支。-1000")
         appendLine("+%go:$roleA:继续剧情测试通过。-1200")
         appendLine("+%end:旁白:你选择了结束分支，魔剧测试完成。-1000")
     }.trim()
+}
+
+private fun pickFirstImageGroupSource(resources: List<ResourceWithTagsCharacters>): String? {
+    val imageResource = resources.firstOrNull { it.resource.type == ResourceType.IMAGE }?.resource ?: return null
+    val sources = parseImageItems(imageResource.contentUriOrPath, imageResource.quoteImageBase64)
+        .mapNotNull { it.path ?: it.base64 }
+    return sources.firstOrNull()
 }
 
 private fun pickFirstImageSource(resources: List<ResourceWithTagsCharacters>): String? {
@@ -3460,6 +3473,11 @@ private fun pickFirstImageSource(resources: List<ResourceWithTagsCharacters>): S
 }
 
 private fun pickFirstVideoSource(resources: List<ResourceWithTagsCharacters>): String? {
+    val videoPayload = resources.firstOrNull { it.resource.type == ResourceType.VIDEO }?.resource?.contentUriOrPath
+    return parseVideoItems(videoPayload).firstOrNull()?.path
+}
+
+private fun pickFirstVideoGroupSource(resources: List<ResourceWithTagsCharacters>): String? {
     val videoPayload = resources.firstOrNull { it.resource.type == ResourceType.VIDEO }?.resource?.contentUriOrPath
     return parseVideoItems(videoPayload).firstOrNull()?.path
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.example.quotepicker.data.CharacterEntity
+import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
@@ -70,6 +71,8 @@ private sealed interface DramaCommand {
     data class RoleLine(val roleKey: String, val text: String, val delayMs: Long) : DramaCommand
     data class ShowVideo(val source: String) : DramaCommand
     data class ShowImage(val source: String) : DramaCommand
+    data class ShowImageGroup(val source: String) : DramaCommand
+    data class ShowVideoGroup(val source: String) : DramaCommand
     data class ShowButtons(val options: List<DramaButtonOption>) : DramaCommand
     data class Countdown(val seconds: Int) : DramaCommand
 }
@@ -84,6 +87,8 @@ private sealed interface DramaMessage {
 private sealed interface DramaMedia {
     data class Image(val source: String) : DramaMedia
     data class Video(val source: String) : DramaMedia
+    data class ImageGroup(val source: String) : DramaMedia
+    data class VideoGroup(val source: String) : DramaMedia
 }
 
 @Composable
@@ -160,6 +165,8 @@ fun MagicDramaScreen(
                 }
                 is DramaCommand.ShowImage -> currentMedia = DramaMedia.Image(cmd.source)
                 is DramaCommand.ShowVideo -> currentMedia = DramaMedia.Video(cmd.source)
+                is DramaCommand.ShowImageGroup -> currentMedia = DramaMedia.ImageGroup(cmd.source)
+                is DramaCommand.ShowVideoGroup -> currentMedia = DramaMedia.VideoGroup(cmd.source)
                 is DramaCommand.Countdown -> {
                     countdownJob?.cancel()
                     countdownJob = coroutineScope.launch {
@@ -271,26 +278,7 @@ private suspend fun launchCountdown(total: Int, onTick: (Int?) -> Unit) {
 }
 
 @Composable
-private fun DramaMediaArea(media: DramaMedia?, vm: ResourceViewModel) {
-    when (media) {
-        is DramaMedia.Image -> {
-            val bitmap = remember(media.source) { decodeImageSource(media.source, vm) }
-            if (bitmap != null) {
-                androidx.compose.foundation.Image(
-                    bitmap = bitmap.asImageBitmap(),
-                    contentDescription = "资源图片",
-                    modifier = Modifier.fillMaxSize(),
-                    contentScale = ContentScale.Fit
-                )
-            }
-        }
-        is DramaMedia.Video -> LoopVideo(uri = Uri.parse(media.source))
-        null -> Box(modifier = Modifier.fillMaxSize())
-    }
-}
-
-@Composable
-private fun LoopVideo(uri: Uri) {
+private fun LoopVideo(uri: Uri, onCompleted: (() -> Unit)? = null) {
     val holder = remember { mutableStateOf<VideoView?>(null) }
     DisposableEffect(Unit) {
         onDispose { holder.value?.stopPlayback() }
@@ -300,7 +288,9 @@ private fun LoopVideo(uri: Uri) {
             VideoView(context).apply {
                 setVideoURI(uri)
                 setOnPreparedListener { it.start() }
-                setOnCompletionListener { it.start() }
+                setOnCompletionListener {
+                    if (onCompleted != null) onCompleted() else it.start()
+                }
                 holder.value = this
             }
         },
@@ -395,6 +385,8 @@ private fun parseDramaCommand(raw: String): DramaCommand? {
         }
         key in setOf("视频", "视频切换", "切换视频") -> DramaCommand.ShowVideo(value)
         key in setOf("图片", "图片切换", "切换图片") -> DramaCommand.ShowImage(value)
+        key in setOf("图片组", "轮播图片") -> DramaCommand.ShowImageGroup(value)
+        key in setOf("视频组", "轮播视频") -> DramaCommand.ShowVideoGroup(value)
         key == "按钮" -> {
             val options = value.split("-")
                 .mapNotNull { item ->
@@ -445,4 +437,72 @@ private fun decodeImageSource(source: String, vm: ResourceViewModel): android.gr
     }
     val uri = Uri.parse(trimmed)
     return if (uri.scheme != null) vm.decodeUriToBitmap(uri) else vm.decodeBase64ToBitmap(trimmed)
+}
+
+@Composable
+private fun DramaMediaArea(media: DramaMedia?, vm: ResourceViewModel) {
+    when (media) {
+        is DramaMedia.Image -> {
+            val bitmap = remember(media.source) { decodeImageSource(media.source, vm) }
+            if (bitmap != null) {
+                androidx.compose.foundation.Image(
+                    bitmap = bitmap.asImageBitmap(),
+                    contentDescription = "资源图片",
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Fit
+                )
+            }
+        }
+        is DramaMedia.Video -> LoopVideo(uri = Uri.parse(media.source))
+        is DramaMedia.ImageGroup -> ImageCarousel(source = media.source, vm = vm)
+        is DramaMedia.VideoGroup -> VideoCarousel(source = media.source, vm = vm)
+        null -> Box(modifier = Modifier.fillMaxSize())
+    }
+}
+
+@Composable
+private fun ImageCarousel(source: String, vm: ResourceViewModel) {
+    val imageSources = remember(source, vm.allResources.value) {
+        parseMediaGroupSource(source, ResourceType.IMAGE, vm)
+    }
+    var index by remember(source) { mutableStateOf(0) }
+    val current = imageSources.getOrNull(index)
+    LaunchedEffect(imageSources) { index = 0 }
+    LaunchedEffect(imageSources, index) {
+        if (imageSources.size > 1) {
+            delay(2500)
+            index = (index + 1) % imageSources.size
+        }
+    }
+    val bitmap = remember(current) { current?.let { decodeImageSource(it, vm) } }
+    if (bitmap != null) {
+        androidx.compose.foundation.Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = "资源图片组",
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Fit
+        )
+    }
+}
+
+@Composable
+private fun VideoCarousel(source: String, vm: ResourceViewModel) {
+    val videoSources = remember(source, vm.allResources.value) {
+        parseMediaGroupSource(source, ResourceType.VIDEO, vm)
+    }
+    var index by remember(source) { mutableStateOf(0) }
+    val current = videoSources.getOrNull(index)
+    LaunchedEffect(videoSources) { index = 0 }
+    LoopVideo(
+        uri = Uri.parse(current.orEmpty()),
+        onCompleted = {
+            if (videoSources.size > 1) {
+                index = (index + 1) % videoSources.size
+            }
+        }
+    )
+}
+
+private fun parseMediaGroupSource(source: String, type: ResourceType, vm: ResourceViewModel): List<String> {
+    return vm.resolveMediaGroupSources(type, source)
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
@@ -9,14 +9,39 @@ data class ResourceFileInfo(
 )
 
 fun encodeResourceFileInfo(type: ResourceType, uri: Uri): String {
+    val typeCode = when (type) {
+        ResourceType.IMAGE -> "i"
+        ResourceType.VIDEO -> "v"
+        ResourceType.SOUND -> "s"
+        ResourceType.TEXT -> "t"
+        ResourceType.SCENE -> "c"
+    }
     val encodedUri = Uri.encode(uri.toString())
-    return "type=${type.name};uri=$encodedUri"
+    return "$typeCode,$encodedUri"
 }
 
 fun decodeResourceFileInfo(raw: String): ResourceFileInfo? {
     val trimmed = raw.trim()
-    val match = Regex("type=([A-Z]+);uri=(.+)").find(trimmed) ?: return null
-    val type = runCatching { ResourceType.valueOf(match.groupValues[1]) }.getOrNull() ?: return null
-    val uriValue = Uri.decode(match.groupValues[2])
+    val compact = Regex("^([ivstc]),(.+)$").find(trimmed)
+    val legacy = Regex("type=([A-Z]+);uri=(.+)").find(trimmed)
+    val (type, encodedValue) = when {
+        compact != null -> {
+            val mappedType = when (compact.groupValues[1]) {
+                "i" -> ResourceType.IMAGE
+                "v" -> ResourceType.VIDEO
+                "s" -> ResourceType.SOUND
+                "t" -> ResourceType.TEXT
+                "c" -> ResourceType.SCENE
+                else -> null
+            } ?: return null
+            mappedType to compact.groupValues[2]
+        }
+        legacy != null -> {
+            val legacyType = runCatching { ResourceType.valueOf(legacy.groupValues[1]) }.getOrNull() ?: return null
+            legacyType to legacy.groupValues[2]
+        }
+        else -> return null
+    }
+    val uriValue = Uri.decode(encodedValue)
     return ResourceFileInfo(type = type, uri = Uri.parse(uriValue))
 }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import org.json.JSONArray
+import org.json.JSONObject
 
 data class ResourceFilterState(
     val selectedType: ResourceType? = null,
@@ -150,6 +152,60 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
 
     fun updateMarkStateFilter(state: ResourceMarkState?) {
         filters.value = filters.value.copy(selectedMarkState = state)
+    }
+
+    fun resolveMediaGroupSources(type: ResourceType, source: String): List<String> {
+        val candidate = source.trim()
+        if (candidate.isBlank()) return emptyList()
+        val resources = allResources.value.map { it.resource }
+        resources.firstOrNull { resource ->
+            resource.type == type && extractResourceMediaSources(resource).any { it == candidate }
+        }?.let { matched ->
+            val items = extractResourceMediaSources(matched)
+            if (items.isNotEmpty()) return items
+        }
+        return listOf(candidate)
+    }
+
+    private fun extractResourceMediaSources(resource: ResourceEntity): List<String> {
+        return when (resource.type) {
+            ResourceType.IMAGE -> parseImageSourceList(resource.contentUriOrPath, resource.quoteImageBase64)
+            ResourceType.VIDEO, ResourceType.SOUND -> parseSimplePathList(resource.contentUriOrPath)
+            else -> emptyList()
+        }
+    }
+
+    private fun parseSimplePathList(raw: String?): List<String> {
+        if (raw.isNullOrBlank()) return emptyList()
+        val trimmed = raw.trim()
+        if (!trimmed.startsWith("[")) return listOf(trimmed)
+        return runCatching {
+            val array = JSONArray(trimmed)
+            List(array.length()) { idx -> array.optString(idx) }.filter { it.isNotBlank() }
+        }.getOrElse { listOf(trimmed) }
+    }
+
+    private fun parseImageSourceList(pathPayload: String?, base64Payload: String?): List<String> {
+        val payload = pathPayload?.takeIf { it.isNotBlank() } ?: base64Payload
+        if (payload.isNullOrBlank()) return emptyList()
+        val trimmed = payload.trim()
+        return when {
+            trimmed.startsWith("[") -> runCatching {
+                val array = JSONArray(trimmed)
+                buildList {
+                    for (i in 0 until array.length()) {
+                        when (val entry = array.get(i)) {
+                            is JSONObject -> entry.optString("image").takeIf { it.isNotBlank() }?.let(::add)
+                            else -> entry.toString().takeIf { it.isNotBlank() }?.let(::add)
+                        }
+                    }
+                }
+            }.getOrElse { listOf(payload) }
+            trimmed.startsWith("{") -> runCatching {
+                JSONObject(trimmed).optString("image").takeIf { it.isNotBlank() }?.let(::listOf) ?: emptyList()
+            }.getOrElse { listOf(payload) }
+            else -> listOf(payload)
+        }
     }
 
     fun moveResourceToGroup(resource: ResourceEntity, newTitle: String, newCreatedAt: Long) =


### PR DESCRIPTION
### Motivation
- Reduce verbosity when copying resource file info while keeping existing scripts working by introducing a compact encoding for resource references.
- Support richer MagicDrama scenarios by adding image-group and video-group directives that can display an entire resource’s media as a carousel.
- Make the group carousel usable from a single file reference by resolving the referenced file back to its owning resource and expanding the resource’s media list.

### Description
- Replace verbose file-info encoding with a compact form `"<typeCode>,<uri>"` where type codes are `i/v/s/t/c` for image/video/sound/text/scene, and maintain backward-compatibility by still parsing the legacy `type=...;uri=...` format in `encodeResourceFileInfo`/`decodeResourceFileInfo` in `ResourceFileInfo.kt`.
- Add new drama commands `ShowImageGroup` / `ShowVideoGroup` and new media states `ImageGroup` / `VideoGroup`, and parse the keywords `图片组`/`轮播图片` and `视频组`/`轮播视频` in `MagicDramaScreen.kt`.
- Implement carousel UI: `ImageCarousel` cycles images on a timed interval and `VideoCarousel` advances on playback completion (via `LoopVideo` updated with an optional `onCompleted` callback) in `MagicDramaScreen.kt`.
- Add `resolveMediaGroupSources` and supporting parsers in `ResourceViewModel.kt` to allow a single provided path to be looked up against resources and expand into the full list of media for that resource.
- Wire the new group directives into the default automated MagicDrama sample by adding `+图片组:` and `+视频组:` examples and helper pickers (`pickFirstImageGroupSource`, `pickFirstVideoGroupSource`) in `ResourceScreen.kt`.

### Testing
- Attempted compile with `./gradlew :app:compileDebugKotlin`, but Gradle distribution download failed due to the environment proxy returning `HTTP 403 Forbidden`, so a full local build could not be completed.
- Ran static/runtime checks including `rg` searches, file prints (`sed`), `git status`, and `git diff` to verify the changesets and references, which succeeded.  
- Verified code was updated and committed; runtime behavior should be validated by running the app (build environment permitting) to test `图片组`/`视频组` rendering and legacy/compact file-info parsing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae33c06120832b9d8e9b546128ba50)