### PR TITLE
新增文本资源使用历史并修复魔剧资源ID引用与联动

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
@@ -38,9 +38,10 @@ class Converters {
         ResourceCharacterCrossRef::class,
         ResponseRecordEntity::class,
         ExecutionSettingsEntity::class,
-        ExecutionResourceEntity::class
+        ExecutionResourceEntity::class,
+        TextResourceUsageHistoryEntity::class
     ],
-    version = 9,
+    version = 10,
     exportSchema = false
 )
 @TypeConverters(Converters::class)
@@ -53,6 +54,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun responseRecordDao(): ResponseRecordDao
     abstract fun executionSettingsDao(): ExecutionSettingsDao
     abstract fun executionResourceDao(): ExecutionResourceDao
+    abstract fun textResourceUsageHistoryDao(): TextResourceUsageHistoryDao
 
     companion object {
         @Volatile private var INSTANCE: AppDatabase? = null

--- a/app/src/main/java/com/example/quotepicker/data/Dao.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Dao.kt
@@ -242,3 +242,19 @@ interface ExecutionResourceDao {
     @Query("DELETE FROM execution_resources")
     suspend fun deleteAll()
 }
+
+
+@Dao
+interface TextResourceUsageHistoryDao {
+    @Query("SELECT * FROM text_resource_usage_history WHERE textResourceId = :textResourceId")
+    suspend fun listByTextResourceId(textResourceId: Long): List<TextResourceUsageHistoryEntity>
+
+    @Query("SELECT * FROM text_resource_usage_history WHERE resourceCode = :resourceCode")
+    suspend fun listByResourceCode(resourceCode: String): List<TextResourceUsageHistoryEntity>
+
+    @Query("DELETE FROM text_resource_usage_history WHERE textResourceId = :textResourceId")
+    suspend fun deleteByTextResourceId(textResourceId: Long)
+
+    @Insert
+    suspend fun insertAll(items: List<TextResourceUsageHistoryEntity>)
+}

--- a/app/src/main/java/com/example/quotepicker/data/Entities.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Entities.kt
@@ -90,6 +90,19 @@ data class ExecutionResourceEntity(
     val createdAt: Long = System.currentTimeMillis()
 )
 
+@Entity(
+    tableName = "text_resource_usage_history",
+    indices = [Index(value = ["resourceCode"]), Index(value = ["textResourceId"])]
+)
+data class TextResourceUsageHistoryEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val textResourceId: Long,
+    val textTitle: String,
+    val resourceCode: String,
+    val fileInfo: String,
+    val createdAt: Long = System.currentTimeMillis()
+)
+
 @Entity(tableName = "resources")
 data class ResourceEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -23,6 +23,7 @@ class Repository private constructor(context: Context) {
     private val responseRecordDao = db.responseRecordDao()
     private val executionSettingsDao = db.executionSettingsDao()
     private val executionResourceDao = db.executionResourceDao()
+    private val textUsageDao = db.textResourceUsageHistoryDao()
 
     fun observeCategories(): Flow<List<TagCategoryEntity>> = categoryDao.observeCategories()
     fun observeTagsByCategory(categoryId: Long): Flow<List<TagEntity>> = tagDao.observeTagsByCategory(categoryId)
@@ -240,7 +241,31 @@ class Repository private constructor(context: Context) {
     suspend fun updateResource(resource: ResourceEntity) =
         resourceDao.update(ensureResourceCode(resource).copy(updatedAt = System.currentTimeMillis()))
 
-    suspend fun deleteResource(resource: ResourceEntity) = resourceDao.delete(resource)
+    suspend fun deleteResource(resource: ResourceEntity) {
+        resourceDao.delete(resource)
+        textUsageDao.deleteByTextResourceId(resource.id)
+    }
+
+    suspend fun replaceTextResourceUsageHistory(textResourceId: Long, textTitle: String, refs: Set<String>) {
+        textUsageDao.deleteByTextResourceId(textResourceId)
+        if (refs.isEmpty()) return
+        val now = System.currentTimeMillis()
+        textUsageDao.insertAll(
+            refs.map { code ->
+                TextResourceUsageHistoryEntity(
+                    textResourceId = textResourceId,
+                    textTitle = textTitle,
+                    resourceCode = code,
+                    fileInfo = code,
+                    createdAt = now
+                )
+            }
+        )
+    }
+
+    suspend fun listUsageByResourceCode(resourceCode: String): List<TextResourceUsageHistoryEntity> =
+        textUsageDao.listByResourceCode(resourceCode)
+
 
     suspend fun updateResourceTags(resourceId: Long, tagIds: List<Long>) {
         crossRefDao.clearResourceTags(resourceId)

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -2167,6 +2167,16 @@ private fun ResourceEditScreen(
     val flowResources = remember(availableResources) {
         availableResources.filter { it.resource.type != ResourceType.FLOW }
     }
+    var usageHistory by remember(resource.resource.resourceCode) { mutableStateOf(listOf<com.example.quotepicker.data.TextResourceUsageHistoryEntity>()) }
+
+    LaunchedEffect(resource.resource.resourceCode) {
+        val code = resource.resource.resourceCode
+        if (code.isNullOrBlank()) {
+            usageHistory = emptyList()
+        } else {
+            vm.listResourceUsageHistory(code) { usageHistory = it }
+        }
+    }
 
     LaunchedEffect(availableResources) {
         if (resource.resource.type == ResourceType.FLOW) {
@@ -2266,6 +2276,23 @@ private fun ResourceEditScreen(
                 label = { Text("名称") },
                 modifier = Modifier.fillMaxWidth()
             )
+            resource.resource.resourceCode?.takeIf { it.isNotBlank() }?.let { code ->
+                Text(
+                    text = "资源ID: $code",
+                    style = MaterialTheme.typography.labelMedium,
+                    color = MaterialTheme.colorScheme.primary
+                )
+                usageHistory
+                    .distinctBy { it.textResourceId }
+                    .takeIf { it.isNotEmpty() }
+                    ?.forEach { usage ->
+                        Text(
+                            text = "被文本使用：${usage.textTitle}",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = Color.Red
+                        )
+                    }
+            }
             when (resource.resource.type) {
                 ResourceType.TEXT -> {
                     OutlinedTextField(
@@ -3438,15 +3465,18 @@ private fun pickFirstImageGroupSource(resources: List<ResourceWithTagsCharacters
 
 private fun pickFirstImageSource(resources: List<ResourceWithTagsCharacters>): String? {
     val imageResource = resources.firstOrNull { it.resource.type == ResourceType.IMAGE }?.resource ?: return null
-    val firstIndex = parseImageItems(imageResource.contentUriOrPath, imageResource.quoteImageBase64)
-        .indexOfFirst { it.path != null }
-    return indexedResourceFileId(imageResource.resourceCode, firstIndex)
+    val items = parseImageItems(imageResource.contentUriOrPath, imageResource.quoteImageBase64)
+    if (items.isEmpty()) return imageResource.resourceCode
+    val firstIndex = items.indexOfFirst { it.path != null }.takeIf { it >= 0 } ?: 0
+    return indexedResourceFileId(imageResource.resourceCode, firstIndex) ?: imageResource.resourceCode
 }
 
 private fun pickFirstVideoSource(resources: List<ResourceWithTagsCharacters>): String? {
     val videoResource = resources.firstOrNull { it.resource.type == ResourceType.VIDEO }?.resource ?: return null
-    val firstIndex = parseVideoItems(videoResource.contentUriOrPath).indexOfFirst { it.path != null }
-    return indexedResourceFileId(videoResource.resourceCode, firstIndex)
+    val items = parseVideoItems(videoResource.contentUriOrPath)
+    if (items.isEmpty()) return videoResource.resourceCode
+    val firstIndex = items.indexOfFirst { it.path != null }.takeIf { it >= 0 } ?: 0
+    return indexedResourceFileId(videoResource.resourceCode, firstIndex) ?: videoResource.resourceCode
 }
 
 private fun pickFirstVideoGroupSource(resources: List<ResourceWithTagsCharacters>): String? {

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceFileInfo.kt
@@ -39,8 +39,8 @@ fun decodeResourceFileInfo(raw: String): ResourceFileInfo? {
             'f' -> ResourceType.FLOW
             else -> return null
         }
-        val index = indexedCode.groupValues[2].toLongOrNull()?.takeIf { it > 0 } ?: return null
-        return ResourceFileInfo(type = type, name = code, resourceId = index)
+        val index = indexedCode.groupValues[2].toIntOrNull()?.takeIf { it > 0 } ?: return null
+        return ResourceFileInfo(type = type, name = "$code.$index", resourceId = null)
     }
     return null
 }

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -19,6 +19,7 @@ import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.data.TagCategoryEntity
 import com.example.quotepicker.data.TagCategoryType
 import com.example.quotepicker.data.TagEntity
+import com.example.quotepicker.data.TextResourceUsageHistoryEntity
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.util.ImageCompression
 import com.example.quotepicker.util.StoragePaths
@@ -335,6 +336,73 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         }
     }
 
+
+    fun listResourceUsageHistory(resourceCode: String, onResult: (List<TextResourceUsageHistoryEntity>) -> Unit) =
+        viewModelScope.launch {
+            onResult(repo.listUsageByResourceCode(resourceCode))
+        }
+
+    private fun extractReferencedResourceCodes(text: String): Set<String> {
+        val refs = mutableSetOf<String>()
+        Regex("""\+资源:([^\n\r]+)""").findAll(text).forEach { m ->
+            val raw = m.groupValues.getOrNull(1).orEmpty()
+            raw.split(',', '&').map { it.trim() }.filter { it.isNotBlank() }.forEach { token ->
+                parseIndexedResourceRef(token)?.let { refs.add(it.resourceCode) }
+            }
+        }
+        Regex("""@[^@]+@\(([^)]+)\)""").findAll(text).forEach { m ->
+            val info = m.groupValues.getOrNull(1).orEmpty().trim()
+            parseIndexedResourceRef(info)?.let { refs.add(it.resourceCode) }
+        }
+        return refs
+    }
+
+    private suspend fun refreshTextUsageHistory(resource: ResourceEntity, text: String) {
+        if (resource.type != ResourceType.TEXT && resource.type != ResourceType.SCENE) return
+        val refs = extractReferencedResourceCodes(text)
+        repo.replaceTextResourceUsageHistory(resource.id, resource.title, refs)
+    }
+
+    private fun remapIndexedRefByMovedItem(text: String, resourceCode: String, fromIndex: Int, toIndex: Int): String {
+        if (resourceCode.isBlank() || fromIndex == toIndex || fromIndex <= 0 || toIndex <= 0) return text
+        val regex = Regex("""\b""" + Regex.escape(resourceCode) + """\.(\d+)\b""")
+        return regex.replace(text) { match ->
+            val current = match.groupValues[1].toIntOrNull() ?: return@replace match.value
+            val next = when {
+                current == fromIndex -> toIndex
+                fromIndex < toIndex && current in (fromIndex + 1)..toIndex -> current - 1
+                fromIndex > toIndex && current in toIndex until fromIndex -> current + 1
+                else -> current
+            }
+            "${resourceCode}.${next}"
+        }
+    }
+
+    private suspend fun remapTextReferencesForMovedMedia(resource: ResourceEntity, oldPaths: List<String>, newPaths: List<String>) {
+        val code = resource.resourceCode ?: return
+        if (oldPaths == newPaths) return
+        val textResources = allResources.value.map { it.resource }.filter { it.type == ResourceType.TEXT || it.type == ResourceType.SCENE }
+        textResources.forEach { textRes ->
+            val oldText = when (textRes.type) {
+                ResourceType.TEXT -> textRes.quoteText.orEmpty()
+                ResourceType.SCENE -> textRes.sceneJson.orEmpty()
+                else -> ""
+            }
+            var updatedText = oldText
+            oldPaths.forEachIndexed { oldIdx, oldPath ->
+                val newIdx = newPaths.indexOf(oldPath)
+                if (newIdx >= 0 && newIdx != oldIdx) {
+                    updatedText = remapIndexedRefByMovedItem(updatedText, code, oldIdx + 1, newIdx + 1)
+                }
+            }
+            if (updatedText != oldText) {
+                val patched = if (textRes.type == ResourceType.TEXT) textRes.copy(quoteText = updatedText) else textRes.copy(sceneJson = updatedText)
+                repo.updateResource(patched)
+                refreshTextUsageHistory(patched, updatedText)
+            }
+        }
+    }
+
     fun moveResourceToGroup(resource: ResourceEntity, newTitle: String, newCreatedAt: Long) =
         viewModelScope.launch {
             repo.updateResource(
@@ -462,7 +530,9 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         characterIds: List<Long>
     ) = viewModelScope.launch {
         if (characterIds.isEmpty()) return@launch
-        repo.updateResource(resource.copy(title = title, quoteText = text))
+        val updated = resource.copy(title = title, quoteText = text)
+        repo.updateResource(updated)
+        refreshTextUsageHistory(updated, text)
         updateResourceTags(resource.id, tagIds)
         updateResourceCharacters(resource.id, characterIds)
     }
@@ -476,9 +546,9 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         characterIds: List<Long>
     ) = viewModelScope.launch {
         if (characterIds.isEmpty()) return@launch
-        repo.updateResource(
-            resource.copy(title = title, quoteText = description, sceneJson = sceneJson)
-        )
+        val updated = resource.copy(title = title, quoteText = description, sceneJson = sceneJson)
+        repo.updateResource(updated)
+        refreshTextUsageHistory(updated, sceneJson)
         updateResourceTags(resource.id, tagIds)
         updateResourceCharacters(resource.id, characterIds)
     }
@@ -491,10 +561,13 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         characterIds: List<Long>
     ) = viewModelScope.launch(Dispatchers.IO) {
         if (characterIds.isEmpty()) return@launch
+        val oldPaths = parseImageSourceList(resource.contentUriOrPath, resource.quoteImageBase64)
         val resolved = resolveImageItems(items)
         if (resolved.isEmpty()) return@launch
         val payload = org.json.JSONArray(resolved).toString()
-        repo.updateResource(resource.copy(title = title, contentUriOrPath = payload, quoteImageBase64 = null))
+        val updated = resource.copy(title = title, contentUriOrPath = payload, quoteImageBase64 = null)
+        repo.updateResource(updated)
+        remapTextReferencesForMovedMedia(updated, oldPaths, parseImageSourceList(updated.contentUriOrPath, updated.quoteImageBase64))
         updateResourceTags(resource.id, tagIds)
         updateResourceCharacters(resource.id, characterIds)
     }
@@ -507,10 +580,13 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         characterIds: List<Long>
     ) = viewModelScope.launch(Dispatchers.IO) {
         if (characterIds.isEmpty()) return@launch
+        val oldPaths = parseSimplePathList(resource.contentUriOrPath)
         val newUris = resolveVideoItems(items)
         if (newUris.isEmpty()) return@launch
         val payload = org.json.JSONArray(newUris).toString()
-        repo.updateResource(resource.copy(title = title, contentUriOrPath = payload))
+        val updated = resource.copy(title = title, contentUriOrPath = payload)
+        repo.updateResource(updated)
+        remapTextReferencesForMovedMedia(updated, oldPaths, parseSimplePathList(updated.contentUriOrPath))
         updateResourceTags(resource.id, tagIds)
         updateResourceCharacters(resource.id, characterIds)
     }


### PR DESCRIPTION
### Motivation

- 使魔剧/特殊文本中的资源引用采用新的资源ID引用方式（如 `i0001.1`）并在无具体媒体项时回退到资源编码，避免预览和自动样例生成错乱。 
- 记录文本资源（TEXT/SCENE）中引用了哪些资源以便在编辑/移动媒体时提示和自动更新引用位置。 

### Description

- 新增 Room 实体 `TextResourceUsageHistoryEntity` 与 DAO `TextResourceUsageHistoryDao`，并将其注册到 `AppDatabase`（数据库版本升级到 `10`）。
- 在 `Repository` 中加入 `textUsageDao`，并新增 `replaceTextResourceUsageHistory`、`listUsageByResourceCode`，以及在删除文本资源时清理历史。 
- 在 `ResourceViewModel` 中新增对文本内容中 `+资源:...` 和 `@...@(...)` 引用的解析与历史刷新逻辑（`extractReferencedResourceCodes` / `refreshTextUsageHistory` / `listResourceUsageHistory`），以及媒体条目移动后重映射文本内 `资源编码.序号` 的函数（`remapIndexedRefByMovedItem` / `remapTextReferencesForMovedMedia`），并在保存文本/场景时触发历史更新。 
- 修正魔剧示例生成中首个媒体引用的选取逻辑（`pickFirstImageSource` / `pickFirstVideoSource`），在媒体项缺失时回退到资源编码并优先返回 `资源编码.序号`（若有）。
- 修复特殊文本文件信息解析：`decodeResourceFileInfo` 现在将 `i0001.1` 类型的字符串解析为 `name = "i0001.1"`，便于按新引用方式预览。 
- 在资源编辑页（`ResourceEditScreen`）新增显示 `资源ID` 且在其下方以红色字体列出“被哪些文本使用”（基于历史表查询）。

### Testing

- Attempted to compile with `./gradlew :app:compileDebugKotlin`, but the build failed in the current environment when downloading the Gradle distribution due to a network/proxy error (`HTTP/1.1 403 Forbidden`), so full compilation could not be completed. 
- Ran repository and source edits locally (code searches and small-run scripts) to verify new functions and UI hooks were inserted; no unit/integration tests were available or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae890542e8832bafe285a8f83332aa)