### PR TITLE
修复声音预览失真并改为角色选择弹窗

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -21,6 +22,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -28,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -52,6 +55,14 @@ fun VoiceSettingsScreen(
     val ui by vm.uiState.collectAsState()
     val builtInProfile = ui.settings.profiles.firstOrNull { it.modelUri == BUILTIN_MODEL_URI }
 
+    val allRoles = remember(ui.narratorName, ui.characterNames) { listOf(ui.narratorName) + ui.characterNames }
+    var selectedRole by rememberSaveable(allRoles) { mutableStateOf(allRoles.firstOrNull().orEmpty()) }
+    var showRoleDialog by rememberSaveable { mutableStateOf(false) }
+
+    if (selectedRole !in allRoles) {
+        selectedRole = allRoles.firstOrNull().orEmpty()
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -75,22 +86,64 @@ fun VoiceSettingsScreen(
                 Text("当前固定模型：vits-zh-hf-fanchen-C.onnx（无需导入）")
                 Text("可为每个角色单独设置 speaker 和参数，并可直接预览。")
             }
+
             item {
-                RoleVoiceSettingRow(
-                    roleName = ui.narratorName,
-                    baseProfile = builtInProfile,
-                    initial = ui.settings.roleSettings.firstOrNull { it.roleName == ui.narratorName },
-                    onSave = { vm.updateRoleSetting(ui.narratorName, builtInProfile?.id, it.speechRate, it.speakerId, it.noiseScale, it.noiseW, it.sentenceSilence) }
-                )
+                Button(
+                    onClick = { showRoleDialog = true },
+                    enabled = allRoles.isNotEmpty()
+                ) {
+                    Text("选择角色：$selectedRole")
+                }
             }
-            items(ui.characterNames, key = { it }) { roleName ->
-                RoleVoiceSettingRow(
-                    roleName = roleName,
-                    baseProfile = builtInProfile,
-                    initial = ui.settings.roleSettings.firstOrNull { it.roleName == roleName },
-                    onSave = { vm.updateRoleSetting(roleName, builtInProfile?.id, it.speechRate, it.speakerId, it.noiseScale, it.noiseW, it.sentenceSilence) }
-                )
+
+            item {
+                val current = ui.settings.roleSettings.firstOrNull { it.roleName == selectedRole }
+                if (selectedRole.isNotBlank()) {
+                    RoleVoiceSettingRow(
+                        roleName = selectedRole,
+                        baseProfile = builtInProfile,
+                        initial = current,
+                        onSave = {
+                            vm.updateRoleSetting(
+                                selectedRole,
+                                builtInProfile?.id,
+                                it.speechRate,
+                                it.speakerId,
+                                it.noiseScale,
+                                it.noiseW,
+                                it.sentenceSilence
+                            )
+                        }
+                    )
+                }
             }
+        }
+
+        if (showRoleDialog) {
+            AlertDialog(
+                onDismissRequest = { showRoleDialog = false },
+                title = { Text("选择角色") },
+                text = {
+                    LazyColumn(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        items(allRoles, key = { it }) { roleName ->
+                            TextButton(
+                                onClick = {
+                                    selectedRole = roleName
+                                    showRoleDialog = false
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(roleName)
+                            }
+                        }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { showRoleDialog = false }) {
+                        Text("关闭")
+                    }
+                }
+            )
         }
     }
 }
@@ -243,4 +296,3 @@ private fun RoleVoiceSettingRow(
         }
     }
 }
-

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlin.math.abs
 import kotlin.math.roundToInt
 
 private const val TTS_TAG = "PiperSpeech"
@@ -56,7 +57,8 @@ class PiperSpeechEngine(private val context: Context) {
                     AudioFormat.CHANNEL_OUT_MONO,
                     AudioFormat.ENCODING_PCM_16BIT
                 )
-                val bufferSize = maxOf(minBufferSize, pcm16.size * 2)
+                val pcmBytes = shortArrayToBytes(pcm16)
+                val bufferSize = maxOf(minBufferSize, pcmBytes.size)
 
                 val track = AudioTrack(
                     AudioAttributes.Builder()
@@ -69,19 +71,18 @@ class PiperSpeechEngine(private val context: Context) {
                         .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
                         .build(),
                     bufferSize,
-                    AudioTrack.MODE_STATIC,
+                    AudioTrack.MODE_STREAM,
                     AudioManager.AUDIO_SESSION_ID_GENERATE
                 )
 
                 audioTrack = track
-                val written = track.write(pcm16, 0, pcm16.size)
+                track.play()
+                val written = track.write(pcmBytes, 0, pcmBytes.size, AudioTrack.WRITE_BLOCKING)
                 if (written <= 0) {
                     track.release()
                     audioTrack = null
                     error("AudioTrack write failed: $written")
                 }
-
-                track.play()
                 true
             }.onFailure { e ->
                 Log.e(TTS_TAG, "speak failed", e)
@@ -155,10 +156,25 @@ class PiperSpeechEngine(private val context: Context) {
     }
 
     private fun floatToPcm16(samples: FloatArray): ShortArray {
+        // sherpa-onnx models may output normalized samples [-1, 1], but some builds return
+        // float values in the int16 range. Auto-detect to avoid heavy distortion.
+        val peak = samples.maxOfOrNull { abs(it) } ?: 1f
+        val scale = if (peak > 1.5f) 1f else Short.MAX_VALUE.toFloat()
+
         return ShortArray(samples.size) { i ->
-            val v = samples[i].coerceIn(-1f, 1f)
-            (v * Short.MAX_VALUE).roundToInt().toShort()
+            val normalized = (samples[i] / scale).coerceIn(-1f, 1f)
+            (normalized * Short.MAX_VALUE).roundToInt().toShort()
         }
+    }
+
+    private fun shortArrayToBytes(samples: ShortArray): ByteArray {
+        val out = ByteArray(samples.size * 2)
+        var j = 0
+        for (sample in samples) {
+            out[j++] = (sample.toInt() and 0xFF).toByte()
+            out[j++] = ((sample.toInt() shr 8) and 0xFF).toByte()
+        }
+        return out
     }
 
     private fun stopInternal() {


### PR DESCRIPTION
### Motivation
- 修复声音设置页面“预览朗读”听起来乱、类似倒放或噪声的问题，并减少页面一次性展示所有角色导致的界面拥挤。 

### Description
- 在 `app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt` 中将 `AudioTrack` 从 `MODE_STATIC` 改为 `MODE_STREAM`，改为使用字节流阻塞写入（`AudioTrack.write(..., AudioTrack.WRITE_BLOCKING)`）并在写入前 `play()`，以避免静态缓冲导致的播放兼容性问题。 
- 为避免模型输出尺度不一致导致的失真，新增采样幅值自适应检测并在 `floatToPcm16` 中按峰值缩放，兼容既有 `[-1,1]` 正规输出也可能接近 int16 范围的输出；同时新增 `shortArrayToBytes` 将 PCM short 转为 byte[]。 
- 在 `app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt` 中改动界面交互：新增“选择角色”按钮与 `AlertDialog` 弹窗列出角色供选择（使用 `rememberSaveable` 保存选择），并仅渲染当前选中角色的 `RoleVoiceSettingRow`，避免一次性展开所有角色设置。 
- 变更涉及的文件：`PiperSpeechEngine.kt`、`VoiceSettingsScreen.kt`，并调整了相应的导入与 UI 控件使用。 

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 进行编译验证，当前运行环境无法下载 Gradle 分发包（代理返回 `HTTP/1.1 403 Forbidden`），导致编译未能完成并视为失败。 
- 本次变更已本地提交修改并生成 PR（代码语义已静态检查过），但由于网络限制未能在 CI/本地完成完整构建或运行时播放验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe14a9bf4832b9913bf2f51f2980c)