### PR TITLE
feat: migrate built-in Fanchen TTS playback to sherpa-onnx

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,8 @@ dependencies {
     implementation("androidx.room:room-ktx:2.6.1")
     ksp("androidx.room:room-compiler:2.6.1")
 
+    implementation("com.k2fsa.sherpa-onnx:sherpa-onnx:1.10.39")
+
     // 可选
     implementation("com.google.accompanist:accompanist-systemuicontroller:0.34.0")
 }

--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.util.PiperSpeechEngine
+import java.util.Locale
 import com.example.quotepicker.util.RoleVoiceSetting
 import com.example.quotepicker.util.VoiceProfile
 import com.example.quotepicker.vm.VoiceSettingsViewModel
@@ -111,6 +112,7 @@ private fun RoleVoiceSettingRow(
     var noiseWText by remember(roleName, initial?.noiseW) { mutableStateOf(initial?.noiseW?.toString() ?: "") }
     var sentenceSilenceText by remember(roleName, initial?.sentenceSilence) { mutableStateOf(initial?.sentenceSilence?.toString() ?: "") }
     var previewText by remember(roleName) { mutableStateOf("你好，我是$roleName，这是一段语音预览。") }
+    var statusText by remember(roleName) { mutableStateOf("") }
 
     fun currentSetting() = RoleVoiceSetting(
         roleName = roleName,
@@ -128,7 +130,7 @@ private fun RoleVoiceSettingRow(
     Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
         Text(roleName)
         Row {
-            Text("语速 ${"%.2f".format(speed)}")
+            Text("语速 ${"%.2f".format(Locale.US, speed)}")
             Spacer(modifier = Modifier.width(8.dp))
             Slider(
                 value = speed,
@@ -147,68 +149,98 @@ private fun RoleVoiceSettingRow(
                 speakerText = it
                 saveCurrent()
             },
-            label = { Text("speaker（可选）") },
+            label = { Text("speaker（0~186）") },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             modifier = Modifier.fillMaxWidth()
         )
+
         OutlinedTextField(
             value = noiseScaleText,
             onValueChange = {
                 noiseScaleText = it
                 saveCurrent()
             },
-            label = { Text("noise_scale（可选）") },
+            label = { Text("noise_scale（暂不单独覆盖）") },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
             modifier = Modifier.fillMaxWidth()
         )
+
         OutlinedTextField(
             value = noiseWText,
             onValueChange = {
                 noiseWText = it
                 saveCurrent()
             },
-            label = { Text("noise_w（可选）") },
+            label = { Text("noise_w（暂不单独覆盖）") },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
             modifier = Modifier.fillMaxWidth()
         )
+
         OutlinedTextField(
             value = sentenceSilenceText,
             onValueChange = {
                 sentenceSilenceText = it
                 saveCurrent()
             },
-            label = { Text("sentence_silence（可选）") },
+            label = { Text("sentence_silence（暂不单独覆盖）") },
             singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
             modifier = Modifier.fillMaxWidth()
         )
+
         OutlinedTextField(
             value = previewText,
             onValueChange = { previewText = it },
             label = { Text("预览文本（可修改）") },
             modifier = Modifier.fillMaxWidth()
         )
-        Button(
-            onClick = {
-                val base = baseProfile ?: return@Button
-                val setting = currentSetting()
-                saveCurrent()
-                val effective = base.copy(
-                    speakerId = setting.speakerId,
-                    noiseScale = setting.noiseScale,
-                    noiseW = setting.noiseW,
-                    sentenceSilence = setting.sentenceSilence
-                )
-                scope.launch {
-                    speech.speak(previewText, effective, setting.speechRate)
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(
+                onClick = {
+                    if (baseProfile == null) return@Button
+                    val setting = currentSetting()
+                    saveCurrent()
+                    val effective = baseProfile.copy(
+                        speakerId = setting.speakerId,
+                        noiseScale = setting.noiseScale,
+                        noiseW = setting.noiseW,
+                        sentenceSilence = setting.sentenceSilence
+                    )
+                    scope.launch {
+                        try {
+                            statusText = "正在初始化/朗读..."
+                            speech.speak(previewText, effective, setting.speechRate)
+                            statusText = "朗读中"
+                        } catch (e: Throwable) {
+                            statusText = "失败：${e.message ?: e.javaClass.simpleName}"
+                            android.util.Log.e("VoiceSettings", "preview failed", e)
+                        }
+                    }
+                },
+                enabled = baseProfile != null
+            ) {
+                Text("预览朗读")
+            }
+
+            Button(
+                onClick = {
+                    scope.launch {
+                        speech.stop()
+                        statusText = "已停止"
+                    }
                 }
-            },
-            enabled = baseProfile != null
-        ) {
-            Text("预览朗读")
+            ) {
+                Text("停止")
+            }
+        }
+
+        if (statusText.isNotBlank()) {
+            Text(statusText)
         }
     }
 }
+

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -1,99 +1,179 @@
 package com.example.quotepicker.util
 
 import android.content.Context
-import android.media.MediaPlayer
-import android.net.Uri
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
 import android.util.Log
+import com.k2fsa.sherpa.onnx.OfflineTts
+import com.k2fsa.sherpa.onnx.OfflineTtsConfig
+import com.k2fsa.sherpa.onnx.OfflineTtsModelConfig
+import com.k2fsa.sherpa.onnx.OfflineTtsVitsModelConfig
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import java.io.File
-import kotlin.coroutines.resume
+import kotlin.math.roundToInt
 
-private const val PIPER_TAG = "PiperSpeech"
+private const val TTS_TAG = "PiperSpeech"
 
 class PiperSpeechEngine(private val context: Context) {
+    companion object {
+        private const val BASE_DIR = "tts/vits-zh-hf-fanchen-C"
+        private const val MODEL_PATH = "$BASE_DIR/vits-zh-hf-fanchen-C.onnx"
+        private const val LEXICON_PATH = "$BASE_DIR/lexicon.txt"
+        private const val TOKENS_PATH = "$BASE_DIR/tokens.txt"
+        private const val RULE_FSTS = "$BASE_DIR/phone.fst,$BASE_DIR/number.fst"
+        private const val RULE_FARS = "$BASE_DIR/rule.far"
+        private const val DICT_DIR = "$BASE_DIR/dict"
+    }
+
+    private val mutex = Mutex()
+
+    @Volatile
+    private var tts: OfflineTts? = null
+
+    @Volatile
+    private var audioTrack: AudioTrack? = null
+
     suspend fun speak(text: String, profile: VoiceProfile, speechRate: Float): Boolean {
-        if (text.isBlank() || profile.modelUri.isBlank()) return false
-        val output = withContext(Dispatchers.IO) {
-            val modelFile = copyUriToCache(profile.modelUri, "model_${profile.id}.onnx") ?: return@withContext null
-            val configFile = profile.configUri.takeIf { it.isNotBlank() }?.let {
-                copyUriToCache(it, "config_${profile.id}.json")
-            }
-            val outFile = File(context.cacheDir, "piper_${System.currentTimeMillis()}.wav")
-            val lengthScale = (1f / speechRate.coerceIn(0.6f, 1.8f)).toString()
-            val command = mutableListOf(
-                "piper",
-                "--model", modelFile.absolutePath,
-                "--output_file", outFile.absolutePath,
-                "--length_scale", lengthScale
-            )
-            configFile?.let {
-                command += listOf("--config", it.absolutePath)
-            }
-            profile.speakerId?.let {
-                if (it >= 0) command += listOf("--speaker", it.toString())
-            }
-            profile.noiseScale?.let {
-                command += listOf("--noise_scale", it.toString())
-            }
-            profile.noiseW?.let {
-                command += listOf("--noise_w", it.toString())
-            }
-            profile.sentenceSilence?.let {
-                command += listOf("--sentence_silence", it.toString())
-            }
-            val process = ProcessBuilder(command).redirectErrorStream(true).start()
-            process.outputStream.bufferedWriter().use {
-                it.write(text)
-                it.newLine()
-            }
-            val exit = process.waitFor()
-            if (exit != 0 || !outFile.exists()) {
-                Log.e(PIPER_TAG, "piper execute failed exit=$exit")
-                null
-            } else {
-                outFile
-            }
-        } ?: return false
+        if (text.isBlank()) return false
+        return withContext(Dispatchers.Default) {
+            runCatching {
+                ensureInit()
+                val engine = tts ?: error("TTS engine not initialized")
+                val sid = normalizeSpeakerId(engine, profile.speakerId)
+                val speed = speechRate.coerceIn(0.5f, 2.0f)
+                val audio = engine.generate(text = text, sid = sid, speed = speed)
 
-        return playFile(output)
-    }
+                stopInternal()
 
-    private fun copyUriToCache(rawUri: String, fileName: String): File? {
-        val uri = Uri.parse(rawUri)
-        return runCatching {
-            val out = File(context.cacheDir, fileName)
-            val inputStream = when (uri.scheme) {
-                "asset" -> context.assets.open(uri.schemeSpecificPart.removePrefix("/"))
-                else -> context.contentResolver.openInputStream(uri)
-            } ?: return null
-            inputStream.use { input ->
-                out.outputStream().use { output -> input.copyTo(output) }
-            }
-            out
-        }.getOrNull()
-    }
+                val pcm16 = floatToPcm16(audio.samples)
+                val sampleRate = engine.sampleRate()
+                val minBufferSize = AudioTrack.getMinBufferSize(
+                    sampleRate,
+                    AudioFormat.CHANNEL_OUT_MONO,
+                    AudioFormat.ENCODING_PCM_16BIT
+                )
+                val bufferSize = maxOf(minBufferSize, pcm16.size * 2)
 
-    private suspend fun playFile(file: File): Boolean = suspendCancellableCoroutine { cont ->
-        val player = MediaPlayer()
-        runCatching {
-            player.setDataSource(file.absolutePath)
-            player.setOnCompletionListener {
-                it.release()
-                if (cont.isActive) cont.resume(true)
-            }
-            player.setOnErrorListener { mp, _, _ ->
-                mp.release()
-                if (cont.isActive) cont.resume(false)
+                val track = AudioTrack(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_MEDIA)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build(),
+                    AudioFormat.Builder()
+                        .setSampleRate(sampleRate)
+                        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                        .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                        .build(),
+                    bufferSize,
+                    AudioTrack.MODE_STATIC,
+                    AudioManager.AUDIO_SESSION_ID_GENERATE
+                )
+
+                audioTrack = track
+                val written = track.write(pcm16, 0, pcm16.size)
+                if (written <= 0) {
+                    track.release()
+                    audioTrack = null
+                    error("AudioTrack write failed: $written")
+                }
+
+                track.play()
                 true
+            }.onFailure { e ->
+                Log.e(TTS_TAG, "speak failed", e)
+            }.getOrDefault(false)
+        }
+    }
+
+    suspend fun stop() = withContext(Dispatchers.IO) {
+        stopInternal()
+    }
+
+    suspend fun release() = withContext(Dispatchers.IO) {
+        stopInternal()
+        mutex.withLock {
+            tts?.release()
+            tts = null
+        }
+    }
+
+    private suspend fun ensureInit() = withContext(Dispatchers.IO) {
+        mutex.withLock {
+            if (tts != null) return@withLock
+
+            val vits = OfflineTtsVitsModelConfig(
+                model = MODEL_PATH,
+                lexicon = LEXICON_PATH,
+                tokens = TOKENS_PATH,
+                dataDir = BASE_DIR,
+                dictDir = DICT_DIR,
+                noiseScale = 0.667f,
+                noiseScaleW = 0.8f,
+                lengthScale = 1.0f
+            )
+
+
+            val ruleFars = if (assetExists(RULE_FARS)) RULE_FARS else ""
+
+            val config = OfflineTtsConfig(
+                model = OfflineTtsModelConfig(
+                    vits = vits,
+                    numThreads = 2,
+                    debug = true,
+                    provider = "cpu"
+                ),
+                ruleFsts = RULE_FSTS,
+                ruleFars = ruleFars,
+                maxNumSentences = 1,
+                silenceScale = 0.2f
+            )
+
+            tts = OfflineTts(
+                assetManager = context.assets,
+                config = config
+            )
+
+            Log.d(TTS_TAG, "TTS initialized. speakers=${tts?.numSpeakers()}, sampleRate=${tts?.sampleRate()}")
+        }
+    }
+
+    private fun assetExists(path: String): Boolean {
+        return runCatching {
+            context.assets.open(path).use { }
+            true
+        }.getOrDefault(false)
+    }
+
+    private fun normalizeSpeakerId(engine: OfflineTts, speakerId: Int?): Int {
+        val count = engine.numSpeakers()
+        if (count <= 0) return 0
+        return (speakerId ?: 0).coerceIn(0, count - 1)
+    }
+
+    private fun floatToPcm16(samples: FloatArray): ShortArray {
+        return ShortArray(samples.size) { i ->
+            val v = samples[i].coerceIn(-1f, 1f)
+            (v * Short.MAX_VALUE).roundToInt().toShort()
+        }
+    }
+
+    private fun stopInternal() {
+        try {
+            audioTrack?.let { track ->
+                try {
+                    track.pause()
+                    track.flush()
+                    track.stop()
+                } catch (_: Throwable) {
+                }
+                track.release()
             }
-            player.prepare()
-            player.start()
-            cont.invokeOnCancellation { player.release() }
-        }.onFailure {
-            player.release()
-            if (cont.isActive) cont.resume(false)
+        } finally {
+            audioTrack = null
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous external `piper` process approach with an in-app offline TTS implementation that directly uses the provided `assets/tts/vits-zh-hf-fanchen-C` model files for more reliable, integrated playback.
- Expose speaker/speed preview functionality in the UI while avoiding runtime failures when optional assets (like `rule.far`) are missing.

### Description
- Replaced the old process-based pipeline in `PiperSpeechEngine` with a sherpa-onnx powered implementation that lazily initializes `OfflineTts` using `OfflineTtsVitsModelConfig` and plays PCM via `AudioTrack`, adding mutex protection and lifecycle management (`ensureInit`, `stop`, `release`).
- Added a safe asset existence check and a fallback to omit `rule.far` when it is not present, preventing initialization errors.
- Updated `VoiceSettingsScreen`/`RoleVoiceSettingRow` to show preview status text, a stop button that calls `speech.stop()`, `Locale.US`-stable speed formatting, and clearer labels for `speaker`/`noise_*`/`sentence_silence` to match model behavior.
- Added the `sherpa-onnx` dependency to `app/build.gradle.kts`: `implementation("com.k2fsa.sherpa-onnx:sherpa-onnx:1.10.39")`.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin` to validate changes, but the Gradle wrapper download failed in this environment due to proxy returning `HTTP 403`, so compilation could not complete.
- Ran local repository checks (`git status`, diffs) to verify file edits and created the changeset including `PiperSpeechEngine.kt`, `VoiceSettingsScreen.kt`, and `app/build.gradle.kts` which were committed successfully in the workspace.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afd6384704832ba6ba8a41ae506243)