### PR TITLE
Refine text-resource usage tracking and usage indicators

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -246,21 +246,23 @@ class Repository private constructor(context: Context) {
         textUsageDao.deleteByTextResourceId(resource.id)
     }
 
-    suspend fun replaceTextResourceUsageHistory(textResourceId: Long, textTitle: String, refs: Set<String>) {
+    suspend fun replaceTextResourceUsageHistory(
+        textResourceId: Long,
+        textTitle: String,
+        refs: Set<Pair<String, String>>
+    ) {
         textUsageDao.deleteByTextResourceId(textResourceId)
         if (refs.isEmpty()) return
         val now = System.currentTimeMillis()
-        textUsageDao.insertAll(
-            refs.map { code ->
+        textUsageDao.insertAll(refs.map { (code, fileInfo) ->
                 TextResourceUsageHistoryEntity(
                     textResourceId = textResourceId,
                     textTitle = textTitle,
                     resourceCode = code,
-                    fileInfo = code,
+                    fileInfo = fileInfo,
                     createdAt = now
                 )
-            }
-        )
+            })
     }
 
     suspend fun listUsageByResourceCode(resourceCode: String): List<TextResourceUsageHistoryEntity> =

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -2276,22 +2276,33 @@ private fun ResourceEditScreen(
                 label = { Text("名称") },
                 modifier = Modifier.fillMaxWidth()
             )
-            resource.resource.resourceCode?.takeIf { it.isNotBlank() }?.let { code ->
+            val resourceCode = resource.resource.resourceCode?.takeIf { it.isNotBlank() }
+            val normalizedUsageHistory = remember(resourceCode, usageHistory) {
+                resourceCode?.let { code ->
+                    usageHistory.filter { it.resourceCode == code }
+                } ?: emptyList()
+            }
+            val wholeUsageTexts = remember(resourceCode, normalizedUsageHistory) {
+                resourceCode?.let { code ->
+                    normalizedUsageHistory
+                        .filter { it.fileInfo == code }
+                        .distinctBy { it.textResourceId }
+                        .map { it.textTitle }
+                } ?: emptyList()
+            }
+            val fileUsageTexts = remember(resourceCode, normalizedUsageHistory) {
+                normalizedUsageHistory
+                    .filter { usage -> resourceCode != null && usage.fileInfo != resourceCode }
+                    .groupBy { it.fileInfo }
+                    .mapValues { (_, usages) -> usages.distinctBy { it.textResourceId }.map { it.textTitle } }
+            }
+            resourceCode?.let { code ->
+                val usageSuffix = wholeUsageTexts.takeIf { it.isNotEmpty() }?.joinToString("、")
                 Text(
-                    text = "资源ID: $code",
+                    text = if (usageSuffix.isNullOrBlank()) "资源ID: $code" else "资源ID: $code  $usageSuffix",
                     style = MaterialTheme.typography.labelMedium,
-                    color = MaterialTheme.colorScheme.primary
+                    color = if (usageSuffix.isNullOrBlank()) MaterialTheme.colorScheme.primary else Color.Red
                 )
-                usageHistory
-                    .distinctBy { it.textResourceId }
-                    .takeIf { it.isNotEmpty() }
-                    ?.forEach { usage ->
-                        Text(
-                            text = "被文本使用：${usage.textTitle}",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = Color.Red
-                        )
-                    }
             }
             when (resource.resource.type) {
                 ResourceType.TEXT -> {
@@ -2346,10 +2357,22 @@ private fun ResourceEditScreen(
                                         }
                                     }
                                     Spacer(Modifier.width(12.dp))
-                                    Text(
-                                        text = item.path?.let { indexedResourceFileId(resource.resource.resourceCode, index) ?: "图片" } ?: "新图片 ${index + 1}",
-                                        modifier = Modifier.weight(1f)
-                                    )
+                                    val fileId = indexedResourceFileId(resource.resource.resourceCode, index)
+                                    val imageUsageSuffix = fileId?.let { id ->
+                                        fileUsageTexts[id]
+                                            ?.takeIf { it.isNotEmpty() }
+                                            ?.joinToString("、")
+                                    }
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(text = item.path?.let { fileId ?: "图片" } ?: "新图片 ${index + 1}")
+                                        imageUsageSuffix?.let { suffix ->
+                                            Text(
+                                                text = suffix,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = Color.Red
+                                            )
+                                        }
+                                    }
                                     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                                         IconButton(onClick = {
                                             if (index > 0) {
@@ -2429,8 +2452,23 @@ private fun ResourceEditScreen(
                                         }
                                     }
                                     Spacer(Modifier.width(12.dp))
-                                    val label = item.path?.let { indexedResourceFileId(resource.resource.resourceCode, index) ?: "视频" } ?: "新视频 ${index + 1}"
-                                    Text(text = label, modifier = Modifier.weight(1f))
+                                    val fileId = indexedResourceFileId(resource.resource.resourceCode, index)
+                                    val label = item.path?.let { fileId ?: "视频" } ?: "新视频 ${index + 1}"
+                                    val videoUsageSuffix = fileId?.let { id ->
+                                        fileUsageTexts[id]
+                                            ?.takeIf { it.isNotEmpty() }
+                                            ?.joinToString("、")
+                                    }
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(text = label)
+                                        videoUsageSuffix?.let { suffix ->
+                                            Text(
+                                                text = suffix,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = Color.Red
+                                            )
+                                        }
+                                    }
                                     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                                         IconButton(onClick = {
                                             if (index > 0) {
@@ -2487,8 +2525,23 @@ private fun ResourceEditScreen(
                                 ) {
                                     Icon(Icons.Default.MusicNote, contentDescription = null)
                                     Spacer(Modifier.width(12.dp))
-                                    val label = item.path?.let { "音频 ${index + 1}" } ?: "新音频 ${index + 1}"
-                                    Text(text = label, modifier = Modifier.weight(1f))
+                                    val fileId = indexedResourceFileId(resource.resource.resourceCode, index)
+                                    val label = item.path?.let { fileId ?: "音频 ${index + 1}" } ?: "新音频 ${index + 1}"
+                                    val soundUsageSuffix = fileId?.let { id ->
+                                        fileUsageTexts[id]
+                                            ?.takeIf { it.isNotEmpty() }
+                                            ?.joinToString("、")
+                                    }
+                                    Column(modifier = Modifier.weight(1f)) {
+                                        Text(text = label)
+                                        soundUsageSuffix?.let { suffix ->
+                                            Text(
+                                                text = suffix,
+                                                style = MaterialTheme.typography.bodySmall,
+                                                color = Color.Red
+                                            )
+                                        }
+                                    }
                                     Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
                                         IconButton(onClick = {
                                             if (index > 0) {

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -342,17 +342,23 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             onResult(repo.listUsageByResourceCode(resourceCode))
         }
 
-    private fun extractReferencedResourceCodes(text: String): Set<String> {
-        val refs = mutableSetOf<String>()
+    private fun extractReferencedResourceCodes(text: String): Set<Pair<String, String>> {
+        val refs = mutableSetOf<Pair<String, String>>()
         Regex("""\+资源:([^\n\r]+)""").findAll(text).forEach { m ->
             val raw = m.groupValues.getOrNull(1).orEmpty()
             raw.split(',', '&').map { it.trim() }.filter { it.isNotBlank() }.forEach { token ->
-                parseIndexedResourceRef(token)?.let { refs.add(it.resourceCode) }
+                parseIndexedResourceRef(token)?.let { ref ->
+                    val fileInfo = if (ref.itemIndex != null) "${ref.resourceCode}.${ref.itemIndex}" else ref.resourceCode
+                    refs.add(ref.resourceCode to fileInfo)
+                }
             }
         }
         Regex("""@[^@]+@\(([^)]+)\)""").findAll(text).forEach { m ->
             val info = m.groupValues.getOrNull(1).orEmpty().trim()
-            parseIndexedResourceRef(info)?.let { refs.add(it.resourceCode) }
+            parseIndexedResourceRef(info)?.let { ref ->
+                val fileInfo = if (ref.itemIndex != null) "${ref.resourceCode}.${ref.itemIndex}" else ref.resourceCode
+                refs.add(ref.resourceCode to fileInfo)
+            }
         }
         return refs
     }
@@ -416,11 +422,9 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     fun addTextResource(title: String, text: String, tagIds: List<Long>, characterIds: List<Long>) =
         viewModelScope.launch {
             if (characterIds.isEmpty()) return@launch
-            repo.addResource(
-                ResourceEntity(type = ResourceType.TEXT, title = title, quoteText = text),
-                tagIds,
-                characterIds
-            )
+            val created = ResourceEntity(type = ResourceType.TEXT, title = title, quoteText = text)
+            val newId = repo.addResource(created, tagIds, characterIds)
+            refreshTextUsageHistory(created.copy(id = newId), text)
         }
 
     fun addImageGroup(title: String, imageUris: List<Uri>, tagIds: List<Long>, characterIds: List<Long>) =
@@ -447,16 +451,14 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     fun addScene(title: String, description: String?, sceneJson: String, tagIds: List<Long>, characterIds: List<Long>) =
         viewModelScope.launch {
             if (characterIds.isEmpty()) return@launch
-            repo.addResource(
-                ResourceEntity(
-                    type = ResourceType.SCENE,
-                    title = title,
-                    quoteText = description,
-                    sceneJson = sceneJson
-                ),
-                tagIds,
-                characterIds
+            val created = ResourceEntity(
+                type = ResourceType.SCENE,
+                title = title,
+                quoteText = description,
+                sceneJson = sceneJson
             )
+            val newId = repo.addResource(created, tagIds, characterIds)
+            refreshTextUsageHistory(created.copy(id = newId), sceneJson)
         }
 
     fun addVideoGroup(title: String, uris: List<Uri>, tagIds: List<Long>, characterIds: List<Long>) =
@@ -599,10 +601,13 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         characterIds: List<Long>
     ) = viewModelScope.launch(Dispatchers.IO) {
         if (characterIds.isEmpty()) return@launch
+        val oldPaths = parseSimplePathList(resource.contentUriOrPath)
         val newUris = resolveSoundItems(items)
         if (newUris.isEmpty()) return@launch
         val payload = org.json.JSONArray(newUris).toString()
-        repo.updateResource(resource.copy(title = title, contentUriOrPath = payload))
+        val updated = resource.copy(title = title, contentUriOrPath = payload)
+        repo.updateResource(updated)
+        remapTextReferencesForMovedMedia(updated, oldPaths, parseSimplePathList(updated.contentUriOrPath))
         updateResourceTags(resource.id, tagIds)
         updateResourceCharacters(resource.id, characterIds)
     }


### PR DESCRIPTION
### Motivation
- Distinguish whole-resource references from per-file (indexed) references so UI and persistence can show where exactly a resource is used.
- Ensure that creating or saving text/scene resources rebuilds the usage binding (removing stale entries and inserting current ones).
- Show usage inline in the resource editor: whole-resource usage appended to the `资源ID` line, and per-file usage shown beneath the corresponding file/item ID in media lists.
- Keep indexed references correct when media items are reordered or moved (include sound groups in remapping).

### Description
- Changed `Repository.replaceTextResourceUsageHistory` to accept `Set<Pair<String,String>>` and persist `fileInfo` separately from `resourceCode` so entries can represent `i0001` and `i0001.2` distinctly (file: `Repository.kt`).
- Updated `ResourceViewModel.extractReferencedResourceCodes` to return `Set<Pair<String,String>>` and populate `fileInfo` with `"<code>.<index>"` when an indexed reference is parsed (file: `ResourceViewModel.kt`).
- Call `refreshTextUsageHistory` immediately after creating text/scene resources in `addTextResource` and `addScene` so usage history is rebuilt on create (file: `ResourceViewModel.kt`).
- Extended media-item remapping to `updateSoundGroup` so `code.index` references in texts are remapped on reorder/move, matching existing image/video behavior (file: `ResourceViewModel.kt`).
- Updated resource editor UI to compute whole-resource usages and per-file usages from `usageHistory`, append whole-resource text names to the `资源ID` line in red, and render per-file text names under individual image/video/sound item labels in red (file: `ResourceScreen.kt`).
- Changes span these files: `Repository.kt`, `ResourceViewModel.kt`, `ResourceScreen.kt`.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper download failed due to an environment proxy/network restriction returning `HTTP 403`, so compilation could not be validated in this environment.
- No automated unit tests were executed in this environment; changes were locally applied and code paths were exercised via static edits and search/replace checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae8e877eb0832bab3c17edd7833df0)