### PR TITLE
简化资源文件引用格式，兼容特殊文本/魔剧粘贴与自动填充

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -3460,26 +3460,32 @@ private fun buildMagicDramaDefaultScript(
 
 private fun pickFirstImageGroupSource(resources: List<ResourceWithTagsCharacters>): String? {
     val imageResource = resources.firstOrNull { it.resource.type == ResourceType.IMAGE }?.resource ?: return null
-    val sources = parseImageItems(imageResource.contentUriOrPath, imageResource.quoteImageBase64)
-        .mapNotNull { it.path ?: it.base64 }
-    return sources.firstOrNull()
+    val source = parseImageItems(imageResource.contentUriOrPath, imageResource.quoteImageBase64)
+        .mapNotNull { it.path }
+        .firstOrNull()
+        ?: return null
+    return encodeResourceFileInfo(ResourceType.IMAGE, Uri.parse(source), imageResource.id)
 }
 
 private fun pickFirstImageSource(resources: List<ResourceWithTagsCharacters>): String? {
-    val imageResource = resources.firstOrNull { it.resource.type == ResourceType.IMAGE }?.resource
-    return parseImageItems(imageResource?.contentUriOrPath, imageResource?.quoteImageBase64)
+    val imageResource = resources.firstOrNull { it.resource.type == ResourceType.IMAGE }?.resource ?: return null
+    val source = parseImageItems(imageResource.contentUriOrPath, imageResource.quoteImageBase64)
+        .mapNotNull { it.path }
         .firstOrNull()
-        ?.let { it.path ?: it.base64 }
+        ?: return null
+    return encodeResourceFileInfo(ResourceType.IMAGE, Uri.parse(source), imageResource.id)
 }
 
 private fun pickFirstVideoSource(resources: List<ResourceWithTagsCharacters>): String? {
-    val videoPayload = resources.firstOrNull { it.resource.type == ResourceType.VIDEO }?.resource?.contentUriOrPath
-    return parseVideoItems(videoPayload).firstOrNull()?.path
+    val videoResource = resources.firstOrNull { it.resource.type == ResourceType.VIDEO }?.resource ?: return null
+    val source = parseVideoItems(videoResource.contentUriOrPath).firstOrNull()?.path ?: return null
+    return encodeResourceFileInfo(ResourceType.VIDEO, Uri.parse(source), videoResource.id)
 }
 
 private fun pickFirstVideoGroupSource(resources: List<ResourceWithTagsCharacters>): String? {
-    val videoPayload = resources.firstOrNull { it.resource.type == ResourceType.VIDEO }?.resource?.contentUriOrPath
-    return parseVideoItems(videoPayload).firstOrNull()?.path
+    val videoResource = resources.firstOrNull { it.resource.type == ResourceType.VIDEO }?.resource ?: return null
+    val source = parseVideoItems(videoResource.contentUriOrPath).firstOrNull()?.path ?: return null
+    return encodeResourceFileInfo(ResourceType.VIDEO, Uri.parse(source), videoResource.id)
 }
 
 private fun parseSceneMessages(raw: String?): List<SceneMessageDraft> {

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -435,6 +435,12 @@ private fun decodeImageSource(source: String, vm: ResourceViewModel): android.gr
             (0 until arr.length()).firstNotNullOfOrNull { idx -> decodeImageSource(arr.get(idx).toString(), vm) }
         }.getOrNull()
     }
+    decodeResourceFileInfo(trimmed)?.let { ref ->
+        if (ref.type == ResourceType.IMAGE) {
+            val uri = vm.resolveMediaUri(ResourceType.IMAGE, ref.name, ref.resourceId)
+            if (uri != null) return vm.decodeUriToBitmap(uri)
+        }
+    }
     val uri = Uri.parse(trimmed)
     return if (uri.scheme != null) vm.decodeUriToBitmap(uri) else vm.decodeBase64ToBitmap(trimmed)
 }
@@ -453,7 +459,14 @@ private fun DramaMediaArea(media: DramaMedia?, vm: ResourceViewModel) {
                 )
             }
         }
-        is DramaMedia.Video -> LoopVideo(uri = Uri.parse(media.source))
+        is DramaMedia.Video -> {
+            val resolved = remember(media.source, vm.allResources.value) {
+                decodeResourceFileInfo(media.source)?.takeIf { it.type == ResourceType.VIDEO }
+                    ?.let { vm.resolveMediaUri(ResourceType.VIDEO, it.name, it.resourceId) }
+                    ?: Uri.parse(media.source)
+            }
+            LoopVideo(uri = resolved)
+        }
         is DramaMedia.ImageGroup -> ImageCarousel(source = media.source, vm = vm)
         is DramaMedia.VideoGroup -> VideoCarousel(source = media.source, vm = vm)
         null -> Box(modifier = Modifier.fillMaxSize())

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
@@ -5,10 +5,11 @@ import com.example.quotepicker.data.ResourceType
 
 data class ResourceFileInfo(
     val type: ResourceType,
-    val uri: Uri
+    val name: String,
+    val resourceId: Long? = null
 )
 
-fun encodeResourceFileInfo(type: ResourceType, uri: Uri): String {
+fun encodeResourceFileInfo(type: ResourceType, uri: Uri, resourceId: Long? = null): String {
     val typeCode = when (type) {
         ResourceType.IMAGE -> "i"
         ResourceType.VIDEO -> "v"
@@ -17,15 +18,18 @@ fun encodeResourceFileInfo(type: ResourceType, uri: Uri): String {
         ResourceType.SCENE -> "c"
         else -> {""}
     }
-    val encodedUri = Uri.encode(uri.toString())
-    return "$typeCode,$encodedUri"
+    val displayName = uri.lastPathSegment?.takeIf { it.isNotBlank() }
+        ?: uri.path?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
+        ?: uri.toString()
+    val encodedName = Uri.encode(displayName)
+    return if (resourceId != null) "$typeCode,$encodedName,$resourceId" else "$typeCode,$encodedName"
 }
 
 fun decodeResourceFileInfo(raw: String): ResourceFileInfo? {
     val trimmed = raw.trim()
-    val compact = Regex("^([ivstc]),(.+)$").find(trimmed)
+    val compact = Regex("^([ivstc]),([^,]+?)(?:,(\\d+))?$").find(trimmed)
     val legacy = Regex("type=([A-Z]+);uri=(.+)").find(trimmed)
-    val (type, encodedValue) = when {
+    val (type, encodedValue, resourceId) = when {
         compact != null -> {
             val mappedType = when (compact.groupValues[1]) {
                 "i" -> ResourceType.IMAGE
@@ -35,14 +39,18 @@ fun decodeResourceFileInfo(raw: String): ResourceFileInfo? {
                 "c" -> ResourceType.SCENE
                 else -> null
             } ?: return null
-            mappedType to compact.groupValues[2]
+            Triple(mappedType, compact.groupValues[2], compact.groupValues.getOrNull(3)?.toLongOrNull())
         }
         legacy != null -> {
             val legacyType = runCatching { ResourceType.valueOf(legacy.groupValues[1]) }.getOrNull() ?: return null
-            legacyType to legacy.groupValues[2]
+            val uri = Uri.parse(Uri.decode(legacy.groupValues[2]))
+            val name = uri.lastPathSegment?.takeIf { it.isNotBlank() }
+                ?: uri.path?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
+                ?: uri.toString()
+            Triple(legacyType, Uri.encode(name), null)
         }
         else -> return null
     }
-    val uriValue = Uri.decode(encodedValue)
-    return ResourceFileInfo(type = type, uri = Uri.parse(uriValue))
+    val nameValue = Uri.decode(encodedValue)
+    return ResourceFileInfo(type = type, name = nameValue, resourceId = resourceId)
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -730,6 +730,9 @@ private fun InlineFilePreview(
     vm: ResourceViewModel,
     modifier: Modifier = Modifier
 ) {
+    val resolvedUri = remember(info, vm.allResources.value) {
+        vm.resolveMediaUri(info.type, info.name, info.resourceId)
+    }
     Card(modifier = modifier.fillMaxWidth()) {
         Box(
             modifier = Modifier
@@ -737,10 +740,14 @@ private fun InlineFilePreview(
                 .heightIn(min = 220.dp, max = 360.dp)
                 .padding(12.dp)
         ) {
+            if (resolvedUri == null) {
+                Text("未找到文件：${info.name}")
+                return@Box
+            }
             when (info.type) {
                 ResourceType.IMAGE -> {
-                    val preview by androidx.compose.runtime.produceState<android.graphics.Bitmap?>(initialValue = null, info.uri) {
-                        value = vm.decodeUriToBitmap(info.uri)
+                    val preview by androidx.compose.runtime.produceState<android.graphics.Bitmap?>(initialValue = null, resolvedUri) {
+                        value = vm.decodeUriToBitmap(resolvedUri)
                     }
                     if (preview != null) {
                         Image(
@@ -755,12 +762,12 @@ private fun InlineFilePreview(
                 }
                 ResourceType.VIDEO -> {
                     MediaPreview(
-                        uri = info.uri,
+                        uri = resolvedUri,
                         modifier = Modifier.height(280.dp)
                     )
                 }
                 ResourceType.SOUND -> {
-                    AudioPreviewSingle(uri = info.uri)
+                    AudioPreviewSingle(uri = resolvedUri)
                 }
                 else -> Text("暂不支持的文件类型")
             }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -153,11 +153,48 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     fun updateMarkStateFilter(state: ResourceMarkState?) {
         filters.value = filters.value.copy(selectedMarkState = state)
     }
+    fun resolveMediaUri(type: ResourceType, name: String, resourceId: Long? = null): Uri? {
+        val targetName = name.trim()
+        if (targetName.isBlank()) return null
+        val resources = allResources.value.map { it.resource }
+            .filter { it.type == type }
+            .filter { resourceId == null || it.id == resourceId }
+        resources.forEach { resource ->
+            val matched = extractResourceMediaSources(resource).firstOrNull { source ->
+                val uri = Uri.parse(source)
+                val candidateName = uri.lastPathSegment?.takeIf { it.isNotBlank() }
+                    ?: uri.path?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
+                candidateName == targetName
+            }
+            if (matched != null) return Uri.parse(matched)
+        }
+        return runCatching { Uri.parse(targetName) }.getOrNull()?.takeIf { it.scheme != null }
+    }
 
     fun resolveMediaGroupSources(type: ResourceType, source: String): List<String> {
         val candidate = source.trim()
         if (candidate.isBlank()) return emptyList()
         val resources = allResources.value.map { it.resource }
+
+        parseCompactMediaRef(candidate)?.let { ref ->
+            if (ref.type == type) {
+                val matchedByRef = resources.firstOrNull { resource ->
+                    resource.type == type && (ref.resourceId == null || resource.id == ref.resourceId)
+                }
+                if (matchedByRef != null) {
+                    val items = extractResourceMediaSources(matchedByRef)
+                    if (ref.resourceId != null) return items
+                    val single = items.firstOrNull { path ->
+                        val uri = Uri.parse(path)
+                        val pathName = uri.lastPathSegment?.takeIf { it.isNotBlank() }
+                            ?: uri.path?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
+                        pathName == ref.name
+                    }
+                    if (single != null) return listOf(single)
+                }
+            }
+        }
+
         resources.firstOrNull { resource ->
             resource.type == type && extractResourceMediaSources(resource).any { it == candidate }
         }?.let { matched ->
@@ -165,6 +202,23 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             if (items.isNotEmpty()) return items
         }
         return listOf(candidate)
+    }
+
+    private data class CompactMediaRef(val type: ResourceType, val name: String, val resourceId: Long?)
+
+    private fun parseCompactMediaRef(raw: String): CompactMediaRef? {
+        val match = Regex("^([ivstc]),([^,]+?)(?:,(\\d+))?$").find(raw.trim()) ?: return null
+        val type = when (match.groupValues[1]) {
+            "i" -> ResourceType.IMAGE
+            "v" -> ResourceType.VIDEO
+            "s" -> ResourceType.SOUND
+            "t" -> ResourceType.TEXT
+            "c" -> ResourceType.SCENE
+            else -> return null
+        }
+        val name = Uri.decode(match.groupValues[2])
+        val resourceId = match.groupValues.getOrNull(3)?.toLongOrNull()
+        return CompactMediaRef(type = type, name = name, resourceId = resourceId)
     }
 
     private fun extractResourceMediaSources(resource: ResourceEntity): List<String> {


### PR DESCRIPTION
### Motivation
- 让“复制文件信息”变得更简洁，只保留必要的标识（`type + name`，必要时带 `resourceId`），避免携带完整 URI/path。
- 保证用户把复制的紧凑引用粘贴到“特殊文本/魔剧/预览”里仍能被识别并正确展示或播放。
- 使魔剧自动填充输出使用紧凑引用以便更短、更易读且能通过 id 稳定定位资源。

### Description
- 将资源文件引用编码从包含完整 URI 改为紧凑格式 `type,name[,resourceId]`，实现于 `ResourceFileInfo.kt`（新增 `name` 与可选 `resourceId`，并调整 `encodeResourceFileInfo`/`decodeResourceFileInfo`）。
- 在预览中改为先基于 `type+name(+id)` 反查真实 URI（`ResourceViewModel.resolveMediaUri`），再进行图片/视频/音频展示，修改点在 `ResourcePreviewScreen.kt` 与 `ResourceViewModel.kt`。
- 魔剧相关解析中添加对紧凑引用的支持：`MagicDramaScreen.kt` 中对图片/视频指令先解析紧凑引用再回查真实 URI，视频播放处也支持通过紧凑引用定位。
- 将魔剧默认测试脚本自动填充改为输出紧凑引用并携带 `resourceId`（修改 `ResourceScreen.kt` 中用于生成默认脚本的资源选择函数）。
- 增强媒体组解析以支持紧凑引用（可通过 `resourceId` 精确定位资源组），新增 `parseCompactMediaRef` 辅助解析函数在 `ResourceViewModel.kt`。

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 以编译变更，执行失败因为当前环境下载 Gradle 发行包被代理阻断返回 HTTP 403，未能完成编译。
- 已在本地修改并提交变更（git 提交成功），变更文件包括 `ResourceFileInfo.kt`、`ResourceViewModel.kt`、`ResourcePreviewScreen.kt`、`MagicDramaScreen.kt`、`ResourceScreen.kt`。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae3e6ac9d8832baee250c5c1bcf9af)