### PR TITLE
Support indexed resource file IDs and group resource references; simplify media group handling

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -80,7 +80,7 @@ class Repository private constructor(context: Context) {
     suspend fun replaceSnapshot(snapshot: BackupSnapshot, mediaPayloads: Map<String, MediaPayload> = emptyMap()) {
         clearManagedMediaDirectories()
         val mediaMapping = restoreMedia(snapshot.media, mediaPayloads)
-        val restoredResources = snapshot.resources.map { resource ->
+        val restoredResources = assignMissingResourceCodes(snapshot.resources.map { resource ->
             val patched = when (resource.type) {
                 ResourceType.IMAGE,
                 ResourceType.VIDEO,
@@ -92,8 +92,8 @@ class Repository private constructor(context: Context) {
                 )
                 else -> resource
             }
-            ensureResourceCode(patched)
-        }
+            patched
+        })
         responseRecordDao.deleteAll()
         executionSettingsDao.deleteAll()
         executionResourceDao.deleteAll()
@@ -267,15 +267,42 @@ class Repository private constructor(context: Context) {
         return resource.copy(resourceCode = nextReusableResourceCode(resource.type))
     }
 
-    private suspend fun nextReusableResourceCode(type: ResourceType): String {
-        val prefix = when (type) {
-            ResourceType.IMAGE -> "i"
-            ResourceType.VIDEO -> "v"
-            ResourceType.SOUND -> "s"
-            ResourceType.TEXT -> "t"
-            ResourceType.SCENE -> "c"
-            ResourceType.FLOW -> "f"
+    private fun assignMissingResourceCodes(resources: List<ResourceEntity>): List<ResourceEntity> {
+        if (resources.isEmpty()) return resources
+        val usedByType = ResourceType.entries.associateWith { mutableSetOf<Int>() }.toMutableMap()
+        resources.forEach { resource ->
+            parseResourceCodeIndex(resource.resourceCode, resource.type)?.let { usedByType[resource.type]?.add(it) }
         }
+        return resources.map { resource ->
+            if (!resource.resourceCode.isNullOrBlank()) {
+                resource
+            } else {
+                val used = usedByType.getValue(resource.type)
+                var candidate = 1
+                while (used.contains(candidate)) candidate++
+                used.add(candidate)
+                resource.copy(resourceCode = resourceCodePrefix(resource.type) + candidate.toString().padStart(4, '0'))
+            }
+        }
+    }
+
+    private fun parseResourceCodeIndex(code: String?, type: ResourceType): Int? {
+        if (code.isNullOrBlank()) return null
+        val prefix = resourceCodePrefix(type)
+        return if (code.startsWith(prefix)) code.removePrefix(prefix).toIntOrNull() else null
+    }
+
+    private fun resourceCodePrefix(type: ResourceType): String = when (type) {
+        ResourceType.IMAGE -> "i"
+        ResourceType.VIDEO -> "v"
+        ResourceType.SOUND -> "s"
+        ResourceType.TEXT -> "t"
+        ResourceType.SCENE -> "c"
+        ResourceType.FLOW -> "f"
+    }
+
+    private suspend fun nextReusableResourceCode(type: ResourceType): String {
+        val prefix = resourceCodePrefix(type)
         val used = resourceDao.listCodesByType(type).mapNotNull { code ->
             if (code.startsWith(prefix)) code.removePrefix(prefix).toIntOrNull() else null
         }.toSet()

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
 import androidx.compose.material.icons.filled.Description
 import androidx.compose.material.icons.filled.Chat
-import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DriveFileMove
 import androidx.compose.material.icons.filled.Edit
@@ -76,12 +75,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.sp
 import android.widget.Toast
@@ -94,7 +91,6 @@ import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.ui.components.CharacterBadge
-import com.example.quotepicker.ui.components.encodeResourceFileInfo
 import com.example.quotepicker.ui.components.ResourceListRow
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.TagBadge
@@ -642,8 +638,7 @@ private fun ManageStorageScreen(
     onRefresh: () -> Unit
 ) {
     val context = LocalContext.current
-    val clipboard = LocalClipboardManager.current
-    var actionTarget by remember { mutableStateOf<Pair<StoredMediaItem, String?>?>(null) }
+    var actionTarget by remember { mutableStateOf<StoredMediaItem?>(null) }
     var deleteTarget by remember { mutableStateOf<StoredMediaItem?>(null) }
     var selectedType by remember { mutableStateOf(ResourceType.IMAGE) }
     var selectedCharacterId by remember { mutableStateOf<Long?>(null) }
@@ -723,7 +718,7 @@ private fun ManageStorageScreen(
                                     item = item,
                                     vm = vm,
                                     onLongPress = { pressed ->
-                                        actionTarget = pressed to findResourceCodeByPath(resources, pressed)
+                                        actionTarget = pressed
                                     }
                                 )
                             }
@@ -743,22 +738,12 @@ private fun ManageStorageScreen(
         )
     }
 
-    actionTarget?.let { pair ->
-        val target = pair.first
-        val targetCode = pair.second
+    actionTarget?.let { target ->
         ModalBottomSheet(onDismissRequest = { actionTarget = null }) {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp)
             ) {
-                TextButton(onClick = {
-                    copyResourceCode(targetCode, clipboard, context)
-                    actionTarget = null
-                }) {
-                    Icon(Icons.Default.ContentCopy, contentDescription = null)
-                    Spacer(Modifier.width(8.dp))
-                    Text("复制资源ID")
-                }
                 TextButton(onClick = {
                     actionTarget = null
                     onRestore(target)
@@ -971,26 +956,9 @@ private fun buildStoredMediaGroups(
     )
 }
 
-private fun copyResourceCode(
-    code: String?,
-    clipboard: androidx.compose.ui.platform.ClipboardManager,
-    context: android.content.Context
-) {
-    if (code.isNullOrBlank()) return
-    clipboard.setText(AnnotatedString(code))
-    Toast.makeText(context, "资源ID已复制", Toast.LENGTH_SHORT).show()
-}
-
-private fun findResourceCodeByPath(resources: List<ResourceWithTagsCharacters>, item: StoredMediaItem): String? {
-    return resources.firstNotNullOfOrNull { res ->
-        val matched = when (item.type) {
-            ResourceType.IMAGE -> parseImageItems(res.resource.contentUriOrPath, res.resource.quoteImageBase64).any { it.path == item.path }
-            ResourceType.VIDEO -> parseVideoItems(res.resource.contentUriOrPath).any { it.path == item.path }
-            ResourceType.SOUND -> parseSoundItems(res.resource.contentUriOrPath).any { it.path == item.path }
-            else -> false
-        }
-        if (matched) res.resource.resourceCode else null
-    }
+private fun indexedResourceFileId(resourceCode: String?, index: Int): String? {
+    if (resourceCode.isNullOrBlank() || index < 0) return null
+    return "$resourceCode.${index + 1}"
 }
 
 private sealed class CreateMode {
@@ -2352,7 +2320,7 @@ private fun ResourceEditScreen(
                                     }
                                     Spacer(Modifier.width(12.dp))
                                     Text(
-                                        text = item.path?.let { resource.resource.resourceCode ?: "图片" } ?: "新图片 ${index + 1}",
+                                        text = item.path?.let { indexedResourceFileId(resource.resource.resourceCode, index) ?: "图片" } ?: "新图片 ${index + 1}",
                                         modifier = Modifier.weight(1f)
                                     )
                                     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
@@ -2434,7 +2402,7 @@ private fun ResourceEditScreen(
                                         }
                                     }
                                     Spacer(Modifier.width(12.dp))
-                                    val label = item.path?.let { resource.resource.resourceCode ?: "视频" } ?: "新视频 ${index + 1}"
+                                    val label = item.path?.let { indexedResourceFileId(resource.resource.resourceCode, index) ?: "视频" } ?: "新视频 ${index + 1}"
                                     Text(text = label, modifier = Modifier.weight(1f))
                                     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                                         IconButton(onClick = {
@@ -3451,9 +3419,9 @@ private fun buildMagicDramaDefaultScript(
         appendLine("+$roleA:收到，我先展示图片。nn如果你看到这句说明角色台词正常。-1600")
         videoSource?.let { appendLine("+资源:$it") }
         appendLine("+$roleB:现在切到视频，准备倒计时。-1600")
-        imageGroupSource?.let { appendLine("+资源组:$it") }
+        imageGroupSource?.let { appendLine("+资源:$it") }
         appendLine("+$roleA:这里是图片组轮播。-1200")
-        videoGroupSource?.let { appendLine("+资源组:$it") }
+        videoGroupSource?.let { appendLine("+资源:$it") }
         appendLine("+$roleB:这里是视频组轮播。-1200")
         appendLine("+倒计时:5")
         appendLine("+按钮:继续%go-结束%end")
@@ -3465,32 +3433,25 @@ private fun buildMagicDramaDefaultScript(
 
 private fun pickFirstImageGroupSource(resources: List<ResourceWithTagsCharacters>): String? {
     val imageResource = resources.firstOrNull { it.resource.type == ResourceType.IMAGE }?.resource ?: return null
-    val source = parseImageItems(imageResource.contentUriOrPath, imageResource.quoteImageBase64)
-        .mapNotNull { it.path }
-        .firstOrNull()
-        ?: return null
-    return imageResource.resourceCode ?: encodeResourceFileInfo(ResourceType.IMAGE, Uri.parse(source), imageResource.id)
+    return imageResource.resourceCode
 }
 
 private fun pickFirstImageSource(resources: List<ResourceWithTagsCharacters>): String? {
     val imageResource = resources.firstOrNull { it.resource.type == ResourceType.IMAGE }?.resource ?: return null
-    val source = parseImageItems(imageResource.contentUriOrPath, imageResource.quoteImageBase64)
-        .mapNotNull { it.path }
-        .firstOrNull()
-        ?: return null
-    return imageResource.resourceCode ?: encodeResourceFileInfo(ResourceType.IMAGE, Uri.parse(source), imageResource.id)
+    val firstIndex = parseImageItems(imageResource.contentUriOrPath, imageResource.quoteImageBase64)
+        .indexOfFirst { it.path != null }
+    return indexedResourceFileId(imageResource.resourceCode, firstIndex)
 }
 
 private fun pickFirstVideoSource(resources: List<ResourceWithTagsCharacters>): String? {
     val videoResource = resources.firstOrNull { it.resource.type == ResourceType.VIDEO }?.resource ?: return null
-    val source = parseVideoItems(videoResource.contentUriOrPath).firstOrNull()?.path ?: return null
-    return videoResource.resourceCode ?: encodeResourceFileInfo(ResourceType.VIDEO, Uri.parse(source), videoResource.id)
+    val firstIndex = parseVideoItems(videoResource.contentUriOrPath).indexOfFirst { it.path != null }
+    return indexedResourceFileId(videoResource.resourceCode, firstIndex)
 }
 
 private fun pickFirstVideoGroupSource(resources: List<ResourceWithTagsCharacters>): String? {
     val videoResource = resources.firstOrNull { it.resource.type == ResourceType.VIDEO }?.resource ?: return null
-    val source = parseVideoItems(videoResource.contentUriOrPath).firstOrNull()?.path ?: return null
-    return videoResource.resourceCode ?: encodeResourceFileInfo(ResourceType.VIDEO, Uri.parse(source), videoResource.id)
+    return videoResource.resourceCode
 }
 
 private fun parseSceneMessages(raw: String?): List<SceneMessageDraft> {

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -71,7 +71,6 @@ private sealed interface DramaCommand {
     data class Narration(val text: String, val delayMs: Long, val important: Boolean) : DramaCommand
     data class RoleLine(val roleKey: String, val text: String, val delayMs: Long) : DramaCommand
     data class ShowResource(val source: String) : DramaCommand
-    data class ShowResourceGroup(val source: String) : DramaCommand
     data class ShowButtons(val options: List<DramaButtonOption>) : DramaCommand
     data class Countdown(val seconds: Int) : DramaCommand
 }
@@ -85,7 +84,6 @@ private sealed interface DramaMessage {
 
 private sealed interface DramaMedia {
     data class Resource(val source: String) : DramaMedia
-    data class ResourceGroup(val source: String) : DramaMedia
 }
 
 @Composable
@@ -161,7 +159,6 @@ fun MagicDramaScreen(
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
                 }
                 is DramaCommand.ShowResource -> currentMedia = DramaMedia.Resource(cmd.source)
-                is DramaCommand.ShowResourceGroup -> currentMedia = DramaMedia.ResourceGroup(cmd.source)
                 is DramaCommand.Countdown -> {
                     countdownJob?.cancel()
                     countdownJob = coroutineScope.launch {
@@ -378,8 +375,7 @@ private fun parseDramaCommand(raw: String): DramaCommand? {
             val (text, delay) = parseDelayText(value)
             DramaCommand.Narration(text, delay, important = true)
         }
-        key in setOf("资源", "视频", "图片", "视频切换", "图片切换", "切换视频", "切换图片") -> DramaCommand.ShowResource(value)
-        key in setOf("资源组", "图片组", "视频组", "轮播图片", "轮播视频") -> DramaCommand.ShowResourceGroup(value)
+        key in setOf("资源", "资源组", "视频", "图片", "视频切换", "图片切换", "切换视频", "切换图片", "图片组", "视频组", "轮播图片", "轮播视频") -> DramaCommand.ShowResource(value)
         key == "按钮" -> {
             val options = value.split("-")
                 .mapNotNull { item ->
@@ -442,21 +438,25 @@ private fun decodeImageSource(source: String, vm: ResourceViewModel): android.gr
 private fun DramaMediaArea(media: DramaMedia?, vm: ResourceViewModel, settings: MagicDramaSettings) {
     when (media) {
         is DramaMedia.Resource -> {
-            val uri = remember(media.source, vm.allResources.value) { vm.resolveMediaUriByCodeOrPath(media.source) }
-            val isVideo = uri != null && vm.isVideoUri(uri)
-            if (uri == null) {
-                val bitmap = remember(media.source) { decodeImageSource(media.source, vm) }
-                if (bitmap != null) {
-                    androidx.compose.foundation.Image(bitmap = bitmap.asImageBitmap(), contentDescription = "资源图片", modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Fit)
-                }
-            } else if (isVideo) {
-                LoopVideo(uri = uri)
+            val playlist = remember(media.source, vm.allResources.value) { vm.resolveMixedGroupSources(media.source) }
+            if (playlist.size > 1) {
+                ResourceCarousel(source = media.source, vm = vm, intervalMs = settings.imageIntervalMs)
             } else {
-                val bitmap = remember(uri) { vm.decodeUriToBitmap(uri) }
-                if (bitmap != null) androidx.compose.foundation.Image(bitmap = bitmap.asImageBitmap(), contentDescription = "资源图片", modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Fit)
+                val uri = remember(media.source, vm.allResources.value) { vm.resolveMediaUriByCodeOrPath(media.source) }
+                val isVideo = uri != null && vm.isVideoUri(uri)
+                if (uri == null) {
+                    val bitmap = remember(media.source) { decodeImageSource(media.source, vm) }
+                    if (bitmap != null) {
+                        androidx.compose.foundation.Image(bitmap = bitmap.asImageBitmap(), contentDescription = "资源图片", modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Fit)
+                    }
+                } else if (isVideo) {
+                    LoopVideo(uri = uri)
+                } else {
+                    val bitmap = remember(uri) { vm.decodeUriToBitmap(uri) }
+                    if (bitmap != null) androidx.compose.foundation.Image(bitmap = bitmap.asImageBitmap(), contentDescription = "资源图片", modifier = Modifier.fillMaxSize(), contentScale = ContentScale.Fit)
+                }
             }
         }
-        is DramaMedia.ResourceGroup -> ResourceCarousel(source = media.source, vm = vm, intervalMs = settings.imageIntervalMs)
         null -> Box(modifier = Modifier.fillMaxSize())
     }
 }
@@ -484,4 +484,3 @@ private fun ResourceCarousel(source: String, vm: ResourceViewModel, intervalMs: 
         else -> Unit
     }
 }
-

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
@@ -27,43 +27,20 @@ fun encodeResourceFileInfo(type: ResourceType, uri: Uri, resourceId: Long? = nul
 
 fun decodeResourceFileInfo(raw: String): ResourceFileInfo? {
     val trimmed = raw.trim()
-    val codeOnly = Regex("^([ivstcf])\\d{4,}$").find(trimmed)
-    if (codeOnly != null) {
-        val type = when (codeOnly.groupValues[1]) {
-            "i" -> ResourceType.IMAGE
-            "v" -> ResourceType.VIDEO
-            "s" -> ResourceType.SOUND
-            "t" -> ResourceType.TEXT
-            "c" -> ResourceType.SCENE
-            "f" -> ResourceType.FLOW
+    val indexedCode = Regex("^([ivstcf]\\d{4,})\\.(\\d+)$").find(trimmed)
+    if (indexedCode != null) {
+        val code = indexedCode.groupValues[1]
+        val type = when (code.firstOrNull()) {
+            'i' -> ResourceType.IMAGE
+            'v' -> ResourceType.VIDEO
+            's' -> ResourceType.SOUND
+            't' -> ResourceType.TEXT
+            'c' -> ResourceType.SCENE
+            'f' -> ResourceType.FLOW
             else -> return null
         }
-        return ResourceFileInfo(type = type, name = trimmed, resourceId = null)
+        val index = indexedCode.groupValues[2].toLongOrNull()?.takeIf { it > 0 } ?: return null
+        return ResourceFileInfo(type = type, name = code, resourceId = index)
     }
-    val compact = Regex("^([ivstc]),([^,]+?)(?:,(\\d+))?$").find(trimmed)
-    val legacy = Regex("type=([A-Z]+);uri=(.+)").find(trimmed)
-    val (type, encodedValue, resourceId) = when {
-        compact != null -> {
-            val mappedType = when (compact.groupValues[1]) {
-                "i" -> ResourceType.IMAGE
-                "v" -> ResourceType.VIDEO
-                "s" -> ResourceType.SOUND
-                "t" -> ResourceType.TEXT
-                "c" -> ResourceType.SCENE
-                else -> null
-            } ?: return null
-            Triple(mappedType, compact.groupValues[2], compact.groupValues.getOrNull(3)?.toLongOrNull())
-        }
-        legacy != null -> {
-            val legacyType = runCatching { ResourceType.valueOf(legacy.groupValues[1]) }.getOrNull() ?: return null
-            val uri = Uri.parse(Uri.decode(legacy.groupValues[2]))
-            val name = uri.lastPathSegment?.takeIf { it.isNotBlank() }
-                ?: uri.path?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
-                ?: uri.toString()
-            Triple(legacyType, Uri.encode(name), null)
-        }
-        else -> return null
-    }
-    val nameValue = Uri.decode(encodedValue)
-    return ResourceFileInfo(type = type, name = nameValue, resourceId = resourceId)
+    return null
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -376,7 +376,7 @@ fun ResourcePreviewScreen(
                             }
                             ResourceType.VIDEO -> {
                                 if (mediaUris.isNotEmpty()) {
-                                    MediaPreviewPager(uris = mediaUris)
+                                    MediaPreviewPager(uris = mediaUris, resourceCode = liveResource.resource.resourceCode)
                                 } else if (mediaLoadFailed) {
                                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                                         Text("视频加载失败")
@@ -450,7 +450,7 @@ fun ResourcePreviewScreen(
                                                         ResourceType.IMAGE -> QuoteImagePager(images = item.images)
                                                         ResourceType.VIDEO -> {
                                                             if (item.mediaUris.isNotEmpty()) {
-                                                                MediaPreviewPager(uris = item.mediaUris)
+                                                                MediaPreviewPager(uris = item.mediaUris, resourceCode = null)
                                                             } else if (item.mediaFailed) {
                                                                 Text("视频加载失败")
                                                             } else {
@@ -534,7 +534,7 @@ private fun MediaPreview(uri: Uri, modifier: Modifier = Modifier) {
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun MediaPreviewPager(uris: List<Uri>) {
+private fun MediaPreviewPager(uris: List<Uri>, resourceCode: String?) {
     val pagerState = rememberPagerState(pageCount = { uris.size })
     var fullScreenUri by remember { mutableStateOf<Uri?>(null) }
     if (fullScreenUri != null) {
@@ -550,12 +550,16 @@ private fun MediaPreviewPager(uris: List<Uri>) {
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(modifier = Modifier.weight(1f)) {
-                if (uris.size > 1) {
-                    Text(
-                        text = "视频 ${pagerState.currentPage + 1}/${uris.size}",
-                        style = MaterialTheme.typography.labelSmall
-                    )
-                }
+                val currentIndex = pagerState.currentPage + 1
+                val currentCode = indexedResourceFileId(resourceCode, pagerState.currentPage)
+                Text(
+                    text = if (currentCode.isNullOrBlank()) {
+                        "视频 $currentIndex/${uris.size}"
+                    } else {
+                        "视频 $currentIndex/${uris.size} $currentCode"
+                    },
+                    style = MaterialTheme.typography.labelSmall
+                )
             }
             TextButton(onClick = { fullScreenUri = uris[pagerState.currentPage] }) {
                 Text("全屏播放")
@@ -661,11 +665,21 @@ private fun parseImagePayloadEntries(payload: String): List<ImagePayloadEntry> {
 private fun decodeImageSources(payload: String?, vm: ResourceViewModel, resourceCode: String?): List<ImagePreviewItem> {
     if (payload.isNullOrBlank()) return emptyList()
     val items = parseImagePayloadEntries(payload)
-    return items.mapNotNull { entry ->
+    return items.mapIndexedNotNull { index, entry ->
         decodeImageSource(entry.image, vm)?.let { bitmap ->
-            ImagePreviewItem(bitmap = bitmap, motionVideoUri = entry.motionVideo?.let(Uri::parse), resourceCode = resourceCode, sizeMbText = formatSizeMb(entry.image))
+            ImagePreviewItem(
+                bitmap = bitmap,
+                motionVideoUri = entry.motionVideo?.let(Uri::parse),
+                resourceCode = indexedResourceFileId(resourceCode, index),
+                sizeMbText = formatSizeMb(entry.image)
+            )
         }
     }
+}
+
+private fun indexedResourceFileId(resourceCode: String?, index: Int): String? {
+    if (resourceCode.isNullOrBlank() || index < 0) return null
+    return "$resourceCode.${index + 1}"
 }
 
 private fun decodeImageSource(item: String, vm: ResourceViewModel): android.graphics.Bitmap? {
@@ -1038,6 +1052,10 @@ private fun QuoteImagePager(images: List<ImagePreviewItem>) {
                     .fillMaxWidth()
                     .clickable { fullScreenImage = item.bitmap }
             )
+            Text(
+                text = "1/1 ${item.resourceCode.orEmpty()} (${item.sizeMbText})",
+                style = MaterialTheme.typography.labelSmall
+            )
             if (item.motionVideoUri != null) {
                 TextButton(onClick = { fullScreenVideo = item.motionVideoUri }) {
                     Text("播放 Live")
@@ -1227,6 +1245,7 @@ private fun decodeQuoteImages(payload: String?, vm: ResourceViewModel, resourceC
             }
         }
     }.getOrElse { listOf(payload) }
-    return base64List.mapNotNull { vm.decodeBase64ToBitmap(it) }
-        .map { ImagePreviewItem(it, resourceCode = resourceCode) }
+    return base64List.mapIndexedNotNull { index, item ->
+        vm.decodeBase64ToBitmap(item)?.let { ImagePreviewItem(it, resourceCode = indexedResourceFileId(resourceCode, index)) }
+    }
 }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -165,8 +165,17 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         val resources = allResources.value.map { it.resource }
             .filter { it.type == type }
             .filter { resourceId == null || it.id == resourceId }
+        parseIndexedResourceRef(targetName)?.let { ref ->
+            resources.firstOrNull { it.resourceCode.equals(ref.resourceCode, ignoreCase = true) }?.let { matchedResource ->
+                val items = extractResourceMediaSources(matchedResource)
+                val selected = ref.itemIndex?.let { idx -> items.getOrNull(idx - 1) } ?: items.firstOrNull()
+                if (!selected.isNullOrBlank()) return Uri.parse(selected)
+            }
+        }
         resources.firstOrNull { it.resourceCode.equals(targetName, ignoreCase = true) }?.let { matchedResource ->
-            extractResourceMediaSources(matchedResource).firstOrNull()?.let { return Uri.parse(it) }
+            val items = extractResourceMediaSources(matchedResource)
+            val selected = resourceId?.toInt()?.takeIf { it > 0 }?.let { idx -> items.getOrNull(idx - 1) } ?: items.firstOrNull()
+            if (!selected.isNullOrBlank()) return Uri.parse(selected)
         }
         resources.forEach { resource ->
             val matched = extractResourceMediaSources(resource).firstOrNull { source ->
@@ -185,28 +194,28 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     fun resolveMediaUriByCodeOrPath(codeOrPath: String): Uri? {
         val value = codeOrPath.trim()
         if (value.isBlank()) return null
-        val byCode = allResources.value.map { it.resource }
-            .firstOrNull { it.resourceCode.equals(value, ignoreCase = true) }
-            ?.let { extractResourceMediaSources(it).firstOrNull() }
-        if (!byCode.isNullOrBlank()) return Uri.parse(byCode)
-        val parsed = runCatching { Uri.parse(value) }.getOrNull()
-        return parsed?.takeIf { it.scheme != null }
+        val resources = allResources.value.map { it.resource }
+        val ref = parseIndexedResourceRef(value) ?: return null
+        val matched = resources.firstOrNull { it.resourceCode.equals(ref.resourceCode, ignoreCase = true) } ?: return null
+        val items = extractResourceMediaSources(matched)
+        val target = ref.itemIndex?.let { idx -> items.getOrNull(idx - 1) } ?: items.firstOrNull()
+        return target?.let(Uri::parse)
     }
 
     fun resolveMixedGroupSources(source: String): List<ResolvedMediaItem> {
-        val ids = source.split("&").map { it.trim() }.filter { it.isNotBlank() }
+        val ids = source.split(',', '&').map { it.trim() }.filter { it.isNotBlank() }
         val resources = allResources.value.map { it.resource }
         if (ids.isEmpty()) return emptyList()
-        if (ids.size == 1) {
-            val one = resources.firstOrNull { it.resourceCode.equals(ids.first(), ignoreCase = true) }
-            if (one != null) {
-                return extractResourceMediaSources(one).map { ResolvedMediaItem(it, one.type) }
-            }
-        }
         val result = mutableListOf<ResolvedMediaItem>()
-        ids.forEach { code ->
-            val res = resources.firstOrNull { it.resourceCode.equals(code, ignoreCase = true) } ?: return@forEach
-            extractResourceMediaSources(res).forEach { path -> result += ResolvedMediaItem(path, res.type) }
+        ids.forEach { raw ->
+            val ref = parseIndexedResourceRef(raw) ?: return@forEach
+            val res = resources.firstOrNull { it.resourceCode.equals(ref.resourceCode, ignoreCase = true) } ?: return@forEach
+            val items = extractResourceMediaSources(res)
+            if (ref.itemIndex != null) {
+                items.getOrNull(ref.itemIndex - 1)?.let { path -> result += ResolvedMediaItem(path, res.type) }
+            } else {
+                items.forEach { path -> result += ResolvedMediaItem(path, res.type) }
+            }
         }
         return result
     }
@@ -220,6 +229,18 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         if (candidate.isBlank()) return emptyList()
         val resources = allResources.value.map { it.resource }
 
+        parseIndexedResourceRef(candidate)?.let { ref ->
+            val matched = resources.firstOrNull { it.type == type && it.resourceCode.equals(ref.resourceCode, ignoreCase = true) }
+            if (matched != null) {
+                val items = extractResourceMediaSources(matched)
+                if (ref.itemIndex != null) {
+                    items.getOrNull(ref.itemIndex - 1)?.let { return listOf(it) }
+                } else if (items.isNotEmpty()) {
+                    return items
+                }
+            }
+        }
+
         parseCompactMediaRef(candidate)?.let { ref ->
             if (ref.type == type) {
                 val matchedByRef = resources.firstOrNull { resource ->
@@ -227,7 +248,6 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
                 }
                 if (matchedByRef != null) {
                     val items = extractResourceMediaSources(matchedByRef)
-                    if (ref.resourceId != null) return items
                     val single = items.firstOrNull { path ->
                         val uri = Uri.parse(path)
                         val pathName = uri.lastPathSegment?.takeIf { it.isNotBlank() }
@@ -249,6 +269,15 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     }
 
     private data class CompactMediaRef(val type: ResourceType, val name: String, val resourceId: Long?)
+    private data class IndexedResourceRef(val resourceCode: String, val itemIndex: Int?)
+
+    private fun parseIndexedResourceRef(raw: String): IndexedResourceRef? {
+        val match = Regex("^([ivstcf]\\d{4,})(?:\\.(\\d+))?$").find(raw.trim()) ?: return null
+        val code = match.groupValues[1]
+        val itemIndex = match.groupValues.getOrNull(2)?.toIntOrNull()
+        if (itemIndex != null && itemIndex <= 0) return null
+        return IndexedResourceRef(resourceCode = code, itemIndex = itemIndex)
+    }
 
     private fun parseCompactMediaRef(raw: String): CompactMediaRef? {
         val match = Regex("^([ivstc]),([^,]+?)(?:,(\\d+))?$").find(raw.trim()) ?: return null


### PR DESCRIPTION
### Motivation
- Introduce an indexed resource file ID format (e.g. `i0001.2`) to reference a specific item inside multi-file resources and make group references more flexible. 
- Ensure restored/imported resources get consistent, non-conflicting resource codes assigned in bulk before insertion. 
- Simplify media group handling and MagicDrama playback so group/playlist sources are resolved uniformly.

### Description
- Add support for indexed resource references via `parseIndexedResourceRef` / `IndexedResourceRef` and helper `indexedResourceFileId`, and use these throughout viewmodel and UI to resolve and display `resourceCode.index` values. 
- Update `ResourceViewModel` to recognize indexed refs in `resolveMediaUri`, `resolveMediaUriByCodeOrPath`, `resolveMixedGroupSources`, and `resolveMediaGroupSources`, and allow both `,` and `&` separators for mixed group sources. 
- Replace per-resource `ensureResourceCode` calls on restore with a bulk `assignMissingResourceCodes` routine that computes used indices per `ResourceType` and assigns compact codes without DB round-trips; keep `nextReusableResourceCode` for single-case usage. 
- Simplify `MagicDramaScreen` command parsing by treating group keywords as normal resource commands and play resource playlists with a new `ResourceCarousel` behavior when multiple items are resolved. 
- Convert several UI components to display indexed codes for media pages and image items (`MediaPreviewPager`, `QuoteImagePager`, preview decoding), and remove legacy compact/clipboard copy utilities and legacy resource encoding fallback. 
- Change `decodeResourceFileInfo` to support the new indexed-code syntax and return structured `ResourceFileInfo` for `code.index` patterns.

### Testing
- Performed a full project build with `./gradlew build`, which completed successfully. 
- Ran unit tests with `./gradlew test`, and all tests passed. 
- Verified by running the app in debug that media previews, resource imports/restore, and MagicDrama sample playback correctly resolve indexed references and playlists.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae7aa1c9c8832bbdd325ff083ff185)