### PR TITLE
移除“上传参考音频（实验）”功能并清理相关存储字段

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -117,7 +117,7 @@ fun VoiceSettingsScreen(
                 )
             }
             item {
-                Text("可上传参考音频（实验）：用于记录你的自定义音色来源，训练/转换后将ONNX模型与JSON配置导入到对应音色。")
+                Text("请为音色导入ONNX模型与JSON配置。")
             }
         }
     }
@@ -197,12 +197,6 @@ private fun VoiceProfileEditor(
             onUpdate(profile.copy(configUri = it.toString()))
         }
     }
-    val refLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
-        uri?.let {
-            context.contentResolver.takePersistableUriPermission(it, android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
-            onUpdate(profile.copy(referenceAudioUri = it.toString()))
-        }
-    }
     Column {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             Text(profile.name)
@@ -210,7 +204,6 @@ private fun VoiceProfileEditor(
         }
         AssistChip(onClick = { modelLauncher.launch(arrayOf("*/*")) }, label = { Text("导入ONNX模型") })
         AssistChip(onClick = { configLauncher.launch(arrayOf("application/json", "text/plain", "*/*")) }, label = { Text("导入配置JSON") })
-        AssistChip(onClick = { refLauncher.launch(arrayOf("audio/*")) }, label = { Text("上传参考音频(实验)") })
         Text("模型: ${profile.modelUri.ifBlank { "未导入" }}")
         Text("配置: ${profile.configUri.ifBlank { "未导入" }}")
     }

--- a/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
+++ b/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
@@ -9,8 +9,7 @@ data class VoiceProfile(
     val id: String,
     val name: String,
     val modelUri: String,
-    val configUri: String,
-    val referenceAudioUri: String? = null
+    val configUri: String
 )
 
 data class RoleVoiceSetting(
@@ -47,7 +46,6 @@ class VoiceSettingsStore(context: Context) {
                             .put("name", profile.name)
                             .put("modelUri", profile.modelUri)
                             .put("configUri", profile.configUri)
-                            .put("referenceAudioUri", profile.referenceAudioUri ?: "")
                     )
                 }
             })
@@ -93,8 +91,7 @@ private fun JSONArray?.toProfiles(): List<VoiceProfile> {
                     id = item.optString("id"),
                     name = item.optString("name"),
                     modelUri = item.optString("modelUri"),
-                    configUri = item.optString("configUri"),
-                    referenceAudioUri = item.optString("referenceAudioUri").ifBlank { null }
+                    configUri = item.optString("configUri")
                 )
             )
         }


### PR DESCRIPTION
### Motivation
- 移除不再需要的“上传参考音频（实验）”功能以简化声音设置界面和功能集。 
- 精简音色数据结构，避免在配置中保留未使用的参考音频 URI 字段。 
- 保持现有模型/配置加载逻辑，以 URI 方式引用模型与配置文件并在运行时复制到缓存使用。 

### Description
- 从 `VoiceSettingsScreen.kt` 中删除了实验性说明文案和用于上传参考音频的 `AssistChip` 及其 `refLauncher` 逻辑，使界面仅保留“导入ONNX模型 / 导入配置JSON”。
- 从 `VoiceProfile` 数据类中移除 `referenceAudioUri` 字段，并相应更新 `VoiceSettingsStore.kt` 的序列化与反序列化逻辑，停止写入/读取该字段。
- 更新 `VoiceSettingsStore` 的 JSON 保存格式，不再包含 `referenceAudioUri` 键，仅保留 `modelUri` 与 `configUri` 等字段。
- 保持 `PiperSpeechEngine` 的现有行为不变，模型与配置仍通过 `modelUri` / `configUri` 的 URI 持久化保存，并在合成时复制到 `cacheDir` 以供 `piper` 调用。 

### Testing
- 运行代码搜索以确认引用已移除：`rg -n "referenceAudioUri|上传参考音频|可上传参考音频"`，检索结果显示相关项已删除（成功）。
- 尝试构建 `./gradlew :app:assembleDebug` 以进行完整编译验证，但在当前环境中下载 Gradle 分发包时受到代理限制返回 `HTTP/1.1 403 Forbidden`，导致构建未完成（失败）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afc1fcde68832ba1e9102ae6fb147f)