### PR TITLE
Add role-selection dialog in Voice Settings and stream float PCM audio in PiperSpeechEngine

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -21,6 +22,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -28,6 +30,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -52,6 +55,14 @@ fun VoiceSettingsScreen(
     val ui by vm.uiState.collectAsState()
     val builtInProfile = ui.settings.profiles.firstOrNull { it.modelUri == BUILTIN_MODEL_URI }
 
+    val allRoles = remember(ui.narratorName, ui.characterNames) { listOf(ui.narratorName) + ui.characterNames }
+    var selectedRole by rememberSaveable(allRoles) { mutableStateOf(allRoles.firstOrNull().orEmpty()) }
+    var showRoleDialog by rememberSaveable { mutableStateOf(false) }
+
+    if (selectedRole !in allRoles) {
+        selectedRole = allRoles.firstOrNull().orEmpty()
+    }
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -75,22 +86,64 @@ fun VoiceSettingsScreen(
                 Text("当前固定模型：vits-zh-hf-fanchen-C.onnx（无需导入）")
                 Text("可为每个角色单独设置 speaker 和参数，并可直接预览。")
             }
+
             item {
-                RoleVoiceSettingRow(
-                    roleName = ui.narratorName,
-                    baseProfile = builtInProfile,
-                    initial = ui.settings.roleSettings.firstOrNull { it.roleName == ui.narratorName },
-                    onSave = { vm.updateRoleSetting(ui.narratorName, builtInProfile?.id, it.speechRate, it.speakerId, it.noiseScale, it.noiseW, it.sentenceSilence) }
-                )
+                Button(
+                    onClick = { showRoleDialog = true },
+                    enabled = allRoles.isNotEmpty()
+                ) {
+                    Text("选择角色：$selectedRole")
+                }
             }
-            items(ui.characterNames, key = { it }) { roleName ->
-                RoleVoiceSettingRow(
-                    roleName = roleName,
-                    baseProfile = builtInProfile,
-                    initial = ui.settings.roleSettings.firstOrNull { it.roleName == roleName },
-                    onSave = { vm.updateRoleSetting(roleName, builtInProfile?.id, it.speechRate, it.speakerId, it.noiseScale, it.noiseW, it.sentenceSilence) }
-                )
+
+            item {
+                val current = ui.settings.roleSettings.firstOrNull { it.roleName == selectedRole }
+                if (selectedRole.isNotBlank()) {
+                    RoleVoiceSettingRow(
+                        roleName = selectedRole,
+                        baseProfile = builtInProfile,
+                        initial = current,
+                        onSave = {
+                            vm.updateRoleSetting(
+                                selectedRole,
+                                builtInProfile?.id,
+                                it.speechRate,
+                                it.speakerId,
+                                it.noiseScale,
+                                it.noiseW,
+                                it.sentenceSilence
+                            )
+                        }
+                    )
+                }
             }
+        }
+
+        if (showRoleDialog) {
+            AlertDialog(
+                onDismissRequest = { showRoleDialog = false },
+                title = { Text("选择角色") },
+                text = {
+                    LazyColumn(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                        items(allRoles, key = { it }) { roleName ->
+                            TextButton(
+                                onClick = {
+                                    selectedRole = roleName
+                                    showRoleDialog = false
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            ) {
+                                Text(roleName)
+                            }
+                        }
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { showRoleDialog = false }) {
+                        Text("关闭")
+                    }
+                }
+            )
         }
     }
 }
@@ -243,4 +296,3 @@ private fun RoleVoiceSettingRow(
         }
     }
 }
-

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlin.math.roundToInt
 
 private const val TTS_TAG = "PiperSpeech"
 
@@ -49,14 +48,18 @@ class PiperSpeechEngine(private val context: Context) {
 
                 stopInternal()
 
-                val pcm16 = floatToPcm16(audio.samples)
-                val sampleRate = engine.sampleRate()
+                val sampleRate = audio.sampleRate
+                val samples = audio.samples
+                if (samples.isEmpty()) {
+                    error("Generated audio is empty")
+                }
+
                 val minBufferSize = AudioTrack.getMinBufferSize(
                     sampleRate,
                     AudioFormat.CHANNEL_OUT_MONO,
-                    AudioFormat.ENCODING_PCM_16BIT
+                    AudioFormat.ENCODING_PCM_FLOAT
                 )
-                val bufferSize = maxOf(minBufferSize, pcm16.size * 2)
+                val bufferSize = maxOf(minBufferSize, samples.size * 4)
 
                 val track = AudioTrack(
                     AudioAttributes.Builder()
@@ -65,23 +68,24 @@ class PiperSpeechEngine(private val context: Context) {
                         .build(),
                     AudioFormat.Builder()
                         .setSampleRate(sampleRate)
-                        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                        .setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
                         .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
                         .build(),
                     bufferSize,
-                    AudioTrack.MODE_STATIC,
+                    AudioTrack.MODE_STREAM,
                     AudioManager.AUDIO_SESSION_ID_GENERATE
                 )
 
                 audioTrack = track
-                val written = track.write(pcm16, 0, pcm16.size)
+                track.play()
+                val written = track.write(samples, 0, samples.size, AudioTrack.WRITE_BLOCKING)
                 if (written <= 0) {
                     track.release()
                     audioTrack = null
                     error("AudioTrack write failed: $written")
                 }
 
-                track.play()
+                Log.d(TTS_TAG, "Played generated audio. sampleRate=$sampleRate, samples=${samples.size}, written=$written")
                 true
             }.onFailure { e ->
                 Log.e(TTS_TAG, "speak failed", e)
@@ -115,7 +119,6 @@ class PiperSpeechEngine(private val context: Context) {
                 noiseScaleW = 0.8f,
                 lengthScale = 1.0f
             )
-
 
             val ruleFars = if (assetExists(RULE_FARS)) RULE_FARS else ""
 
@@ -152,13 +155,6 @@ class PiperSpeechEngine(private val context: Context) {
         val count = engine.numSpeakers()
         if (count <= 0) return 0
         return (speakerId ?: 0).coerceIn(0, count - 1)
-    }
-
-    private fun floatToPcm16(samples: FloatArray): ShortArray {
-        return ShortArray(samples.size) { i ->
-            val v = samples[i].coerceIn(-1f, 1f)
-            (v * Short.MAX_VALUE).roundToInt().toShort()
-        }
     }
 
     private fun stopInternal() {


### PR DESCRIPTION
### Motivation
- Provide a single UI to pick which role's voice settings to edit instead of rendering separate rows for narrator and all characters. 
- Fix audio playback to consume the TTS engine's float samples directly and stream them to `AudioTrack` to avoid conversion issues and improve reliability.

### Description
- Replace per-role list rendering with a selectable role approach in `VoiceSettingsScreen.kt` by adding `selectedRole`, a role selection `Button`, and an `AlertDialog` showing all roles, using `rememberSaveable` to preserve state.  
- Render a single `RoleVoiceSettingRow` for the currently selected role and update `vm.updateRoleSetting` calls to use the selected role.  
- In `PiperSpeechEngine.kt`, consume `audio.samples` and `audio.sampleRate` directly, validate non-empty output, remove PCM16 conversion, and compute buffer sizing for float samples.  
- Configure `AudioTrack` to use `AudioFormat.ENCODING_PCM_FLOAT`, `AudioTrack.MODE_STREAM`, call `write(samples, ..., AudioTrack.WRITE_BLOCKING)`, and add logging; remove the unused `floatToPcm16` helper and related imports.

### Testing
- Ran `./gradlew assembleDebug` to build the app and the build completed successfully.  
- Ran unit tests with `./gradlew testDebugUnitTest` and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe14a9bf4832b9913bf2f51f2980c)