### PR TITLE
Fix text resource usage mapping to stable file URIs

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -2296,6 +2296,13 @@ private fun ResourceEditScreen(
                     .groupBy { it.fileInfo }
                     .mapValues { (_, usages) -> usages.distinctBy { it.textResourceId }.map { it.textTitle } }
             }
+
+            fun mediaUsageSuffix(path: String?): String? {
+                if (path.isNullOrBlank()) return null
+                return fileUsageTexts[path]
+                    ?.takeIf { it.isNotEmpty() }
+                    ?.joinToString("、")
+            }
             resourceCode?.let { code ->
                 val usageSuffix = wholeUsageTexts.takeIf { it.isNotEmpty() }?.joinToString("、")
                 Text(
@@ -2358,11 +2365,7 @@ private fun ResourceEditScreen(
                                     }
                                     Spacer(Modifier.width(12.dp))
                                     val fileId = indexedResourceFileId(resource.resource.resourceCode, index)
-                                    val imageUsageSuffix = fileId?.let { id ->
-                                        fileUsageTexts[id]
-                                            ?.takeIf { it.isNotEmpty() }
-                                            ?.joinToString("、")
-                                    }
+                                    val imageUsageSuffix = mediaUsageSuffix(item.path)
                                     Column(modifier = Modifier.weight(1f)) {
                                         Text(text = item.path?.let { fileId ?: "图片" } ?: "新图片 ${index + 1}")
                                         imageUsageSuffix?.let { suffix ->
@@ -2454,11 +2457,7 @@ private fun ResourceEditScreen(
                                     Spacer(Modifier.width(12.dp))
                                     val fileId = indexedResourceFileId(resource.resource.resourceCode, index)
                                     val label = item.path?.let { fileId ?: "视频" } ?: "新视频 ${index + 1}"
-                                    val videoUsageSuffix = fileId?.let { id ->
-                                        fileUsageTexts[id]
-                                            ?.takeIf { it.isNotEmpty() }
-                                            ?.joinToString("、")
-                                    }
+                                    val videoUsageSuffix = mediaUsageSuffix(item.path)
                                     Column(modifier = Modifier.weight(1f)) {
                                         Text(text = label)
                                         videoUsageSuffix?.let { suffix ->
@@ -2527,11 +2526,7 @@ private fun ResourceEditScreen(
                                     Spacer(Modifier.width(12.dp))
                                     val fileId = indexedResourceFileId(resource.resource.resourceCode, index)
                                     val label = item.path?.let { fileId ?: "音频 ${index + 1}" } ?: "新音频 ${index + 1}"
-                                    val soundUsageSuffix = fileId?.let { id ->
-                                        fileUsageTexts[id]
-                                            ?.takeIf { it.isNotEmpty() }
-                                            ?.joinToString("、")
-                                    }
+                                    val soundUsageSuffix = mediaUsageSuffix(item.path)
                                     Column(modifier = Modifier.weight(1f)) {
                                         Text(text = label)
                                         soundUsageSuffix?.let { suffix ->

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -342,22 +342,31 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
             onResult(repo.listUsageByResourceCode(resourceCode))
         }
 
+    private fun resolveUsageFileInfo(ref: IndexedResourceRef): String {
+        if (ref.itemIndex == null) return ref.resourceCode
+        val resource = allResources.value
+            .asSequence()
+            .map { it.resource }
+            .firstOrNull { it.resourceCode.equals(ref.resourceCode, ignoreCase = true) }
+            ?: return "${ref.resourceCode}.${ref.itemIndex}"
+        val selectedPath = extractResourceMediaSources(resource).getOrNull(ref.itemIndex - 1)
+        return selectedPath?.takeIf { it.isNotBlank() } ?: "${ref.resourceCode}.${ref.itemIndex}"
+    }
+
     private fun extractReferencedResourceCodes(text: String): Set<Pair<String, String>> {
         val refs = mutableSetOf<Pair<String, String>>()
         Regex("""\+资源:([^\n\r]+)""").findAll(text).forEach { m ->
             val raw = m.groupValues.getOrNull(1).orEmpty()
             raw.split(',', '&').map { it.trim() }.filter { it.isNotBlank() }.forEach { token ->
                 parseIndexedResourceRef(token)?.let { ref ->
-                    val fileInfo = if (ref.itemIndex != null) "${ref.resourceCode}.${ref.itemIndex}" else ref.resourceCode
-                    refs.add(ref.resourceCode to fileInfo)
+                    refs.add(ref.resourceCode to resolveUsageFileInfo(ref))
                 }
             }
         }
         Regex("""@[^@]+@\(([^)]+)\)""").findAll(text).forEach { m ->
             val info = m.groupValues.getOrNull(1).orEmpty().trim()
             parseIndexedResourceRef(info)?.let { ref ->
-                val fileInfo = if (ref.itemIndex != null) "${ref.resourceCode}.${ref.itemIndex}" else ref.resourceCode
-                refs.add(ref.resourceCode to fileInfo)
+                refs.add(ref.resourceCode to resolveUsageFileInfo(ref))
             }
         }
         return refs


### PR DESCRIPTION
### Motivation
- Text references that point to individual files were stored/matched by index (e.g. `i0002.3`), which breaks after reordering/moving media; single-file references must be resolved and stored by the actual media URI/path so the binding remains stable.

### Description
- Add `resolveUsageFileInfo(ref: IndexedResourceRef)` to resolve a single-file reference to the underlying media path (fallback to `code.index` when unresolved) in `ResourceViewModel.kt`.
- Use `resolveUsageFileInfo` from `extractReferencedResourceCodes` so `text_resource_usage_history.fileInfo` stores full media URI/path for `single` refs and keeps resource code for `all` refs.
- Update the resource edit UI (`ResourceScreen.kt`) by adding `mediaUsageSuffix(path: String?)` and changing usage lookups to match by `item.path` (full URI/path) for images, videos, and sounds so usage labels continue to follow files after moves/sorts.
- Skills: none — direct code edits were made, no external skill files were used.

### Testing
- Ran the unit test task `./gradlew testDebugUnitTest`, which failed because the Android SDK path is not configured in this environment (`sdk.dir` in `local.properties` is invalid), so automated unit tests could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af69f04234832ba78a0e6b8d52c222)