### PR TITLE
Support built-in fanchen ONNX voice and advanced Piper options

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenu
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
@@ -29,18 +30,20 @@ import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.input.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.util.RoleVoiceSetting
 import com.example.quotepicker.util.VoiceProfile
 import com.example.quotepicker.vm.VoiceSettingsViewModel
-import androidx.compose.runtime.collectAsState
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -115,7 +118,7 @@ fun VoiceSettingsScreen(
                 )
             }
             item {
-                Text("请为音色导入ONNX模型与JSON配置。")
+                Text("ONNX 必填；JSON 配置可选（vits-zh-hf-fanchen-C.onnx 可不提供 json）。")
             }
         }
     }
@@ -183,6 +186,11 @@ private fun VoiceProfileEditor(
     onDelete: () -> Unit
 ) {
     val context = LocalContext.current
+    var speakerText by remember(profile.id, profile.speakerId) { mutableStateOf(profile.speakerId?.toString() ?: "") }
+    var noiseScaleText by remember(profile.id, profile.noiseScale) { mutableStateOf(profile.noiseScale?.toString() ?: "") }
+    var noiseWText by remember(profile.id, profile.noiseW) { mutableStateOf(profile.noiseW?.toString() ?: "") }
+    var sentenceSilenceText by remember(profile.id, profile.sentenceSilence) { mutableStateOf(profile.sentenceSilence?.toString() ?: "") }
+
     val modelLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
         uri?.let {
             context.contentResolver.takePersistableUriPermission(it, android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION)
@@ -195,14 +203,71 @@ private fun VoiceProfileEditor(
             onUpdate(profile.copy(configUri = it.toString()))
         }
     }
-    Column {
+
+    fun saveAdvanced() {
+        onUpdate(
+            profile.copy(
+                speakerId = speakerText.toIntOrNull(),
+                noiseScale = noiseScaleText.toFloatOrNull(),
+                noiseW = noiseWText.toFloatOrNull(),
+                sentenceSilence = sentenceSilenceText.toFloatOrNull()
+            )
+        )
+    }
+
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             Text(profile.name)
             IconButton(onClick = onDelete) { Icon(Icons.Default.Delete, contentDescription = "删除音色") }
         }
-        AssistChip(onClick = { modelLauncher.launch(arrayOf("*/*")) }, label = { Text("导入ONNX模型") })
-        AssistChip(onClick = { configLauncher.launch(arrayOf("application/json", "text/plain", "*/*")) }, label = { Text("导入配置JSON") })
+        AssistChip(onClick = { modelLauncher.launch(arrayOf("*/*")) }, label = { Text("导入ONNX模型（必填）") })
+        AssistChip(onClick = { configLauncher.launch(arrayOf("application/json", "text/plain", "*/*")) }, label = { Text("导入配置JSON（可选）") })
         Text("模型: ${profile.modelUri.ifBlank { "未导入" }}")
-        Text("配置: ${profile.configUri.ifBlank { "未导入" }}")
+        Text("配置: ${profile.configUri.ifBlank { "未导入（将使用模型默认参数）" }}")
+
+        OutlinedTextField(
+            value = speakerText,
+            onValueChange = {
+                speakerText = it
+                saveAdvanced()
+            },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("Speaker ID（可选）") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number)
+        )
+        OutlinedTextField(
+            value = noiseScaleText,
+            onValueChange = {
+                noiseScaleText = it
+                saveAdvanced()
+            },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("noise_scale（可选）") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
+        )
+        OutlinedTextField(
+            value = noiseWText,
+            onValueChange = {
+                noiseWText = it
+                saveAdvanced()
+            },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("noise_w（可选）") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
+        )
+        OutlinedTextField(
+            value = sentenceSilenceText,
+            onValueChange = {
+                sentenceSilenceText = it
+                saveAdvanced()
+            },
+            modifier = Modifier.fillMaxWidth(),
+            label = { Text("sentence_silence（可选）") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal)
+        )
     }
 }

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -14,19 +14,36 @@ private const val PIPER_TAG = "PiperSpeech"
 
 class PiperSpeechEngine(private val context: Context) {
     suspend fun speak(text: String, profile: VoiceProfile, speechRate: Float): Boolean {
-        if (text.isBlank() || profile.modelUri.isBlank() || profile.configUri.isBlank()) return false
+        if (text.isBlank() || profile.modelUri.isBlank()) return false
         val output = withContext(Dispatchers.IO) {
             val modelFile = copyUriToCache(profile.modelUri, "model_${profile.id}.onnx") ?: return@withContext null
-            val configFile = copyUriToCache(profile.configUri, "config_${profile.id}.json") ?: return@withContext null
+            val configFile = profile.configUri.takeIf { it.isNotBlank() }?.let {
+                copyUriToCache(it, "config_${profile.id}.json")
+            }
             val outFile = File(context.cacheDir, "piper_${System.currentTimeMillis()}.wav")
             val lengthScale = (1f / speechRate.coerceIn(0.6f, 1.8f)).toString()
-            val process = ProcessBuilder(
+            val command = mutableListOf(
                 "piper",
                 "--model", modelFile.absolutePath,
-                "--config", configFile.absolutePath,
                 "--output_file", outFile.absolutePath,
                 "--length_scale", lengthScale
-            ).redirectErrorStream(true).start()
+            )
+            configFile?.let {
+                command += listOf("--config", it.absolutePath)
+            }
+            profile.speakerId?.let {
+                if (it >= 0) command += listOf("--speaker", it.toString())
+            }
+            profile.noiseScale?.let {
+                command += listOf("--noise_scale", it.toString())
+            }
+            profile.noiseW?.let {
+                command += listOf("--noise_w", it.toString())
+            }
+            profile.sentenceSilence?.let {
+                command += listOf("--sentence_silence", it.toString())
+            }
+            val process = ProcessBuilder(command).redirectErrorStream(true).start()
             process.outputStream.bufferedWriter().use {
                 it.write(text)
                 it.newLine()
@@ -47,9 +64,13 @@ class PiperSpeechEngine(private val context: Context) {
         val uri = Uri.parse(rawUri)
         return runCatching {
             val out = File(context.cacheDir, fileName)
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                out.outputStream().use { output -> input.copyTo(output) }
+            val inputStream = when (uri.scheme) {
+                "asset" -> context.assets.open(uri.schemeSpecificPart.removePrefix("/"))
+                else -> context.contentResolver.openInputStream(uri)
             } ?: return null
+            inputStream.use { input ->
+                out.outputStream().use { output -> input.copyTo(output) }
+            }
             out
         }.getOrNull()
     }

--- a/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
+++ b/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
@@ -5,11 +5,18 @@ import org.json.JSONArray
 import org.json.JSONObject
 import java.util.UUID
 
+private const val BUILTIN_PROFILE_NAME = "vits-zh-hf-fanchen-C"
+private const val BUILTIN_MODEL_URI = "asset://tts/vits-zh-hf-fanchen-C.onnx"
+
 data class VoiceProfile(
     val id: String,
     val name: String,
     val modelUri: String,
-    val configUri: String
+    val configUri: String,
+    val speakerId: Int? = null,
+    val noiseScale: Float? = null,
+    val noiseW: Float? = null,
+    val sentenceSilence: Float? = null
 )
 
 data class RoleVoiceSetting(
@@ -27,13 +34,18 @@ class VoiceSettingsStore(context: Context) {
     private val prefs = context.applicationContext.getSharedPreferences("voice_settings", Context.MODE_PRIVATE)
 
     fun load(): VoiceSettings {
-        val raw = prefs.getString(KEY_PAYLOAD, null) ?: return VoiceSettings()
-        return runCatching {
-            val root = JSONObject(raw)
-            val profiles = root.optJSONArray("profiles").toProfiles()
-            val roleSettings = root.optJSONArray("roleSettings").toRoleSettings()
-            VoiceSettings(profiles = profiles, roleSettings = roleSettings)
-        }.getOrDefault(VoiceSettings())
+        val raw = prefs.getString(KEY_PAYLOAD, null)
+        val parsed = if (raw == null) {
+            VoiceSettings()
+        } else {
+            runCatching {
+                val root = JSONObject(raw)
+                val profiles = root.optJSONArray("profiles").toProfiles()
+                val roleSettings = root.optJSONArray("roleSettings").toRoleSettings()
+                VoiceSettings(profiles = profiles, roleSettings = roleSettings)
+            }.getOrDefault(VoiceSettings())
+        }
+        return parsed.withBuiltinProfile()
     }
 
     fun save(settings: VoiceSettings) {
@@ -46,6 +58,10 @@ class VoiceSettingsStore(context: Context) {
                             .put("name", profile.name)
                             .put("modelUri", profile.modelUri)
                             .put("configUri", profile.configUri)
+                            .put("speakerId", profile.speakerId)
+                            .put("noiseScale", profile.noiseScale)
+                            .put("noiseW", profile.noiseW)
+                            .put("sentenceSilence", profile.sentenceSilence)
                     )
                 }
             })
@@ -81,6 +97,19 @@ class VoiceSettingsStore(context: Context) {
     }
 }
 
+
+private fun VoiceSettings.withBuiltinProfile(): VoiceSettings {
+    val existing = profiles.firstOrNull { it.modelUri == BUILTIN_MODEL_URI }
+    if (existing != null) return this
+    val builtIn = VoiceProfile(
+        id = UUID.randomUUID().toString(),
+        name = BUILTIN_PROFILE_NAME,
+        modelUri = BUILTIN_MODEL_URI,
+        configUri = ""
+    )
+    return copy(profiles = listOf(builtIn) + profiles)
+}
+
 private fun JSONArray?.toProfiles(): List<VoiceProfile> {
     if (this == null) return emptyList()
     return buildList {
@@ -91,11 +120,25 @@ private fun JSONArray?.toProfiles(): List<VoiceProfile> {
                     id = item.optString("id"),
                     name = item.optString("name"),
                     modelUri = item.optString("modelUri"),
-                    configUri = item.optString("configUri")
+                    configUri = item.optString("configUri"),
+                    speakerId = item.optNullableInt("speakerId"),
+                    noiseScale = item.optNullableFloat("noiseScale"),
+                    noiseW = item.optNullableFloat("noiseW"),
+                    sentenceSilence = item.optNullableFloat("sentenceSilence")
                 )
             )
         }
     }
+}
+
+private fun JSONObject.optNullableInt(key: String): Int? {
+    if (isNull(key) || !has(key)) return null
+    return optInt(key)
+}
+
+private fun JSONObject.optNullableFloat(key: String): Float? {
+    if (isNull(key) || !has(key)) return null
+    return optDouble(key).toFloat()
 }
 
 private fun JSONArray?.toRoleSettings(): List<RoleVoiceSetting> {


### PR DESCRIPTION
### Motivation
- Allow the app to use the bundled `vits-zh-hf-fanchen-C.onnx` model out-of-the-box without requiring the user to re-upload ONNX/JSON files. 
- Expose Piper multi-speaker and synthesis tuning options so the bundled model (and other ONNXs) that support 100+ speakers can be used directly. 

### Description
- Add optional Piper tuning fields to `VoiceProfile`: `speakerId`, `noiseScale`, `noiseW`, and `sentenceSilence`, and persist them in `SharedPreferences` via `VoiceSettingsStore` (`app/src/main/java/.../VoiceSettingsStore.kt`).
- Inject a built-in profile for `asset://tts/vits-zh-hf-fanchen-C.onnx` at settings load so the bundled ONNX is available by default.
- Update `PiperSpeechEngine.speak` (`app/src/main/java/.../PiperSpeechEngine.kt`) to allow missing JSON configs (skip `--config` when empty), to pass optional flags (`--speaker`, `--noise_scale`, `--noise_w`, `--sentence_silence`) when present, and to support `asset://` URIs by copying assets into cache before invoking `piper`.
- Improve the settings UI (`app/src/main/java/.../VoiceSettingsScreen.kt`) to mark ONNX as required and JSON as optional, and add editable fields for `Speaker ID`, `noise_scale`, `noise_w`, and `sentence_silence` so users can tune multi-speaker models from the app.

### Testing
- Attempted to build the app with `./gradlew :app:assembleDebug`, but the Gradle wrapper download failed in this environment due to a network proxy error: `HTTP/1.1 403 Forbidden`, so a full build/assemble could not be completed.
- Verified local code edits and committed the changes; no other automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afcdece8f4832bafcc184f3b08d02a)