### PR TITLE
feat: add external storage permission flow for StoragePaths

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
+
     <application
         android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"

--- a/app/src/main/java/com/example/quotepicker/MainActivity.kt
+++ b/app/src/main/java/com/example/quotepicker/MainActivity.kt
@@ -1,15 +1,36 @@
 package com.example.quotepicker
 
+import android.Manifest
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.Environment
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.material3.Surface
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import com.example.quotepicker.ui.GateScreen
 import com.example.quotepicker.ui.MainScreen
 
@@ -19,13 +40,97 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             Surface(color = MaterialTheme.colorScheme.background) {
-                var passed by remember { mutableStateOf(false) }
-                if (passed) {
-                    MainScreen()
+                var hasStoragePermission by remember { mutableStateOf(checkStoragePermission()) }
+                if (!hasStoragePermission) {
+                    StoragePermissionScreen(onPermissionChanged = {
+                        hasStoragePermission = checkStoragePermission()
+                    })
                 } else {
-                    GateScreen(onPassed = { passed = true })
+                    var passed by remember { mutableStateOf(false) }
+                    if (passed) {
+                        MainScreen()
+                    } else {
+                        GateScreen(onPassed = { passed = true })
+                    }
                 }
             }
+        }
+    }
+
+    private fun checkStoragePermission(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Environment.isExternalStorageManager()
+        } else {
+            val readGranted = ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.READ_EXTERNAL_STORAGE
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+            val writeGranted = ContextCompat.checkSelfPermission(
+                this,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE
+            ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+            readGranted && writeGranted
+        }
+    }
+}
+
+@androidx.compose.runtime.Composable
+private fun StoragePermissionScreen(
+    onPermissionChanged: () -> Unit
+) {
+    val context = LocalContext.current
+
+    val runtimePermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions()
+    ) {
+        onPermissionChanged()
+    }
+    val allFilesAccessLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.StartActivityForResult()
+    ) {
+        onPermissionChanged()
+    }
+
+    LaunchedEffect(Unit) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            runtimePermissionLauncher.launch(
+                arrayOf(
+                    Manifest.permission.READ_EXTERNAL_STORAGE,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE
+                )
+            )
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = "需要存储权限才能访问 StoragePaths 目录，请授权后继续。",
+            textAlign = TextAlign.Center
+        )
+        Button(
+            modifier = Modifier.padding(top = 16.dp),
+            onClick = {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                    val packageUri = Uri.parse("package:${context.packageName}")
+                    val intent = Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION, packageUri)
+                    allFilesAccessLauncher.launch(intent)
+                } else {
+                    runtimePermissionLauncher.launch(
+                        arrayOf(
+                            Manifest.permission.READ_EXTERNAL_STORAGE,
+                            Manifest.permission.WRITE_EXTERNAL_STORAGE
+                        )
+                    )
+                }
+            }
+        ) {
+            Text("去授权")
         }
     }
 }


### PR DESCRIPTION
### Motivation
- `StoragePaths` accesses the device external storage and can fail without proper permissions, so the app must declare and request the required permissions and avoid entering flows that use `StoragePaths` before authorization is granted.

### Description
- Added `MANAGE_EXTERNAL_STORAGE` and legacy `READ_EXTERNAL_STORAGE`/`WRITE_EXTERNAL_STORAGE` declarations to `app/src/main/AndroidManifest.xml` to cover modern and older Android versions.
- Implemented a runtime permission gate in `app/src/main/java/com/example/quotepicker/MainActivity.kt` including a `checkStoragePermission()` helper that uses `Environment.isExternalStorageManager()` for Android R+ and runtime READ/WRITE checks for pre-R devices.
- Added a `StoragePermissionScreen` composable that launches either `ActivityResultContracts.RequestMultiplePermissions()` for legacy runtime permissions or `ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION` for all-files access, and updates the UI when permission state changes.
- The app now blocks entering the main `GateScreen`/`MainScreen` flow until storage permission state is satisfied to prevent unauthorized `StoragePaths` access.

### Testing
- Attempted to run `./gradlew :app:compileDebugKotlin` to compile the app, but the Gradle wrapper download was blocked by the environment proxy and the build failed with `HTTP/1.1 403 Forbidden`, so compilation could not be verified.
- Ran quick file inspections (`rg`/`sed`) to confirm the modifications to `app/src/main/AndroidManifest.xml` and `app/src/main/java/com/example/quotepicker/MainActivity.kt`, which showed the intended changes were applied successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae762b6f58832b8286fc55dd510aae)