### PR TITLE
Preserve and migrate text usage history when a text resource title changes

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Dao.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Dao.kt
@@ -255,6 +255,10 @@ interface TextResourceUsageHistoryDao {
     @Query("DELETE FROM text_resource_usage_history WHERE textResourceId = :textResourceId")
     suspend fun deleteByTextResourceId(textResourceId: Long)
 
+    @Query("DELETE FROM text_resource_usage_history WHERE textResourceId = :textResourceId AND textTitle = :textTitle")
+    suspend fun deleteByTextResourceIdAndTitle(textResourceId: Long, textTitle: String)
+
+
     @Insert
     suspend fun insertAll(items: List<TextResourceUsageHistoryEntity>)
 }

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -265,6 +265,27 @@ class Repository private constructor(context: Context) {
             })
     }
 
+    suspend fun replaceTextResourceUsageTitle(
+        textResourceId: Long,
+        oldTitle: String,
+        newTitle: String
+    ) {
+        if (oldTitle == newTitle) return
+        val oldRecords = textUsageDao.listByTextResourceId(textResourceId).filter { it.textTitle == oldTitle }
+        if (oldRecords.isEmpty()) return
+        textUsageDao.deleteByTextResourceIdAndTitle(textResourceId, oldTitle)
+        val now = System.currentTimeMillis()
+        textUsageDao.insertAll(oldRecords.map {
+            TextResourceUsageHistoryEntity(
+                textResourceId = it.textResourceId,
+                textTitle = newTitle,
+                resourceCode = it.resourceCode,
+                fileInfo = it.fileInfo,
+                createdAt = now
+            )
+        })
+    }
+
     suspend fun listUsageByResourceCode(resourceCode: String): List<TextResourceUsageHistoryEntity> =
         textUsageDao.listByResourceCode(resourceCode)
 

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -2105,11 +2105,13 @@ private fun ResourceEditScreen(
     onBack: () -> Unit
 ) {
     var title by remember { mutableStateOf(resource.resource.title) }
+    val originalTitle = remember(resource.resource.id) { resource.resource.title }
     var selectedTags by remember { mutableStateOf(resource.tags.map { it.id }.toSet()) }
     var selectedCharacters by remember { mutableStateOf(resource.characters.map { it.id }.toSet()) }
     var showTagPicker by remember { mutableStateOf(false) }
     var showCharacterPicker by remember { mutableStateOf(false) }
     var textContent by remember { mutableStateOf(resource.resource.quoteText.orEmpty()) }
+    val originalTextContent = remember(resource.resource.id) { resource.resource.quoteText.orEmpty() }
     var description by remember { mutableStateOf(resource.resource.quoteText.orEmpty()) }
     var sceneMessages by remember { mutableStateOf(parseSceneMessages(resource.resource.sceneJson)) }
     var imageItems by remember {
@@ -2219,6 +2221,8 @@ private fun ResourceEditScreen(
                             )
                             ResourceType.TEXT -> vm.updateTextResource(
                                 resource.resource,
+                                originalTitle,
+                                originalTextContent,
                                 title.trim(),
                                 textContent.trim(),
                                 selectedTags.toList(),

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -560,6 +560,8 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
 
     fun updateTextResource(
         resource: ResourceEntity,
+        originalTitle: String,
+        originalText: String,
         title: String,
         text: String,
         tagIds: List<Long>,
@@ -568,7 +570,12 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         if (characterIds.isEmpty()) return@launch
         val updated = resource.copy(title = title, quoteText = text)
         repo.updateResource(updated)
-        refreshTextUsageHistory(updated, text)
+        if (originalTitle != title) {
+            repo.replaceTextResourceUsageTitle(resource.id, originalTitle, title)
+        }
+        if (originalText != text) {
+            refreshTextUsageHistory(updated, text)
+        }
         updateResourceTags(resource.id, tagIds)
         updateResourceCharacters(resource.id, characterIds)
     }


### PR DESCRIPTION
### Motivation
- Ensure that renaming a text resource preserves and re-associates its existing usage history instead of deleting all usage records for the resource when only the title changed.
- Avoid unnecessary re-scan of references when only the title changed, and only refresh usage history when the resource text actually changes.

### Description
- Added a new DAO query `deleteByTextResourceIdAndTitle` to remove usage rows that match both `textResourceId` and `textTitle`.
- Implemented `replaceTextResourceUsageTitle` in `Repository` to migrate matching usage records to a new title by deleting old-title rows and reinserting them with the new title and updated timestamps.
- Stored `originalTitle` and `originalTextContent` in `ResourceEditScreen` and passed them to the ViewModel when saving, so the ViewModel can detect title vs content changes.
- Updated `ResourceViewModel.updateTextResource` to call `repo.replaceTextResourceUsageTitle` only when the title changed and to call `refreshTextUsageHistory` only when the text content changed.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afa0928d00832b87387011f7893a20)