### PR TITLE
按角色扩展语音参数并支持魔剧旁白/注意朗读开关

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -3,14 +3,11 @@ package com.example.quotepicker.ui
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
@@ -34,7 +31,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.util.PiperSpeechEngine
@@ -55,7 +51,7 @@ fun VoiceSettingsScreen(
     val ui by vm.uiState.collectAsState()
     val builtInProfile = ui.settings.profiles.firstOrNull { it.modelUri == BUILTIN_MODEL_URI }
 
-    val allRoles = remember(ui.narratorName, ui.characterNames) { listOf(ui.narratorName) + ui.characterNames }
+    val allRoles = remember(ui.narratorName, ui.noticeName, ui.characterNames) { listOf(ui.narratorName, ui.noticeName) + ui.characterNames }
     var selectedRole by rememberSaveable(allRoles) { mutableStateOf(allRoles.firstOrNull().orEmpty()) }
     var showRoleDialog by rememberSaveable { mutableStateOf(false) }
 
@@ -110,8 +106,10 @@ fun VoiceSettingsScreen(
                                 it.speechRate,
                                 it.speakerId,
                                 it.noiseScale,
-                                it.noiseW,
-                                it.sentenceSilence
+                                it.noiseScaleW,
+                                it.lengthScale,
+                                it.maxNumSentences,
+                                it.silenceScale
                             )
                         }
                     )
@@ -159,90 +157,73 @@ private fun RoleVoiceSettingRow(
     val scope = rememberCoroutineScope()
     val speech = remember(context) { PiperSpeechEngine(context) }
 
-    var speed by remember(roleName, initial?.speechRate) { mutableStateOf(initial?.speechRate ?: 1.0f) }
-    var speakerText by remember(roleName, initial?.speakerId) { mutableStateOf(initial?.speakerId?.toString() ?: "") }
-    var noiseScaleText by remember(roleName, initial?.noiseScale) { mutableStateOf(initial?.noiseScale?.toString() ?: "") }
-    var noiseWText by remember(roleName, initial?.noiseW) { mutableStateOf(initial?.noiseW?.toString() ?: "") }
-    var sentenceSilenceText by remember(roleName, initial?.sentenceSilence) { mutableStateOf(initial?.sentenceSilence?.toString() ?: "") }
+    var speed by remember(roleName, initial?.speechRate) { mutableStateOf((initial?.speechRate ?: 1.0f).coerceIn(0.6f, 1.8f)) }
+    var speakerId by remember(roleName, initial?.speakerId) { mutableStateOf((initial?.speakerId ?: 0).coerceIn(0, 186)) }
+    var noiseScale by remember(roleName, initial?.noiseScale) { mutableStateOf((initial?.noiseScale ?: 0.667f).coerceIn(0.1f, 2.0f)) }
+    var noiseScaleW by remember(roleName, initial?.noiseScaleW) { mutableStateOf((initial?.noiseScaleW ?: 0.8f).coerceIn(0.1f, 2.0f)) }
+    var lengthScale by remember(roleName, initial?.lengthScale) { mutableStateOf((initial?.lengthScale ?: 1.0f).coerceIn(0.5f, 2.0f)) }
+    var maxNumSentences by remember(roleName, initial?.maxNumSentences) { mutableStateOf((initial?.maxNumSentences ?: 1).coerceIn(1, 10)) }
+    var silenceScale by remember(roleName, initial?.silenceScale) { mutableStateOf((initial?.silenceScale ?: 0.2f).coerceIn(0f, 1f)) }
     var previewText by remember(roleName) { mutableStateOf("你好，我是$roleName，这是一段语音预览。") }
     var statusText by remember(roleName) { mutableStateOf("") }
 
     fun currentSetting() = RoleVoiceSetting(
         roleName = roleName,
         speechRate = speed,
-        speakerId = speakerText.toIntOrNull(),
-        noiseScale = noiseScaleText.toFloatOrNull(),
-        noiseW = noiseWText.toFloatOrNull(),
-        sentenceSilence = sentenceSilenceText.toFloatOrNull()
+        speakerId = speakerId,
+        noiseScale = noiseScale,
+        noiseScaleW = noiseScaleW,
+        lengthScale = lengthScale,
+        maxNumSentences = maxNumSentences,
+        silenceScale = silenceScale
     )
 
-    fun saveCurrent() {
-        onSave(currentSetting())
-    }
+    fun saveCurrent() = onSave(currentSetting())
 
-    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-        Text(roleName)
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("$roleName（每项都限制在安全区间）")
+
+        Text("speakerId: 选择音色说话人。推荐 0（可尝试不同角色分配不同 speaker）。")
         Row {
-            Text("语速 ${"%.2f".format(Locale.US, speed)}")
-            Spacer(modifier = Modifier.width(8.dp))
-            Slider(
-                value = speed,
-                onValueChange = {
-                    speed = it
-                    saveCurrent()
-                },
-                valueRange = 0.6f..1.8f,
-                modifier = Modifier.weight(1f)
-            )
+            Text("$speakerId")
+            Slider(value = speakerId.toFloat(), onValueChange = { speakerId = it.toInt(); saveCurrent() }, valueRange = 0f..186f, modifier = Modifier.weight(1f))
         }
 
-        OutlinedTextField(
-            value = speakerText,
-            onValueChange = {
-                speakerText = it
-                saveCurrent()
-            },
-            label = { Text("speaker（0~186）") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-            modifier = Modifier.fillMaxWidth()
-        )
+        Text("speed: 语速。推荐 1.0。")
+        Row {
+            Text("${"%.2f".format(Locale.US, speed)}")
+            Slider(value = speed, onValueChange = { speed = it; saveCurrent() }, valueRange = 0.6f..1.8f, modifier = Modifier.weight(1f))
+        }
 
-        OutlinedTextField(
-            value = noiseScaleText,
-            onValueChange = {
-                noiseScaleText = it
-                saveCurrent()
-            },
-            label = { Text("noise_scale（暂不单独覆盖）") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-            modifier = Modifier.fillMaxWidth()
-        )
+        Text("noiseScale: 发音随机度，越高越活泼。推荐 0.667。")
+        Row {
+            Text("${"%.3f".format(Locale.US, noiseScale)}")
+            Slider(value = noiseScale, onValueChange = { noiseScale = it; saveCurrent() }, valueRange = 0.1f..2.0f, modifier = Modifier.weight(1f))
+        }
 
-        OutlinedTextField(
-            value = noiseWText,
-            onValueChange = {
-                noiseWText = it
-                saveCurrent()
-            },
-            label = { Text("noise_w（暂不单独覆盖）") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-            modifier = Modifier.fillMaxWidth()
-        )
+        Text("noiseScaleW: 音素时长随机度。推荐 0.8。")
+        Row {
+            Text("${"%.3f".format(Locale.US, noiseScaleW)}")
+            Slider(value = noiseScaleW, onValueChange = { noiseScaleW = it; saveCurrent() }, valueRange = 0.1f..2.0f, modifier = Modifier.weight(1f))
+        }
 
-        OutlinedTextField(
-            value = sentenceSilenceText,
-            onValueChange = {
-                sentenceSilenceText = it
-                saveCurrent()
-            },
-            label = { Text("sentence_silence（暂不单独覆盖）") },
-            singleLine = true,
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
-            modifier = Modifier.fillMaxWidth()
-        )
+        Text("lengthScale: 句子整体时长缩放，越大越慢。推荐 1.0。")
+        Row {
+            Text("${"%.2f".format(Locale.US, lengthScale)}")
+            Slider(value = lengthScale, onValueChange = { lengthScale = it; saveCurrent() }, valueRange = 0.5f..2.0f, modifier = Modifier.weight(1f))
+        }
+
+        Text("maxNumSentences: 单次切句上限。推荐 1。")
+        Row {
+            Text("$maxNumSentences")
+            Slider(value = maxNumSentences.toFloat(), onValueChange = { maxNumSentences = it.toInt().coerceIn(1, 10); saveCurrent() }, valueRange = 1f..10f, modifier = Modifier.weight(1f))
+        }
+
+        Text("silenceScale: 句间停顿缩放。推荐 0.2。")
+        Row {
+            Text("${"%.2f".format(Locale.US, silenceScale)}")
+            Slider(value = silenceScale, onValueChange = { silenceScale = it; saveCurrent() }, valueRange = 0f..1f, modifier = Modifier.weight(1f))
+        }
 
         OutlinedTextField(
             value = previewText,
@@ -260,8 +241,10 @@ private fun RoleVoiceSettingRow(
                     val effective = baseProfile.copy(
                         speakerId = setting.speakerId,
                         noiseScale = setting.noiseScale,
-                        noiseW = setting.noiseW,
-                        sentenceSilence = setting.sentenceSilence
+                        noiseScaleW = setting.noiseScaleW,
+                        lengthScale = setting.lengthScale,
+                        maxNumSentences = setting.maxNumSentences,
+                        silenceScale = setting.silenceScale
                     )
                     scope.launch {
                         try {
@@ -275,24 +258,11 @@ private fun RoleVoiceSettingRow(
                     }
                 },
                 enabled = baseProfile != null
-            ) {
-                Text("预览朗读")
-            }
+            ) { Text("预览朗读") }
 
-            Button(
-                onClick = {
-                    scope.launch {
-                        speech.stop()
-                        statusText = "已停止"
-                    }
-                }
-            ) {
-                Text("停止")
-            }
+            Button(onClick = { scope.launch { speech.stop(); statusText = "已停止" } }) { Text("停止") }
         }
 
-        if (statusText.isNotBlank()) {
-            Text(statusText)
-        }
+        if (statusText.isNotBlank()) Text(statusText)
     }
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -64,6 +64,10 @@ data class MagicDramaSettings(
     val imageIntervalMs: Long = 3000L
 )
 
+data class MagicDramaPlaybackOptions(
+    val readNarrationAndNotice: Boolean = false
+)
+
 private sealed interface DramaCommand {
     data class Narration(val text: String, val delayMs: Long, val important: Boolean) : DramaCommand
     data class RoleLine(val roleKey: String, val text: String, val delayMs: Long) : DramaCommand
@@ -89,6 +93,7 @@ fun MagicDramaScreen(
     script: String,
     boundCharacters: List<CharacterEntity>,
     settings: MagicDramaSettings,
+    playbackOptions: MagicDramaPlaybackOptions,
     vm: ResourceViewModel,
     onClose: () -> Unit
 ) {
@@ -114,7 +119,7 @@ fun MagicDramaScreen(
         }
     }
 
-    LaunchedEffect(script, settings.defaultDelayMs, voiceSettings) {
+    LaunchedEffect(script, settings.defaultDelayMs, voiceSettings, playbackOptions) {
         messages.clear()
         currentMedia = null
         countdownSeconds = null
@@ -127,37 +132,28 @@ fun MagicDramaScreen(
             when (val cmd = queue.removeFirst()) {
                 is DramaCommand.Narration -> {
                     val text = renderRandomToken(cmd.text)
-                    messages += DramaMessage.Narration(text = text, important = cmd.important)
-                    val narratorSetting = voiceSettings.roleSettings.firstOrNull { it.roleName == "旁白" }
-                    val narratorProfile = voiceSettings.profiles.firstOrNull { it.id == narratorSetting?.profileId }
-                        ?: voiceSettings.profiles.firstOrNull { it.modelUri == "asset://tts/vits-zh-hf-fanchen-C.onnx" }
-                    if (narratorProfile != null) {
-                        val effective = narratorProfile.copy(
-                            speakerId = narratorSetting?.speakerId,
-                            noiseScale = narratorSetting?.noiseScale,
-                            noiseW = narratorSetting?.noiseW,
-                            sentenceSilence = narratorSetting?.sentenceSilence
+                    val voiceRole = if (cmd.important) "注意" else "旁白"
+                    if (playbackOptions.readNarrationAndNotice) {
+                        speakByRole(
+                            text = text,
+                            roleName = voiceRole,
+                            voiceSettings = voiceSettings,
+                            piperSpeechEngine = piperSpeechEngine
                         )
-                        piperSpeechEngine.speak(text, effective, narratorSetting?.speechRate ?: 1.0f)
                     }
+                    messages += DramaMessage.Narration(text = text, important = cmd.important)
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
                 }
                 is DramaCommand.RoleLine -> {
                     val role = resolveRoleName(cmd.roleKey, boundCharacters)
                     val text = cmd.text.replace("nn", "\n")
+                    speakByRole(
+                        text = text,
+                        roleName = role,
+                        voiceSettings = voiceSettings,
+                        piperSpeechEngine = piperSpeechEngine
+                    )
                     messages += DramaMessage.Role(role = role, text = text)
-                    val roleSetting = voiceSettings.roleSettings.firstOrNull { it.roleName == role }
-                    val roleProfile = voiceSettings.profiles.firstOrNull { it.id == roleSetting?.profileId }
-                        ?: voiceSettings.profiles.firstOrNull { it.modelUri == "asset://tts/vits-zh-hf-fanchen-C.onnx" }
-                    if (roleProfile != null) {
-                        val effective = roleProfile.copy(
-                            speakerId = roleSetting?.speakerId,
-                            noiseScale = roleSetting?.noiseScale,
-                            noiseW = roleSetting?.noiseW,
-                            sentenceSilence = roleSetting?.sentenceSilence
-                        )
-                        piperSpeechEngine.speak(text, effective, roleSetting?.speechRate ?: 1.0f)
-                    }
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
                 }
                 is DramaCommand.ShowResource -> currentMedia = DramaMedia.Resource(cmd.source)
@@ -259,6 +255,29 @@ fun MagicDramaScreen(
                 Icon(Icons.Default.Close, contentDescription = "关闭", tint = Color.White)
             }
         }
+    }
+}
+
+
+private suspend fun speakByRole(
+    text: String,
+    roleName: String,
+    voiceSettings: com.example.quotepicker.util.VoiceSettings,
+    piperSpeechEngine: PiperSpeechEngine
+) {
+    val roleSetting = voiceSettings.roleSettings.firstOrNull { it.roleName == roleName }
+    val roleProfile = voiceSettings.profiles.firstOrNull { it.id == roleSetting?.profileId }
+        ?: voiceSettings.profiles.firstOrNull { it.modelUri == "asset://tts/vits-zh-hf-fanchen-C.onnx" }
+    if (roleProfile != null) {
+        val effective = roleProfile.copy(
+            speakerId = roleSetting?.speakerId,
+            noiseScale = roleSetting?.noiseScale,
+            noiseScaleW = roleSetting?.noiseScaleW,
+            lengthScale = roleSetting?.lengthScale,
+            maxNumSentences = roleSetting?.maxNumSentences,
+            silenceScale = roleSetting?.silenceScale
+        )
+        piperSpeechEngine.speak(text, effective, roleSetting?.speechRate ?: 1.0f)
     }
 }
 

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.AssistChip
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -279,6 +280,7 @@ fun ResourcePreviewScreen(
                                 var showMagicDrama by remember(liveResource.resource.id) { mutableStateOf(false) }
                                 var defaultDelayInput by remember(liveResource.resource.id) { mutableStateOf("3000") }
                                 var imageIntervalInput by remember(liveResource.resource.id) { mutableStateOf("3000") }
+                                var readNarrationAndNotice by remember(liveResource.resource.id) { mutableStateOf(false) }
                                 if (showMagicDrama) {
                                     MagicDramaScreen(
                                         title = liveResource.resource.title,
@@ -287,6 +289,9 @@ fun ResourcePreviewScreen(
                                         settings = MagicDramaSettings(
                                             defaultDelayMs = defaultDelayInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 1000L,
                                             imageIntervalMs = imageIntervalInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 3000L
+                                        ),
+                                        playbackOptions = MagicDramaPlaybackOptions(
+                                            readNarrationAndNotice = readNarrationAndNotice
                                         ),
                                         vm = vm,
                                         onClose = { showMagicDrama = false }
@@ -297,11 +302,18 @@ fun ResourcePreviewScreen(
                                         verticalArrangement = Arrangement.spacedBy(10.dp),
                                         horizontalAlignment = Alignment.CenterHorizontally
                                     ) {
+                                        Row(verticalAlignment = Alignment.CenterVertically) {
+                                            Checkbox(
+                                                checked = readNarrationAndNotice,
+                                                onCheckedChange = { readNarrationAndNotice = it }
+                                            )
+                                            Text("朗读旁白和注意（关闭时仅角色朗读）")
+                                        }
                                         TextButton(onClick = { showMagicDrama = true }) {
                                             Text("开始魔剧")
                                         }
                                         Text(
-                                            text = "播放设置（声音请到标签页右上角“声音设置”中配置）",
+                                            text = "播放设置（声音请到标签页右上角“声音设置”中配置；注意可按角色单独配置）",
                                             style = MaterialTheme.typography.labelMedium,
                                             color = Color(0xFF5F6280)
                                         )

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -48,12 +48,15 @@ class PiperSpeechEngine(private val context: Context) {
     @Volatile
     private var preparedModelDir: File? = null
 
+    @Volatile
+    private var configSignature: String? = null
+
     suspend fun speak(text: String, profile: VoiceProfile, speechRate: Float): Boolean {
         if (text.isBlank()) return false
 
         return withContext(Dispatchers.Default) {
             runCatching {
-                ensureInit()
+                ensureInit(profile)
 
                 val engine = tts ?: error("TTS engine not initialized")
                 val sid = normalizeSpeakerId(engine, profile.speakerId)
@@ -109,12 +112,28 @@ class PiperSpeechEngine(private val context: Context) {
             tts?.release()
             tts = null
             preparedModelDir = null
+            configSignature = null
         }
     }
 
-    private suspend fun ensureInit() = withContext(Dispatchers.IO) {
+    private suspend fun ensureInit(profile: VoiceProfile) = withContext(Dispatchers.IO) {
+        val effectiveNoiseScale = (profile.noiseScale ?: 0.667f).coerceIn(0.1f, 2.0f)
+        val effectiveNoiseScaleW = (profile.noiseScaleW ?: 0.8f).coerceIn(0.1f, 2.0f)
+        val effectiveLengthScale = (profile.lengthScale ?: 1.0f).coerceIn(0.5f, 2.0f)
+        val effectiveMaxNumSentences = (profile.maxNumSentences ?: 1).coerceIn(1, 10)
+        val effectiveSilenceScale = (profile.silenceScale ?: 0.2f).coerceIn(0f, 1f)
+        val targetSignature = listOf(
+            effectiveNoiseScale,
+            effectiveNoiseScaleW,
+            effectiveLengthScale,
+            effectiveMaxNumSentences,
+            effectiveSilenceScale
+        ).joinToString("|")
+
         mutex.withLock {
-            if (tts != null) return@withLock
+            if (tts != null && configSignature == targetSignature) return@withLock
+            tts?.release()
+            tts = null
 
             val modelDir = prepareModelDir()
             preparedModelDir = modelDir
@@ -147,9 +166,9 @@ class PiperSpeechEngine(private val context: Context) {
                 lexicon = lexiconPath,
                 tokens = tokensPath,
                 dictDir = dictDirPath,
-                noiseScale = 0.667f,
-                noiseScaleW = 0.8f,
-                lengthScale = 1.0f
+                noiseScale = effectiveNoiseScale,
+                noiseScaleW = effectiveNoiseScaleW,
+                lengthScale = effectiveLengthScale
             )
 
             val config = OfflineTtsConfig(
@@ -161,11 +180,12 @@ class PiperSpeechEngine(private val context: Context) {
                 ),
                 ruleFsts = ruleFsts,
                 ruleFars = ruleFars,
-                maxNumSentences = 1,
-                silenceScale = 0.2f
+                maxNumSentences = effectiveMaxNumSentences,
+                silenceScale = effectiveSilenceScale
             )
 
             tts = OfflineTts(config = config)
+            configSignature = targetSignature
 
             Log.d(
                 TTS_TAG,

--- a/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
+++ b/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
@@ -15,8 +15,10 @@ data class VoiceProfile(
     val configUri: String,
     val speakerId: Int? = null,
     val noiseScale: Float? = null,
-    val noiseW: Float? = null,
-    val sentenceSilence: Float? = null
+    val noiseScaleW: Float? = null,
+    val lengthScale: Float? = null,
+    val maxNumSentences: Int? = null,
+    val silenceScale: Float? = null
 )
 
 data class RoleVoiceSetting(
@@ -25,8 +27,10 @@ data class RoleVoiceSetting(
     val speechRate: Float = 1.0f,
     val speakerId: Int? = null,
     val noiseScale: Float? = null,
-    val noiseW: Float? = null,
-    val sentenceSilence: Float? = null
+    val noiseScaleW: Float? = null,
+    val lengthScale: Float? = null,
+    val maxNumSentences: Int? = null,
+    val silenceScale: Float? = null
 )
 
 data class VoiceSettings(
@@ -64,8 +68,10 @@ class VoiceSettingsStore(context: Context) {
                             .put("configUri", profile.configUri)
                             .put("speakerId", profile.speakerId)
                             .put("noiseScale", profile.noiseScale)
-                            .put("noiseW", profile.noiseW)
-                            .put("sentenceSilence", profile.sentenceSilence)
+                            .put("noiseScaleW", profile.noiseScaleW)
+                            .put("lengthScale", profile.lengthScale)
+                            .put("maxNumSentences", profile.maxNumSentences)
+                            .put("silenceScale", profile.silenceScale)
                     )
                 }
             })
@@ -78,8 +84,10 @@ class VoiceSettingsStore(context: Context) {
                             .put("speechRate", item.speechRate)
                             .put("speakerId", item.speakerId)
                             .put("noiseScale", item.noiseScale)
-                            .put("noiseW", item.noiseW)
-                            .put("sentenceSilence", item.sentenceSilence)
+                            .put("noiseScaleW", item.noiseScaleW)
+                            .put("lengthScale", item.lengthScale)
+                            .put("maxNumSentences", item.maxNumSentences)
+                            .put("silenceScale", item.silenceScale)
                     )
                 }
             })
@@ -116,8 +124,12 @@ private fun JSONArray?.toProfiles(): List<VoiceProfile> {
                     configUri = item.optString("configUri"),
                     speakerId = item.optNullableInt("speakerId"),
                     noiseScale = item.optNullableFloat("noiseScale"),
-                    noiseW = item.optNullableFloat("noiseW"),
-                    sentenceSilence = item.optNullableFloat("sentenceSilence")
+                    noiseScaleW = item.optNullableFloat("noiseScaleW")
+                        ?: item.optNullableFloat("noiseW"),
+                    lengthScale = item.optNullableFloat("lengthScale"),
+                    maxNumSentences = item.optNullableInt("maxNumSentences"),
+                    silenceScale = item.optNullableFloat("silenceScale")
+                        ?: item.optNullableFloat("sentenceSilence")
                 )
             )
         }
@@ -148,8 +160,12 @@ private fun JSONArray?.toRoleSettings(): List<RoleVoiceSetting> {
                     speechRate = item.optDouble("speechRate", 1.0).toFloat(),
                     speakerId = item.optNullableInt("speakerId"),
                     noiseScale = item.optNullableFloat("noiseScale"),
-                    noiseW = item.optNullableFloat("noiseW"),
-                    sentenceSilence = item.optNullableFloat("sentenceSilence")
+                    noiseScaleW = item.optNullableFloat("noiseScaleW")
+                        ?: item.optNullableFloat("noiseW"),
+                    lengthScale = item.optNullableFloat("lengthScale"),
+                    maxNumSentences = item.optNullableInt("maxNumSentences"),
+                    silenceScale = item.optNullableFloat("silenceScale")
+                        ?: item.optNullableFloat("sentenceSilence")
                 )
             )
         }

--- a/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
@@ -20,6 +20,7 @@ import java.util.UUID
 data class VoiceSettingsUiState(
     val characterNames: List<String> = emptyList(),
     val narratorName: String = "旁白",
+    val noticeName: String = "注意",
     val settings: VoiceSettings = VoiceSettings()
 )
 
@@ -78,8 +79,10 @@ class VoiceSettingsViewModel(application: Application) : AndroidViewModel(applic
         speechRate: Float,
         speakerId: Int?,
         noiseScale: Float?,
-        noiseW: Float?,
-        sentenceSilence: Float?
+        noiseScaleW: Float?,
+        lengthScale: Float?,
+        maxNumSentences: Int?,
+        silenceScale: Float?
     ) {
         localSettings.update { state ->
             val cleaned = state.roleSettings.filterNot { it.roleName == roleName }
@@ -90,8 +93,10 @@ class VoiceSettingsViewModel(application: Application) : AndroidViewModel(applic
                     speechRate = speechRate,
                     speakerId = speakerId,
                     noiseScale = noiseScale,
-                    noiseW = noiseW,
-                    sentenceSilence = sentenceSilence
+                    noiseScaleW = noiseScaleW,
+                    lengthScale = lengthScale,
+                    maxNumSentences = maxNumSentences,
+                    silenceScale = silenceScale
                 )
             )
         }


### PR DESCRIPTION
### Motivation
- 需要让魔剧按角色使用可配置的语音参数并在界面显示每项作用与推荐值，同时限制可调范围以保证安全。 
- 希望旁白/“注意”可以作为独立角色进行朗读控制，并在魔剧预览中可开关旁白与注意的朗读行为。 
- 播放存在延迟，播放逻辑需改为在语音处理完成后再显示文本以避免“先出字后出声”的体验割裂。 

### Description
- 扩展持久化数据模型：在 `VoiceSettingsStore` 中为 `VoiceProfile` 与 `RoleVoiceSetting` 增加 `noiseScaleW / lengthScale / maxNumSentences / silenceScale` 等字段，并保留对旧字段 `noiseW` 和 `sentenceSilence` 的兼容读取。 
- 更新声音设置界面：在 `VoiceSettingsScreen`/`RoleVoiceSettingRow` 使用滑块与说明文本展示 `speakerId / speed / noiseScale / noiseScaleW / lengthScale / maxNumSentences / silenceScale`，所有控件在安全区间内变化并实时保存与支持预览朗读。 
- 魔剧播放改动：在 `ResourcePreviewScreen` 添加“朗读旁白和注意”复选项传入 `MagicDramaPlaybackOptions`，在 `MagicDramaScreen` 中新增 `speakByRole`，并根据开关决定是否朗读旁白/注意，且先触发语音再将文本加入消息列表（把延迟包含在播放节奏内）。 
- TTS 引擎按角色参数动态初始化：在 `PiperSpeechEngine` 中根据传入角色配置构建 `OfflineTts` 配置（并用配置签名复用/重建引擎），把参数限制在合理区间以防异常。 

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 进行编译验证，构建在当前环境因缺少 Java 17 toolchain 而失败（环境问题，非代码逻辑错误）。
- 已对修改的 Kotlin 文件做静态检查与本地编辑/查找验证（无运行时测试通过，因为无法完成 APK 编译）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0d50f9af4832bbc220a3135e38cf8)