### PR TITLE
feat: replace Android TTS with Piper voice settings for Magic Drama

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.VolumeUp
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
@@ -90,6 +91,12 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     var deleteTag by remember { mutableStateOf<TagEntity?>(null) }
     var selectedParentTag by remember { mutableStateOf<SelectedParentTagContext?>(null) }
     var showSubTagDialog by remember { mutableStateOf(false) }
+    var showVoiceSettings by remember { mutableStateOf(false) }
+
+    if (showVoiceSettings) {
+        VoiceSettingsScreen(onBack = { showVoiceSettings = false })
+        return
+    }
 
     val isInCategory = ui.currentCategory != null
     val linkedCategoryName = remember(ui.currentCategory) { extractLinkedCategoryName(ui.currentCategory?.name) }
@@ -155,6 +162,13 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                             }
                         }) {
                             Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                        }
+                    }
+                },
+                actions = {
+                    if (!isInCategory && !isInSubTagPage) {
+                        IconButton(onClick = { showVoiceSettings = true }) {
+                            Icon(Icons.Default.VolumeUp, contentDescription = "声音设置")
                         }
                     }
                 }

--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -1,0 +1,217 @@
+package com.example.quotepicker.ui
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material3.AssistChip
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenu
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.quotepicker.util.RoleVoiceSetting
+import com.example.quotepicker.util.VoiceProfile
+import com.example.quotepicker.vm.VoiceSettingsViewModel
+import androidx.compose.runtime.collectAsState
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VoiceSettingsScreen(
+    onBack: () -> Unit,
+    vm: VoiceSettingsViewModel = viewModel()
+) {
+    val ui by vm.uiState.collectAsState()
+    var newProfileName by remember { mutableStateOf("") }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("声音设置（Piper + ONNX，仅中文）") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "返回")
+                    }
+                }
+            )
+        }
+    ) { inner ->
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(inner)
+                .padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            item {
+                Text("音色库")
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    OutlinedTextField(
+                        value = newProfileName,
+                        onValueChange = { newProfileName = it },
+                        modifier = Modifier.weight(1f),
+                        label = { Text("新增音色名称") },
+                        singleLine = true
+                    )
+                    AssistChip(
+                        onClick = {
+                            vm.addProfile(newProfileName)
+                            newProfileName = ""
+                        },
+                        label = { Text("添加") }
+                    )
+                }
+            }
+            items(ui.settings.profiles, key = { it.id }) { profile ->
+                VoiceProfileEditor(
+                    profile = profile,
+                    onUpdate = vm::updateProfile,
+                    onDelete = { vm.removeProfile(profile.id) }
+                )
+            }
+
+            item { Text("角色绑定（旁白也按角色处理）") }
+            item {
+                RoleVoiceSettingRow(
+                    roleName = ui.narratorName,
+                    allProfiles = ui.settings.profiles,
+                    initial = ui.settings.roleSettings.firstOrNull { it.roleName == ui.narratorName },
+                    onSave = { vm.updateRoleSetting(ui.narratorName, it.profileId, it.speechRate) }
+                )
+            }
+            items(ui.characterNames, key = { it }) { roleName ->
+                RoleVoiceSettingRow(
+                    roleName = roleName,
+                    allProfiles = ui.settings.profiles,
+                    initial = ui.settings.roleSettings.firstOrNull { it.roleName == roleName },
+                    onSave = { vm.updateRoleSetting(roleName, it.profileId, it.speechRate) }
+                )
+            }
+            item {
+                Text("可上传参考音频（实验）：用于记录你的自定义音色来源，训练/转换后将ONNX模型与JSON配置导入到对应音色。")
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun RoleVoiceSettingRow(
+    roleName: String,
+    allProfiles: List<VoiceProfile>,
+    initial: RoleVoiceSetting?,
+    onSave: (RoleVoiceSetting) -> Unit
+) {
+    var expanded by remember(roleName, allProfiles) { mutableStateOf(false) }
+    var profileId by remember(roleName, initial?.profileId) { mutableStateOf(initial?.profileId) }
+    var speed by remember(roleName, initial?.speechRate) { mutableStateOf(initial?.speechRate ?: 1.0f) }
+    Column {
+        Text(roleName)
+        ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = !expanded }) {
+            OutlinedTextField(
+                value = allProfiles.firstOrNull { it.id == profileId }?.name ?: "未设置",
+                onValueChange = {},
+                readOnly = true,
+                label = { Text("音色") },
+                trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .menuAnchor()
+            )
+            ExposedDropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+                DropdownMenuItem(text = { Text("未设置") }, onClick = {
+                    profileId = null
+                    expanded = false
+                    onSave(RoleVoiceSetting(roleName = roleName, profileId = null, speechRate = speed))
+                })
+                allProfiles.forEach { profile ->
+                    DropdownMenuItem(text = { Text(profile.name) }, onClick = {
+                        profileId = profile.id
+                        expanded = false
+                        onSave(RoleVoiceSetting(roleName = roleName, profileId = profile.id, speechRate = speed))
+                    })
+                }
+            }
+        }
+        Row {
+            Text("语速 ${"%.2f".format(speed)}")
+            Spacer(modifier = Modifier.width(8.dp))
+            Slider(
+                value = speed,
+                onValueChange = {
+                    speed = it
+                    onSave(RoleVoiceSetting(roleName = roleName, profileId = profileId, speechRate = it))
+                },
+                valueRange = 0.6f..1.8f,
+                modifier = Modifier.weight(1f)
+            )
+        }
+    }
+}
+
+@Composable
+private fun VoiceProfileEditor(
+    profile: VoiceProfile,
+    onUpdate: (VoiceProfile) -> Unit,
+    onDelete: () -> Unit
+) {
+    val context = LocalContext.current
+    val modelLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+        uri?.let {
+            context.contentResolver.takePersistableUriPermission(it, android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            onUpdate(profile.copy(modelUri = it.toString()))
+        }
+    }
+    val configLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+        uri?.let {
+            context.contentResolver.takePersistableUriPermission(it, android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            onUpdate(profile.copy(configUri = it.toString()))
+        }
+    }
+    val refLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+        uri?.let {
+            context.contentResolver.takePersistableUriPermission(it, android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
+            onUpdate(profile.copy(referenceAudioUri = it.toString()))
+        }
+    }
+    Column {
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Text(profile.name)
+            IconButton(onClick = onDelete) { Icon(Icons.Default.Delete, contentDescription = "删除音色") }
+        }
+        AssistChip(onClick = { modelLauncher.launch(arrayOf("*/*")) }, label = { Text("导入ONNX模型") })
+        AssistChip(onClick = { configLauncher.launch(arrayOf("application/json", "text/plain", "*/*")) }, label = { Text("导入配置JSON") })
+        AssistChip(onClick = { refLauncher.launch(arrayOf("audio/*")) }, label = { Text("上传参考音频(实验)") })
+        Text("模型: ${profile.modelUri.ifBlank { "未导入" }}")
+        Text("配置: ${profile.configUri.ifBlank { "未导入" }}")
+    }
+}

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -1,9 +1,6 @@
 package com.example.quotepicker.ui.components
 
 import android.net.Uri
-import android.speech.tts.TextToSpeech
-import android.speech.tts.UtteranceProgressListener
-import android.util.Log
 import android.widget.VideoView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -18,6 +15,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.weight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -53,21 +51,18 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.example.quotepicker.data.CharacterEntity
 import com.example.quotepicker.data.ResourceType
+import com.example.quotepicker.util.PiperSpeechEngine
+import com.example.quotepicker.util.VoiceSettingsStore
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withTimeoutOrNull
 import org.json.JSONArray
-import java.util.Locale
 
 data class MagicDramaSettings(
     val defaultDelayMs: Long = 1000L,
-    val imageIntervalMs: Long = 3000L,
-    val enableSpeech: Boolean = true,
-    val speechRate: Float = 1.0f,
-    val speechPitch: Float = 1.0f
+    val imageIntervalMs: Long = 3000L
 )
 
 private sealed interface DramaCommand {
@@ -89,11 +84,6 @@ private sealed interface DramaMedia {
     data class Resource(val source: String) : DramaMedia
 }
 
-private const val TTS_TAG = "MagicDramaTTS"
-
-private fun isLanguageAvailable(status: Int): Boolean =
-    status != TextToSpeech.LANG_MISSING_DATA && status != TextToSpeech.LANG_NOT_SUPPORTED
-
 @Composable
 fun MagicDramaScreen(
     title: String,
@@ -114,39 +104,18 @@ fun MagicDramaScreen(
     val parsed = remember(script) { parseDramaScript(script) }
     val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
-    var ttsReady by remember { mutableStateOf(false) }
-    var ttsInitialized by remember { mutableStateOf(false) }
-    var ttsSupported by remember { mutableStateOf(false) }
-    val tts = remember {
-        TextToSpeech(context) { status ->
-            ttsInitialized = true
-            ttsReady = status == TextToSpeech.SUCCESS
-            Log.i(TTS_TAG, "init status=$status ready=$ttsReady")
-        }.apply {
-            setOnUtteranceProgressListener(object : UtteranceProgressListener() {
-                override fun onStart(utteranceId: String?) = Unit
-                override fun onDone(utteranceId: String?) = Unit
-                @Deprecated("Deprecated in Java")
-                override fun onError(utteranceId: String?) {
-                    Log.e(TTS_TAG, "utterance error id=$utteranceId")
-                }
-                override fun onError(utteranceId: String?, errorCode: Int) {
-                    Log.e(TTS_TAG, "utterance error id=$utteranceId code=$errorCode")
-                }
-            })
-        }
-    }
+    val voiceSettingsStore = remember(context) { VoiceSettingsStore(context) }
+    val piperSpeechEngine = remember(context) { PiperSpeechEngine(context) }
+    val voiceSettings = remember { voiceSettingsStore.load() }
 
     DisposableEffect(Unit) {
         onDispose {
             countdownJob?.cancel()
             pendingBranch?.cancel()
-            tts.stop()
-            tts.shutdown()
         }
     }
 
-    LaunchedEffect(script, settings.defaultDelayMs, settings.enableSpeech, settings.speechRate, settings.speechPitch) {
+    LaunchedEffect(script, settings.defaultDelayMs, voiceSettings) {
         messages.clear()
         currentMedia = null
         countdownSeconds = null
@@ -154,49 +123,16 @@ fun MagicDramaScreen(
         pendingBranch = null
         countdownJob?.cancel()
         countdownJob = null
-        if (settings.enableSpeech) {
-            if (!ttsInitialized) {
-                withTimeoutOrNull(1500) {
-                    while (!ttsInitialized) {
-                        delay(50)
-                    }
-                }
-            }
-            if (ttsReady) {
-                val candidateLocales = listOf(Locale.SIMPLIFIED_CHINESE, Locale.CHINESE, Locale.getDefault()).distinct()
-                val selectedLocale = candidateLocales.firstOrNull { locale ->
-                    val status = tts.setLanguage(locale)
-                    Log.i(TTS_TAG, "try locale=$locale status=$status")
-                    isLanguageAvailable(status)
-                }
-                ttsSupported = selectedLocale != null
-                if (ttsSupported) {
-                    tts.setSpeechRate(settings.speechRate)
-                    tts.setPitch(settings.speechPitch)
-                    Log.i(TTS_TAG, "tts ready engine=${tts.defaultEngine} locale=$selectedLocale")
-                } else {
-                    Log.e(TTS_TAG, "no supported locale for engine=${tts.defaultEngine}")
-                }
-            } else {
-                ttsSupported = false
-                Log.e(TTS_TAG, "tts init did not succeed, skip speech")
-            }
-        } else {
-            tts.stop()
-            ttsSupported = false
-        }
-
         val queue = ArrayDeque(parsed.main)
         while (queue.isNotEmpty()) {
             when (val cmd = queue.removeFirst()) {
                 is DramaCommand.Narration -> {
                     val text = renderRandomToken(cmd.text)
                     messages += DramaMessage.Narration(text = text, important = cmd.important)
-                    if (settings.enableSpeech && ttsSupported) {
-                        val speakStatus = tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "narration_${messages.size}")
-                        if (speakStatus == TextToSpeech.ERROR) {
-                            Log.e(TTS_TAG, "speak failed for narration")
-                        }
+                    val narratorSetting = voiceSettings.roleSettings.firstOrNull { it.roleName == "旁白" }
+                    val narratorProfile = voiceSettings.profiles.firstOrNull { it.id == narratorSetting?.profileId }
+                    if (narratorProfile != null) {
+                        piperSpeechEngine.speak(text, narratorProfile, narratorSetting?.speechRate ?: 1.0f)
                     }
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
                 }
@@ -204,11 +140,10 @@ fun MagicDramaScreen(
                     val role = resolveRoleName(cmd.roleKey, boundCharacters)
                     val text = cmd.text.replace("nn", "\n")
                     messages += DramaMessage.Role(role = role, text = text)
-                    if (settings.enableSpeech && ttsSupported) {
-                        val speakStatus = tts.speak(text, TextToSpeech.QUEUE_FLUSH, null, "role_${messages.size}")
-                        if (speakStatus == TextToSpeech.ERROR) {
-                            Log.e(TTS_TAG, "speak failed for role=$role")
-                        }
+                    val roleSetting = voiceSettings.roleSettings.firstOrNull { it.roleName == role }
+                    val roleProfile = voiceSettings.profiles.firstOrNull { it.id == roleSetting?.profileId }
+                    if (roleProfile != null) {
+                        piperSpeechEngine.speak(text, roleProfile, roleSetting?.speechRate ?: 1.0f)
                     }
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
                 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Switch
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -280,9 +279,6 @@ fun ResourcePreviewScreen(
                                 var showMagicDrama by remember(liveResource.resource.id) { mutableStateOf(false) }
                                 var defaultDelayInput by remember(liveResource.resource.id) { mutableStateOf("3000") }
                                 var imageIntervalInput by remember(liveResource.resource.id) { mutableStateOf("3000") }
-                                var enableSpeech by remember(liveResource.resource.id) { mutableStateOf(true) }
-                                var speechRateInput by remember(liveResource.resource.id) { mutableStateOf("1.0") }
-                                var speechPitchInput by remember(liveResource.resource.id) { mutableStateOf("1.0") }
                                 if (showMagicDrama) {
                                     MagicDramaScreen(
                                         title = liveResource.resource.title,
@@ -290,10 +286,7 @@ fun ResourcePreviewScreen(
                                         boundCharacters = liveResource.characters,
                                         settings = MagicDramaSettings(
                                             defaultDelayMs = defaultDelayInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 1000L,
-                                            imageIntervalMs = imageIntervalInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 3000L,
-                                            enableSpeech = enableSpeech,
-                                            speechRate = speechRateInput.toFloatOrNull()?.coerceIn(0.5f, 2.0f) ?: 1.0f,
-                                            speechPitch = speechPitchInput.toFloatOrNull()?.coerceIn(0.5f, 2.0f) ?: 1.0f
+                                            imageIntervalMs = imageIntervalInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 3000L
                                         ),
                                         vm = vm,
                                         onClose = { showMagicDrama = false }
@@ -308,21 +301,10 @@ fun ResourcePreviewScreen(
                                             Text("开始魔剧")
                                         }
                                         Text(
-                                            text = "播放设置（开始前设置）",
+                                            text = "播放设置（声音请到标签页右上角“声音设置”中配置）",
                                             style = MaterialTheme.typography.labelMedium,
                                             color = Color(0xFF5F6280)
                                         )
-                                        Row(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            horizontalArrangement = Arrangement.SpaceBetween,
-                                            verticalAlignment = Alignment.CenterVertically
-                                        ) {
-                                            Text("文本显示时朗读")
-                                            Switch(
-                                                checked = enableSpeech,
-                                                onCheckedChange = { enableSpeech = it }
-                                            )
-                                        }
                                         OutlinedTextField(
                                             value = defaultDelayInput,
                                             onValueChange = { defaultDelayInput = it },
@@ -337,24 +319,6 @@ fun ResourcePreviewScreen(
                                             label = { Text("图片轮播毫秒(300-10000)") },
                                             modifier = Modifier.fillMaxWidth()
                                         )
-                                        if (enableSpeech) {
-                                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
-                                                OutlinedTextField(
-                                                    value = speechRateInput,
-                                                    onValueChange = { speechRateInput = it },
-                                                    singleLine = true,
-                                                    label = { Text("语速0.5-2") },
-                                                    modifier = Modifier.weight(1f)
-                                                )
-                                                OutlinedTextField(
-                                                    value = speechPitchInput,
-                                                    onValueChange = { speechPitchInput = it },
-                                                    singleLine = true,
-                                                    label = { Text("音调0.5-2") },
-                                                    modifier = Modifier.weight(1f)
-                                                )
-                                            }
-                                        }
                                     }
                                 } else {
                                     if (quoteText.isNotBlank()) {

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -1,0 +1,78 @@
+package com.example.quotepicker.util
+
+import android.content.Context
+import android.media.MediaPlayer
+import android.net.Uri
+import android.util.Log
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import java.io.File
+import kotlin.coroutines.resume
+
+private const val PIPER_TAG = "PiperSpeech"
+
+class PiperSpeechEngine(private val context: Context) {
+    suspend fun speak(text: String, profile: VoiceProfile, speechRate: Float): Boolean {
+        if (text.isBlank() || profile.modelUri.isBlank() || profile.configUri.isBlank()) return false
+        val output = withContext(Dispatchers.IO) {
+            val modelFile = copyUriToCache(profile.modelUri, "model_${profile.id}.onnx") ?: return@withContext null
+            val configFile = copyUriToCache(profile.configUri, "config_${profile.id}.json") ?: return@withContext null
+            val outFile = File(context.cacheDir, "piper_${System.currentTimeMillis()}.wav")
+            val lengthScale = (1f / speechRate.coerceIn(0.6f, 1.8f)).toString()
+            val process = ProcessBuilder(
+                "piper",
+                "--model", modelFile.absolutePath,
+                "--config", configFile.absolutePath,
+                "--output_file", outFile.absolutePath,
+                "--length_scale", lengthScale
+            ).redirectErrorStream(true).start()
+            process.outputStream.bufferedWriter().use {
+                it.write(text)
+                it.newLine()
+            }
+            val exit = process.waitFor()
+            if (exit != 0 || !outFile.exists()) {
+                Log.e(PIPER_TAG, "piper execute failed exit=$exit")
+                null
+            } else {
+                outFile
+            }
+        } ?: return false
+
+        return playFile(output)
+    }
+
+    private fun copyUriToCache(rawUri: String, fileName: String): File? {
+        val uri = Uri.parse(rawUri)
+        return runCatching {
+            val out = File(context.cacheDir, fileName)
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                out.outputStream().use { output -> input.copyTo(output) }
+            } ?: return null
+            out
+        }.getOrNull()
+    }
+
+    private suspend fun playFile(file: File): Boolean = suspendCancellableCoroutine { cont ->
+        val player = MediaPlayer()
+        runCatching {
+            player.setDataSource(file.absolutePath)
+            player.setOnCompletionListener {
+                it.release()
+                if (cont.isActive) cont.resume(true)
+            }
+            player.setOnErrorListener { mp, _, _ ->
+                mp.release()
+                if (cont.isActive) cont.resume(false)
+                true
+            }
+            player.prepare()
+            player.start()
+            cont.invokeOnCancellation { player.release() }
+        }.onFailure {
+            player.release()
+            if (cont.isActive) cont.resume(false)
+        }
+    }
+}

--- a/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
+++ b/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
@@ -1,0 +1,120 @@
+package com.example.quotepicker.util
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
+
+data class VoiceProfile(
+    val id: String,
+    val name: String,
+    val modelUri: String,
+    val configUri: String,
+    val referenceAudioUri: String? = null
+)
+
+data class RoleVoiceSetting(
+    val roleName: String,
+    val profileId: String? = null,
+    val speechRate: Float = 1.0f
+)
+
+data class VoiceSettings(
+    val profiles: List<VoiceProfile> = emptyList(),
+    val roleSettings: List<RoleVoiceSetting> = emptyList()
+)
+
+class VoiceSettingsStore(context: Context) {
+    private val prefs = context.applicationContext.getSharedPreferences("voice_settings", Context.MODE_PRIVATE)
+
+    fun load(): VoiceSettings {
+        val raw = prefs.getString(KEY_PAYLOAD, null) ?: return VoiceSettings()
+        return runCatching {
+            val root = JSONObject(raw)
+            val profiles = root.optJSONArray("profiles").toProfiles()
+            val roleSettings = root.optJSONArray("roleSettings").toRoleSettings()
+            VoiceSettings(profiles = profiles, roleSettings = roleSettings)
+        }.getOrDefault(VoiceSettings())
+    }
+
+    fun save(settings: VoiceSettings) {
+        val root = JSONObject()
+            .put("profiles", JSONArray().apply {
+                settings.profiles.forEach { profile ->
+                    put(
+                        JSONObject()
+                            .put("id", profile.id)
+                            .put("name", profile.name)
+                            .put("modelUri", profile.modelUri)
+                            .put("configUri", profile.configUri)
+                            .put("referenceAudioUri", profile.referenceAudioUri ?: "")
+                    )
+                }
+            })
+            .put("roleSettings", JSONArray().apply {
+                settings.roleSettings.forEach { item ->
+                    put(
+                        JSONObject()
+                            .put("roleName", item.roleName)
+                            .put("profileId", item.profileId ?: "")
+                            .put("speechRate", item.speechRate)
+                    )
+                }
+            })
+        prefs.edit().putString(KEY_PAYLOAD, root.toString()).apply()
+    }
+
+    fun ensureProfile(name: String): VoiceProfile {
+        val settings = load()
+        val existing = settings.profiles.firstOrNull { it.name == name }
+        if (existing != null) return existing
+        val created = VoiceProfile(
+            id = UUID.randomUUID().toString(),
+            name = name,
+            modelUri = "",
+            configUri = ""
+        )
+        save(settings.copy(profiles = settings.profiles + created))
+        return created
+    }
+
+    companion object {
+        private const val KEY_PAYLOAD = "payload"
+    }
+}
+
+private fun JSONArray?.toProfiles(): List<VoiceProfile> {
+    if (this == null) return emptyList()
+    return buildList {
+        for (i in 0 until length()) {
+            val item = optJSONObject(i) ?: continue
+            add(
+                VoiceProfile(
+                    id = item.optString("id"),
+                    name = item.optString("name"),
+                    modelUri = item.optString("modelUri"),
+                    configUri = item.optString("configUri"),
+                    referenceAudioUri = item.optString("referenceAudioUri").ifBlank { null }
+                )
+            )
+        }
+    }
+}
+
+private fun JSONArray?.toRoleSettings(): List<RoleVoiceSetting> {
+    if (this == null) return emptyList()
+    return buildList {
+        for (i in 0 until length()) {
+            val item = optJSONObject(i) ?: continue
+            val role = item.optString("roleName")
+            if (role.isBlank()) continue
+            add(
+                RoleVoiceSetting(
+                    roleName = role,
+                    profileId = item.optString("profileId").ifBlank { null },
+                    speechRate = item.optDouble("speechRate", 1.0).toFloat()
+                )
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
@@ -1,0 +1,86 @@
+package com.example.quotepicker.vm
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.quotepicker.data.Repository
+import com.example.quotepicker.util.RoleVoiceSetting
+import com.example.quotepicker.util.VoiceProfile
+import com.example.quotepicker.util.VoiceSettings
+import com.example.quotepicker.util.VoiceSettingsStore
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.util.UUID
+
+data class VoiceSettingsUiState(
+    val characterNames: List<String> = emptyList(),
+    val narratorName: String = "旁白",
+    val settings: VoiceSettings = VoiceSettings()
+)
+
+class VoiceSettingsViewModel(application: Application) : AndroidViewModel(application) {
+    private val repo = Repository.get(application)
+    private val store = VoiceSettingsStore(application)
+    private val localSettings = MutableStateFlow(store.load())
+
+    val uiState: StateFlow<VoiceSettingsUiState> = combine(
+        repo.observeCharacters(),
+        localSettings
+    ) { characters, settings ->
+        VoiceSettingsUiState(
+            characterNames = characters.map { it.name },
+            settings = settings
+        )
+    }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), VoiceSettingsUiState())
+
+    fun addProfile(name: String) {
+        val finalName = name.trim().ifBlank { "音色${System.currentTimeMillis() % 10000}" }
+        localSettings.update {
+            it.copy(
+                profiles = it.profiles + VoiceProfile(
+                    id = UUID.randomUUID().toString(),
+                    name = finalName,
+                    modelUri = "",
+                    configUri = ""
+                )
+            )
+        }
+        persist()
+    }
+
+    fun updateProfile(profile: VoiceProfile) {
+        localSettings.update { state ->
+            state.copy(profiles = state.profiles.map { if (it.id == profile.id) profile else it })
+        }
+        persist()
+    }
+
+    fun removeProfile(profileId: String) {
+        localSettings.update { state ->
+            state.copy(
+                profiles = state.profiles.filterNot { it.id == profileId },
+                roleSettings = state.roleSettings.map {
+                    if (it.profileId == profileId) it.copy(profileId = null) else it
+                }
+            )
+        }
+        persist()
+    }
+
+    fun updateRoleSetting(roleName: String, profileId: String?, speechRate: Float) {
+        localSettings.update { state ->
+            val cleaned = state.roleSettings.filterNot { it.roleName == roleName }
+            state.copy(roleSettings = cleaned + RoleVoiceSetting(roleName = roleName, profileId = profileId, speechRate = speechRate))
+        }
+        persist()
+    }
+
+    private fun persist() {
+        viewModelScope.launch { store.save(localSettings.value) }
+    }
+}


### PR DESCRIPTION
### Motivation

- The app previously depended on the Android `TextToSpeech` engine which may be unavailable on some devices, so Magic Drama narration must be preserved using a Piper + ONNX workflow and only Chinese voices.  
- Provide a centrally managed, per-role voice/profile UI so users can pick imported ONNX models and per-role speech rates (the narrator `旁白` is treated as a role).  
- Move voice configuration out of the Magic Drama preview controls and into a dedicated settings screen with an entry point on the Tag category page.

### Description

- Removed runtime use of Android `TextToSpeech` in `MagicDramaScreen` and instead resolve role voice settings and call a new `PiperSpeechEngine` to synthesize and play WAV output from imported ONNX model + JSON config.  
- Added a `VoiceSettingsStore` (persisted JSON in `SharedPreferences`), `VoiceSettingsViewModel`, and a `VoiceSettingsScreen` UI to manage voice profiles, import ONNX model/config, upload reference audio (experimental), and bind profiles + speech rate to each role (including `旁白`).  
- Added `PiperSpeechEngine` which copies model/config URIs to cache, invokes a `piper` CLI process to produce an output WAV, and plays it with `MediaPlayer`.  
- Updated UI wiring: added a Volume icon action on the Tag category page (`TagScreen`) to open `VoiceSettingsScreen`, and removed the old TTS enable/voice-rate/pitch controls from the Magic Drama preview UI (`ResourcePreviewScreen`), replacing them with a hint to configure voices in the new settings screen.

### Testing

- Ran a local compile check attempt with `./gradlew :app:compileDebugKotlin`, which failed due to environment proxy blocking Gradle distribution download (`HTTP/1.1 403 Forbidden`) and not due to code errors in the changes.  
- Performed automated code searches (`rg`) to confirm `TextToSpeech` references were removed from runtime paths and that new symbols (`PiperSpeechEngine`, `VoiceSettingsStore`, `VoiceSettingsViewModel`, `VoiceSettingsScreen`) are present.  
- Committed the changes (`git commit`) after implementing the new modules and UI wiring.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afbe6b9920832ba5fbf5235c83b551)