### PR TITLE
Voice settings: add Save (as Text/Sound) and text-resource fallback for role configs

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.example.quotepicker.ui
 
+import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -27,18 +28,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.util.PiperSpeechEngine
-import java.util.Locale
 import com.example.quotepicker.util.RoleVoiceSetting
 import com.example.quotepicker.util.VoiceProfile
 import com.example.quotepicker.vm.VoiceSettingsViewModel
+import java.io.File
+import java.util.Locale
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 
 private const val BUILTIN_MODEL_URI = "asset://tts/vits-zh-hf-fanchen-C.onnx"
 
@@ -50,13 +52,8 @@ fun VoiceSettingsScreen(
 ) {
     val ui by vm.uiState.collectAsState()
     val builtInProfile = ui.settings.profiles.firstOrNull { it.modelUri == BUILTIN_MODEL_URI }
-
-    val allRoles = remember(ui.narratorName, ui.noticeName, ui.characterNames) { listOf(ui.narratorName, ui.noticeName) + ui.characterNames }
-    var selectedRole by rememberSaveable(allRoles) { mutableStateOf(allRoles.firstOrNull().orEmpty()) }
-    var showRoleDialog by rememberSaveable { mutableStateOf(false) }
-
-    if (selectedRole !in allRoles) {
-        selectedRole = allRoles.firstOrNull().orEmpty()
+    val allRoles = remember(ui.narratorName, ui.noticeName, ui.characterNames) {
+        (listOf(ui.narratorName, ui.noticeName) + ui.characterNames).distinct()
     }
 
     Scaffold(
@@ -80,68 +77,32 @@ fun VoiceSettingsScreen(
         ) {
             item {
                 Text("当前固定模型：vits-zh-hf-fanchen-C.onnx（无需导入）")
-                Text("可为每个角色单独设置 speaker 和参数，并可直接预览。")
+                Text("可为每个角色单独设置 speaker 和参数，并可直接预览/保存。")
             }
 
-            item {
-                Button(
-                    onClick = { showRoleDialog = true },
-                    enabled = allRoles.isNotEmpty()
-                ) {
-                    Text("选择角色：$selectedRole")
-                }
+            items(allRoles, key = { it }) { roleName ->
+                val current = ui.settings.roleSettings.firstOrNull { it.roleName == roleName }
+                RoleVoiceSettingRow(
+                    roleName = roleName,
+                    baseProfile = builtInProfile,
+                    initial = current,
+                    onSave = {
+                        vm.updateRoleSetting(
+                            roleName,
+                            builtInProfile?.id,
+                            it.speechRate,
+                            it.speakerId,
+                            it.noiseScale,
+                            it.noiseScaleW,
+                            it.lengthScale,
+                            it.maxNumSentences,
+                            it.silenceScale
+                        )
+                    },
+                    onSaveAsText = { payload -> vm.saveRoleConfigAsText(roleName, payload) },
+                    onSaveAsSound = { uri -> vm.savePreviewAsSound(roleName, uri) }
+                )
             }
-
-            item {
-                val current = ui.settings.roleSettings.firstOrNull { it.roleName == selectedRole }
-                if (selectedRole.isNotBlank()) {
-                    RoleVoiceSettingRow(
-                        roleName = selectedRole,
-                        baseProfile = builtInProfile,
-                        initial = current,
-                        onSave = {
-                            vm.updateRoleSetting(
-                                selectedRole,
-                                builtInProfile?.id,
-                                it.speechRate,
-                                it.speakerId,
-                                it.noiseScale,
-                                it.noiseScaleW,
-                                it.lengthScale,
-                                it.maxNumSentences,
-                                it.silenceScale
-                            )
-                        }
-                    )
-                }
-            }
-        }
-
-        if (showRoleDialog) {
-            AlertDialog(
-                onDismissRequest = { showRoleDialog = false },
-                title = { Text("选择角色") },
-                text = {
-                    LazyColumn(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                        items(allRoles, key = { it }) { roleName ->
-                            TextButton(
-                                onClick = {
-                                    selectedRole = roleName
-                                    showRoleDialog = false
-                                },
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Text(roleName)
-                            }
-                        }
-                    }
-                },
-                confirmButton = {
-                    TextButton(onClick = { showRoleDialog = false }) {
-                        Text("关闭")
-                    }
-                }
-            )
         }
     }
 }
@@ -151,7 +112,9 @@ private fun RoleVoiceSettingRow(
     roleName: String,
     baseProfile: VoiceProfile?,
     initial: RoleVoiceSetting?,
-    onSave: (RoleVoiceSetting) -> Unit
+    onSave: (RoleVoiceSetting) -> Unit,
+    onSaveAsText: (String) -> Unit,
+    onSaveAsSound: (Uri) -> Unit
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -166,6 +129,7 @@ private fun RoleVoiceSettingRow(
     var silenceScale by remember(roleName, initial?.silenceScale) { mutableStateOf((initial?.silenceScale ?: 0.2f).coerceIn(0f, 1f)) }
     var previewText by remember(roleName) { mutableStateOf("你好，我是$roleName，这是一段语音预览。") }
     var statusText by remember(roleName) { mutableStateOf("") }
+    var showSaveDialog by remember(roleName) { mutableStateOf(false) }
 
     fun currentSetting() = RoleVoiceSetting(
         roleName = roleName,
@@ -177,6 +141,28 @@ private fun RoleVoiceSettingRow(
         maxNumSentences = maxNumSentences,
         silenceScale = silenceScale
     )
+
+    fun effectiveProfile(setting: RoleVoiceSetting): VoiceProfile? = baseProfile?.copy(
+        speakerId = setting.speakerId,
+        noiseScale = setting.noiseScale,
+        noiseScaleW = setting.noiseScaleW,
+        lengthScale = setting.lengthScale,
+        maxNumSentences = setting.maxNumSentences,
+        silenceScale = setting.silenceScale
+    )
+
+    fun voiceConfigPayload(setting: RoleVoiceSetting): String = JSONObject()
+        .put("kind", "voice_config")
+        .put("roleName", roleName)
+        .put("speechRate", setting.speechRate)
+        .put("speakerId", setting.speakerId)
+        .put("noiseScale", setting.noiseScale)
+        .put("noiseScaleW", setting.noiseScaleW)
+        .put("lengthScale", setting.lengthScale)
+        .put("maxNumSentences", setting.maxNumSentences)
+        .put("silenceScale", setting.silenceScale)
+        .put("previewText", previewText)
+        .toString()
 
     fun saveCurrent() = onSave(currentSetting())
 
@@ -235,17 +221,9 @@ private fun RoleVoiceSettingRow(
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             Button(
                 onClick = {
-                    if (baseProfile == null) return@Button
                     val setting = currentSetting()
                     saveCurrent()
-                    val effective = baseProfile.copy(
-                        speakerId = setting.speakerId,
-                        noiseScale = setting.noiseScale,
-                        noiseScaleW = setting.noiseScaleW,
-                        lengthScale = setting.lengthScale,
-                        maxNumSentences = setting.maxNumSentences,
-                        silenceScale = setting.silenceScale
-                    )
+                    val effective = effectiveProfile(setting) ?: return@Button
                     scope.launch {
                         try {
                             statusText = "正在初始化/朗读..."
@@ -261,8 +239,47 @@ private fun RoleVoiceSettingRow(
             ) { Text("预览朗读") }
 
             Button(onClick = { scope.launch { speech.stop(); statusText = "已停止" } }) { Text("停止") }
+            Button(onClick = { showSaveDialog = true }, enabled = baseProfile != null && previewText.isNotBlank()) { Text("保存") }
         }
 
         if (statusText.isNotBlank()) Text(statusText)
+    }
+
+    if (showSaveDialog) {
+        AlertDialog(
+            onDismissRequest = { showSaveDialog = false },
+            title = { Text("保存方式") },
+            text = { Text("选择作为声音或作为文本保存") },
+            confirmButton = {
+                TextButton(onClick = {
+                    val setting = currentSetting()
+                    saveCurrent()
+                    onSaveAsText(voiceConfigPayload(setting))
+                    statusText = "已保存为文本配置"
+                    showSaveDialog = false
+                }) { Text("作为文本") }
+            },
+            dismissButton = {
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    TextButton(onClick = {
+                        val setting = currentSetting()
+                        saveCurrent()
+                        val effective = effectiveProfile(setting) ?: return@TextButton
+                        scope.launch {
+                            val out = File(context.filesDir, "audio/voice_config_${roleName}_${System.currentTimeMillis()}.wav")
+                            val ok = speech.synthesizeToWav(previewText, effective, setting.speechRate, out)
+                            if (ok) {
+                                onSaveAsSound(Uri.fromFile(out))
+                                statusText = "已保存为声音"
+                            } else {
+                                statusText = "保存声音失败"
+                            }
+                        }
+                        showSaveDialog = false
+                    }) { Text("作为声音") }
+                    TextButton(onClick = { showSaveDialog = false }) { Text("取消") }
+                }
+            }
+        )
     }
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -49,8 +50,11 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.example.quotepicker.data.CharacterEntity
+import com.example.quotepicker.data.ResourceMarkState
 import com.example.quotepicker.data.ResourceType
+import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.util.PiperSpeechEngine
+import com.example.quotepicker.util.RoleVoiceSetting
 import com.example.quotepicker.util.VoiceSettingsStore
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.CompletableDeferred
@@ -58,6 +62,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.json.JSONArray
+import org.json.JSONObject
 
 data class MagicDramaSettings(
     val defaultDelayMs: Long = 1000L,
@@ -111,6 +116,7 @@ fun MagicDramaScreen(
     val voiceSettingsStore = remember(context) { VoiceSettingsStore(context) }
     val piperSpeechEngine = remember(context) { PiperSpeechEngine(context) }
     val voiceSettings = remember { voiceSettingsStore.load() }
+    val allResources by vm.allResources.collectAsState()
 
     DisposableEffect(Unit) {
         onDispose {
@@ -138,6 +144,7 @@ fun MagicDramaScreen(
                             text = text,
                             roleName = voiceRole,
                             voiceSettings = voiceSettings,
+                            allResources = allResources,
                             piperSpeechEngine = piperSpeechEngine
                         )
                     }
@@ -151,6 +158,7 @@ fun MagicDramaScreen(
                         text = text,
                         roleName = role,
                         voiceSettings = voiceSettings,
+                        allResources = allResources,
                         piperSpeechEngine = piperSpeechEngine
                     )
                     messages += DramaMessage.Role(role = role, text = text)
@@ -263,9 +271,11 @@ private suspend fun speakByRole(
     text: String,
     roleName: String,
     voiceSettings: com.example.quotepicker.util.VoiceSettings,
+    allResources: List<ResourceWithTagsCharacters>,
     piperSpeechEngine: PiperSpeechEngine
 ) {
-    val roleSetting = voiceSettings.roleSettings.firstOrNull { it.roleName == roleName }
+    val roleSetting = resolveRoleSettingFromTextResource(roleName, allResources)
+        ?: voiceSettings.roleSettings.firstOrNull { it.roleName == roleName }
     val roleProfile = voiceSettings.profiles.firstOrNull { it.id == roleSetting?.profileId }
         ?: voiceSettings.profiles.firstOrNull { it.modelUri == "asset://tts/vits-zh-hf-fanchen-C.onnx" }
     if (roleProfile != null) {
@@ -279,6 +289,39 @@ private suspend fun speakByRole(
         )
         piperSpeechEngine.speak(text, effective, roleSetting?.speechRate ?: 1.0f)
     }
+}
+
+private fun resolveRoleSettingFromTextResource(
+    roleName: String,
+    resources: List<ResourceWithTagsCharacters>
+): RoleVoiceSetting? {
+    val candidates = resources.filter { item ->
+        item.resource.type == ResourceType.TEXT &&
+                item.resource.title.contains("声音配置") &&
+                item.characters.any { it.name == roleName }
+    }
+    if (candidates.isEmpty()) return null
+    val favorites = candidates.filter { it.resource.markState == ResourceMarkState.FAVORITE }
+    val chosen = if (favorites.size == 1) favorites.first() else candidates.first()
+    return parseVoiceConfig(chosen.resource.quoteText.orEmpty(), roleName)
+}
+
+private fun parseVoiceConfig(raw: String, roleName: String): RoleVoiceSetting? {
+    if (raw.isBlank()) return null
+    return runCatching {
+        val obj = JSONObject(raw)
+        if (obj.optString("kind") != "voice_config") return@runCatching null
+        RoleVoiceSetting(
+            roleName = roleName,
+            speechRate = obj.optDouble("speechRate", 1.0).toFloat(),
+            speakerId = obj.optInt("speakerId", 0),
+            noiseScale = obj.optDouble("noiseScale", 0.667).toFloat(),
+            noiseScaleW = obj.optDouble("noiseScaleW", 0.8).toFloat(),
+            lengthScale = obj.optDouble("lengthScale", 1.0).toFloat(),
+            maxNumSentences = obj.optInt("maxNumSentences", 1),
+            silenceScale = obj.optDouble("silenceScale", 0.2).toFloat()
+        )
+    }.getOrNull()
 }
 
 private suspend fun launchCountdown(total: Int, onTick: (Int?) -> Unit) {

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.io.File
 import java.io.FileOutputStream
 import kotlin.math.abs
@@ -104,6 +106,32 @@ class PiperSpeechEngine(private val context: Context) {
 
     suspend fun stop() = withContext(Dispatchers.IO) {
         stopInternal()
+    }
+
+    suspend fun synthesizeToWav(
+        text: String,
+        profile: VoiceProfile,
+        speechRate: Float,
+        outFile: File
+    ): Boolean {
+        if (text.isBlank()) return false
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                ensureInit(profile)
+                val engine = tts ?: error("TTS engine not initialized")
+                val sid = normalizeSpeakerId(engine, profile.speakerId)
+                val speed = speechRate.coerceIn(0.5f, 2.0f)
+                val audio = engine.generate(text = text, sid = sid, speed = speed)
+                val samples = audio.samples
+                if (samples.isEmpty()) error("Generated audio is empty")
+                val pcm16 = floatToPcm16WithGain(samples)
+                outFile.parentFile?.mkdirs()
+                writeWavFile(outFile, pcm16, audio.sampleRate)
+                true
+            }.onFailure { e ->
+                Log.e(TTS_TAG, "synthesizeToWav failed", e)
+            }.getOrDefault(false)
+        }
     }
 
     suspend fun release() = withContext(Dispatchers.IO) {
@@ -369,6 +397,32 @@ class PiperSpeechEngine(private val context: Context) {
             }
         } finally {
             audioTrack = null
+        }
+    }
+
+    private fun writeWavFile(file: File, samples: ShortArray, sampleRate: Int) {
+        val dataBytes = samples.size * 2
+        val header = ByteBuffer.allocate(44).order(ByteOrder.LITTLE_ENDIAN).apply {
+            put("RIFF".toByteArray())
+            putInt(36 + dataBytes)
+            put("WAVE".toByteArray())
+            put("fmt ".toByteArray())
+            putInt(16)
+            putShort(1)
+            putShort(1)
+            putInt(sampleRate)
+            putInt(sampleRate * 2)
+            putShort(2)
+            putShort(16)
+            put("data".toByteArray())
+            putInt(dataBytes)
+        }.array()
+        FileOutputStream(file).use { fos ->
+            fos.write(header)
+            val pcm = ByteBuffer.allocate(dataBytes).order(ByteOrder.LITTLE_ENDIAN)
+            samples.forEach { pcm.putShort(it) }
+            fos.write(pcm.array())
+            fos.flush()
         }
     }
 }

--- a/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
@@ -1,9 +1,12 @@
 package com.example.quotepicker.vm
 
 import android.app.Application
+import android.net.Uri
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.quotepicker.data.Repository
+import com.example.quotepicker.data.ResourceEntity
+import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.util.RoleVoiceSetting
 import com.example.quotepicker.util.VoiceProfile
 import com.example.quotepicker.util.VoiceSettings
@@ -12,6 +15,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -101,6 +105,34 @@ class VoiceSettingsViewModel(application: Application) : AndroidViewModel(applic
             )
         }
         persist()
+    }
+
+
+    fun saveRoleConfigAsText(roleName: String, textPayload: String) = viewModelScope.launch {
+        val finalRole = roleName.trim()
+        if (finalRole.isBlank() || textPayload.isBlank()) return@launch
+        val matched = repo.observeCharacters().first().firstOrNull { it.name == finalRole } ?: return@launch
+        val title = "声音配置-$finalRole-${'$'}{System.currentTimeMillis() % 100000}"
+        repo.addResource(
+            ResourceEntity(type = ResourceType.TEXT, title = title, quoteText = textPayload),
+            tagIds = emptyList(),
+            characterIds = listOf(matched.id)
+        )
+    }
+
+    fun savePreviewAsSound(roleName: String, wavUri: Uri) = viewModelScope.launch {
+        val finalRole = roleName.trim()
+        if (finalRole.isBlank()) return@launch
+        val matched = repo.observeCharacters().first().firstOrNull { it.name == finalRole } ?: return@launch
+        repo.addResource(
+            ResourceEntity(
+                type = ResourceType.SOUND,
+                title = "声音配置-$finalRole-${'$'}{System.currentTimeMillis() % 100000}",
+                contentUriOrPath = org.json.JSONArray(listOf(wavUri.toString())).toString()
+            ),
+            tagIds = emptyList(),
+            characterIds = listOf(matched.id)
+        )
     }
 
     private fun persist() {


### PR DESCRIPTION
### Motivation
- Implement the new voice settings UX: remove the separate role-selection button and expose per-role settings inline with a `保存` (Save) action after preview/stop. 
- Allow persisting the current voice configuration either as a text resource (so it can be edited/managed) or as an actual sound file generated from the preview. 
- Make runtime playback prefer a text-based voice configuration resource named like "声音配置-*" (with favorite selection rules) and fall back to the existing stored role settings if none is found. 

### Description
- UI: `VoiceSettingsScreen` and `RoleVoiceSettingRow` were updated to list roles inline, add a `保存` button and show a save-mode dialog with `作为文本` and `作为声音` options, and serialize current settings into a JSON payload; changes in `app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt`.
- ViewModel: added `saveRoleConfigAsText(...)` and `savePreviewAsSound(...)` in `VoiceSettingsViewModel` to create `TEXT` and `SOUND` resources respectively; these call the repository to persist resources; changes in `app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt`.
- TTS: added `synthesizeToWav(...)` and a WAV writer (`writeWavFile`) to `PiperSpeechEngine` to generate a PCM->WAV file from the current preview parameters for saving playback files; changes in `app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt`.
- Playback fallback: `MagicDramaScreen.speakByRole(...)` now attempts to find a role-bound text resource whose title contains `"声音配置"`, prefers a single favorite if present, parses its JSON into a `RoleVoiceSetting` (`resolveRoleSettingFromTextResource` / `parseVoiceConfig`) and uses it for synthesis, otherwise falls back to local `VoiceSettings`; changes in `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt`.

### Testing
- Attempted to run Kotlin compilation with `./gradlew :app:compileDebugKotlin` but the environment failed to download the Gradle distribution due to a network/proxy `HTTP/1.1 403 Forbidden`, so no binary compilation was completed. 
- No automated unit/instrumentation tests were run in the environment because of the same network/proxy limitation. 
- Static edits and basic smoke checks (searches, file reads, and local run-time command attempts) were performed and the changes were committed to the repository, but full build validation could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0dfdfce8c832ba0f0388a0755356d)