### PR TITLE
Fix restored resource codes and show single-item preview counters

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -80,7 +80,7 @@ class Repository private constructor(context: Context) {
     suspend fun replaceSnapshot(snapshot: BackupSnapshot, mediaPayloads: Map<String, MediaPayload> = emptyMap()) {
         clearManagedMediaDirectories()
         val mediaMapping = restoreMedia(snapshot.media, mediaPayloads)
-        val restoredResources = snapshot.resources.map { resource ->
+        val restoredResources = assignMissingResourceCodes(snapshot.resources.map { resource ->
             val patched = when (resource.type) {
                 ResourceType.IMAGE,
                 ResourceType.VIDEO,
@@ -92,8 +92,8 @@ class Repository private constructor(context: Context) {
                 )
                 else -> resource
             }
-            ensureResourceCode(patched)
-        }
+            patched
+        })
         responseRecordDao.deleteAll()
         executionSettingsDao.deleteAll()
         executionResourceDao.deleteAll()
@@ -267,15 +267,42 @@ class Repository private constructor(context: Context) {
         return resource.copy(resourceCode = nextReusableResourceCode(resource.type))
     }
 
-    private suspend fun nextReusableResourceCode(type: ResourceType): String {
-        val prefix = when (type) {
-            ResourceType.IMAGE -> "i"
-            ResourceType.VIDEO -> "v"
-            ResourceType.SOUND -> "s"
-            ResourceType.TEXT -> "t"
-            ResourceType.SCENE -> "c"
-            ResourceType.FLOW -> "f"
+    private fun assignMissingResourceCodes(resources: List<ResourceEntity>): List<ResourceEntity> {
+        if (resources.isEmpty()) return resources
+        val usedByType = ResourceType.entries.associateWith { mutableSetOf<Int>() }.toMutableMap()
+        resources.forEach { resource ->
+            parseResourceCodeIndex(resource.resourceCode, resource.type)?.let { usedByType[resource.type]?.add(it) }
         }
+        return resources.map { resource ->
+            if (!resource.resourceCode.isNullOrBlank()) {
+                resource
+            } else {
+                val used = usedByType.getValue(resource.type)
+                var candidate = 1
+                while (used.contains(candidate)) candidate++
+                used.add(candidate)
+                resource.copy(resourceCode = resourceCodePrefix(resource.type) + candidate.toString().padStart(4, '0'))
+            }
+        }
+    }
+
+    private fun parseResourceCodeIndex(code: String?, type: ResourceType): Int? {
+        if (code.isNullOrBlank()) return null
+        val prefix = resourceCodePrefix(type)
+        return if (code.startsWith(prefix)) code.removePrefix(prefix).toIntOrNull() else null
+    }
+
+    private fun resourceCodePrefix(type: ResourceType): String = when (type) {
+        ResourceType.IMAGE -> "i"
+        ResourceType.VIDEO -> "v"
+        ResourceType.SOUND -> "s"
+        ResourceType.TEXT -> "t"
+        ResourceType.SCENE -> "c"
+        ResourceType.FLOW -> "f"
+    }
+
+    private suspend fun nextReusableResourceCode(type: ResourceType): String {
+        val prefix = resourceCodePrefix(type)
         val used = resourceDao.listCodesByType(type).mapNotNull { code ->
             if (code.startsWith(prefix)) code.removePrefix(prefix).toIntOrNull() else null
         }.toSet()

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -550,12 +550,10 @@ private fun MediaPreviewPager(uris: List<Uri>) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(modifier = Modifier.weight(1f)) {
-                if (uris.size > 1) {
-                    Text(
-                        text = "视频 ${pagerState.currentPage + 1}/${uris.size}",
-                        style = MaterialTheme.typography.labelSmall
-                    )
-                }
+                Text(
+                    text = "视频 ${pagerState.currentPage + 1}/${uris.size}",
+                    style = MaterialTheme.typography.labelSmall
+                )
             }
             TextButton(onClick = { fullScreenUri = uris[pagerState.currentPage] }) {
                 Text("全屏播放")
@@ -1037,6 +1035,10 @@ private fun QuoteImagePager(images: List<ImagePreviewItem>) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable { fullScreenImage = item.bitmap }
+            )
+            Text(
+                text = "1/1 ${item.resourceCode.orEmpty()} (${item.sizeMbText})",
+                style = MaterialTheme.typography.labelSmall
             )
             if (item.motionVideoUri != null) {
                 TextButton(onClick = { fullScreenVideo = item.motionVideoUri }) {


### PR DESCRIPTION
### Motivation
- Restoring a snapshot that contained resources without `resourceCode` produced duplicate fallback codes (e.g. `i0001`/`v0001`) because codes were assigned per-resource against the database instead of being allocated deterministically for the whole restore batch. 
- When previewing media with a single item the UI hid the pager/metadata, but it should always show a `1/1 <code> (size)` style label for clarity.

### Description
- During restore `replaceSnapshot` now runs `assignMissingResourceCodes` to allocate missing `resourceCode` values deterministically in-memory per `ResourceType`, avoiding duplicate codes; new helpers `assignMissingResourceCodes`, `parseResourceCodeIndex`, and `resourceCodePrefix` were added to `Repository.kt`.
- `nextReusableResourceCode` was refactored to use the shared `resourceCodePrefix` helper.
- `ResourcePreviewScreen.kt` was updated so the video pager text is always shown (even when there is one video), and single-image preview now displays a metadata label in the same format as multi-image mode (`1/1 <resourceCode> (<size>)`).
- Modified files: `app/src/main/java/com/example/quotepicker/data/Repository.kt` and `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`.

### Testing
- Attempted to compile with `./gradlew :app:compileDebugKotlin`, but the build could not complete because Gradle distribution download was blocked by a proxy (`HTTP/1.1 403 Forbidden`), so compile verification was not possible in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae7aa1c9c8832bbdd325ff083ff185)