### PR TITLE
Fix MagicDrama TTS initialization race and language support checks

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -107,6 +107,7 @@ fun MagicDramaScreen(
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     var ttsReady by remember { mutableStateOf(false) }
+    var ttsSupported by remember { mutableStateOf(false) }
     val tts = remember {
         TextToSpeech(context) { status ->
             ttsReady = status == TextToSpeech.SUCCESS
@@ -131,11 +132,17 @@ fun MagicDramaScreen(
         countdownJob?.cancel()
         countdownJob = null
         if (settings.enableSpeech) {
-            tts.language = Locale.CHINA
+            while (!ttsReady) {
+                delay(50)
+            }
+            val languageStatus = tts.setLanguage(Locale.CHINESE)
+            ttsSupported = languageStatus != TextToSpeech.LANG_MISSING_DATA &&
+                languageStatus != TextToSpeech.LANG_NOT_SUPPORTED
             tts.setSpeechRate(settings.speechRate)
             tts.setPitch(settings.speechPitch)
         } else {
             tts.stop()
+            ttsSupported = false
         }
 
         val queue = ArrayDeque(parsed.main)
@@ -144,7 +151,7 @@ fun MagicDramaScreen(
                 is DramaCommand.Narration -> {
                     val text = renderRandomToken(cmd.text)
                     messages += DramaMessage.Narration(text = text, important = cmd.important)
-                    if (settings.enableSpeech && ttsReady) {
+                    if (settings.enableSpeech && ttsSupported) {
                         tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "narration_${messages.size}")
                     }
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
@@ -153,7 +160,7 @@ fun MagicDramaScreen(
                     val role = resolveRoleName(cmd.roleKey, boundCharacters)
                     val text = cmd.text.replace("nn", "\n")
                     messages += DramaMessage.Role(role = role, text = text)
-                    if (settings.enableSpeech && ttsReady) {
+                    if (settings.enableSpeech && ttsSupported) {
                         tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "role_${messages.size}")
                     }
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)


### PR DESCRIPTION
### Motivation
- The MagicDrama auto-read feature could call `TextToSpeech.speak` before the TTS engine finished initializing, and it did not validate whether the requested language data was available, causing silent playback.

### Description
- Add a `ttsSupported` flag and wait for `ttsReady` before configuring and using TTS by polling with `delay(50)` until initialization completes.
- Validate language availability using `tts.setLanguage(Locale.CHINESE)` and only allow `speak` when the language status is not `LANG_MISSING_DATA` or `LANG_NOT_SUPPORTED`.
- Use `ttsSupported` in place of the prior `ttsReady` checks when invoking `speak`, and reset `ttsSupported` to `false` when speech is disabled.
- Changes are confined to `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt` and preserve existing rate/pitch settings behavior.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, but the build could not proceed in this environment because the Gradle distribution download was blocked by a proxy (`HTTP/1.1 403 Forbidden`), so automated compilation could not be validated.
- No other automated tests were run in this environment due to the same network restriction.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afaba108d4832b8b0ae2c4c125c7ea)