### PR TITLE
Resource-backed voice config editor, WAV export and runtime resource-based voice selection

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.example.quotepicker.ui
 
+import android.net.Uri
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,7 +8,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.AlertDialog
@@ -27,17 +27,17 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.quotepicker.util.PiperSpeechEngine
-import java.util.Locale
 import com.example.quotepicker.util.RoleVoiceSetting
 import com.example.quotepicker.util.VoiceProfile
+import com.example.quotepicker.vm.ResourceViewModel
 import com.example.quotepicker.vm.VoiceSettingsViewModel
+import java.util.Locale
 import kotlinx.coroutines.launch
 
 private const val BUILTIN_MODEL_URI = "asset://tts/vits-zh-hf-fanchen-C.onnx"
@@ -46,18 +46,13 @@ private const val BUILTIN_MODEL_URI = "asset://tts/vits-zh-hf-fanchen-C.onnx"
 @Composable
 fun VoiceSettingsScreen(
     onBack: () -> Unit,
-    vm: VoiceSettingsViewModel = viewModel()
+    vm: VoiceSettingsViewModel = viewModel(),
+    resourceVm: ResourceViewModel = viewModel()
 ) {
     val ui by vm.uiState.collectAsState()
+    val resourceUi by resourceVm.uiState.collectAsState()
     val builtInProfile = ui.settings.profiles.firstOrNull { it.modelUri == BUILTIN_MODEL_URI }
-
-    val allRoles = remember(ui.narratorName, ui.noticeName, ui.characterNames) { listOf(ui.narratorName, ui.noticeName) + ui.characterNames }
-    var selectedRole by rememberSaveable(allRoles) { mutableStateOf(allRoles.firstOrNull().orEmpty()) }
-    var showRoleDialog by rememberSaveable { mutableStateOf(false) }
-
-    if (selectedRole !in allRoles) {
-        selectedRole = allRoles.firstOrNull().orEmpty()
-    }
+    val current = vm.globalRoleSetting(ui.settings)
 
     Scaffold(
         topBar = {
@@ -80,95 +75,76 @@ fun VoiceSettingsScreen(
         ) {
             item {
                 Text("当前固定模型：vits-zh-hf-fanchen-C.onnx（无需导入）")
-                Text("可为每个角色单独设置 speaker 和参数，并可直接预览。")
+                Text("只维护一套通用配置；保存时可绑定到任意角色的“声音配置”文本资源。")
             }
-
             item {
-                Button(
-                    onClick = { showRoleDialog = true },
-                    enabled = allRoles.isNotEmpty()
-                ) {
-                    Text("选择角色：$selectedRole")
-                }
+                VoiceSettingEditor(
+                    title = "通用配置",
+                    baseProfile = builtInProfile,
+                    initial = current,
+                    initialPreviewText = ui.settings.rolePreviewTexts[VoiceSettingsViewModel.DEFAULT_ROLE_KEY],
+                    allTags = resourceUi.tags,
+                    allCharacters = resourceUi.characters,
+                    onSave = {
+                        vm.updateRoleSetting(
+                            VoiceSettingsViewModel.DEFAULT_ROLE_KEY,
+                            builtInProfile?.id,
+                            it.speechRate,
+                            it.speakerId,
+                            it.noiseScale,
+                            it.noiseScaleW,
+                            it.lengthScale,
+                            it.maxNumSentences,
+                            it.silenceScale
+                        )
+                    },
+                    onPersistPreviewText = { vm.updatePreviewText(VoiceSettingsViewModel.DEFAULT_ROLE_KEY, it) },
+                    onSaveAsText = { title, content, tagIds, characterIds ->
+                        resourceVm.addTextResource(title, content, tagIds, characterIds)
+                    },
+                    onSaveAsSound = { title, uri, tagIds, characterIds ->
+                        resourceVm.addSoundGroup(title, listOf(uri), tagIds, characterIds)
+                    },
+                    buildConfigText = { vm.buildDefaultConfigText() }
+                )
             }
-
-            item {
-                val current = ui.settings.roleSettings.firstOrNull { it.roleName == selectedRole }
-                if (selectedRole.isNotBlank()) {
-                    RoleVoiceSettingRow(
-                        roleName = selectedRole,
-                        baseProfile = builtInProfile,
-                        initial = current,
-                        onSave = {
-                            vm.updateRoleSetting(
-                                selectedRole,
-                                builtInProfile?.id,
-                                it.speechRate,
-                                it.speakerId,
-                                it.noiseScale,
-                                it.noiseScaleW,
-                                it.lengthScale,
-                                it.maxNumSentences,
-                                it.silenceScale
-                            )
-                        }
-                    )
-                }
-            }
-        }
-
-        if (showRoleDialog) {
-            AlertDialog(
-                onDismissRequest = { showRoleDialog = false },
-                title = { Text("选择角色") },
-                text = {
-                    LazyColumn(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                        items(allRoles, key = { it }) { roleName ->
-                            TextButton(
-                                onClick = {
-                                    selectedRole = roleName
-                                    showRoleDialog = false
-                                },
-                                modifier = Modifier.fillMaxWidth()
-                            ) {
-                                Text(roleName)
-                            }
-                        }
-                    }
-                },
-                confirmButton = {
-                    TextButton(onClick = { showRoleDialog = false }) {
-                        Text("关闭")
-                    }
-                }
-            )
         }
     }
 }
 
 @Composable
-private fun RoleVoiceSettingRow(
-    roleName: String,
+private fun VoiceSettingEditor(
+    title: String,
     baseProfile: VoiceProfile?,
     initial: RoleVoiceSetting?,
-    onSave: (RoleVoiceSetting) -> Unit
+    initialPreviewText: String?,
+    allTags: List<com.example.quotepicker.data.TagEntity>,
+    allCharacters: List<com.example.quotepicker.data.CharacterEntity>,
+    onSave: (RoleVoiceSetting) -> Unit,
+    onPersistPreviewText: (String) -> Unit,
+    onSaveAsText: (String, String, List<Long>, List<Long>) -> Unit,
+    onSaveAsSound: (String, Uri, List<Long>, List<Long>) -> Unit,
+    buildConfigText: () -> String
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val speech = remember(context) { PiperSpeechEngine(context) }
 
-    var speed by remember(roleName, initial?.speechRate) { mutableStateOf((initial?.speechRate ?: 1.0f).coerceIn(0.6f, 1.8f)) }
-    var speakerId by remember(roleName, initial?.speakerId) { mutableStateOf((initial?.speakerId ?: 0).coerceIn(0, 186)) }
-    var noiseScale by remember(roleName, initial?.noiseScale) { mutableStateOf((initial?.noiseScale ?: 0.667f).coerceIn(0.1f, 2.0f)) }
-    var noiseScaleW by remember(roleName, initial?.noiseScaleW) { mutableStateOf((initial?.noiseScaleW ?: 0.8f).coerceIn(0.1f, 2.0f)) }
-    var lengthScale by remember(roleName, initial?.lengthScale) { mutableStateOf((initial?.lengthScale ?: 1.0f).coerceIn(0.5f, 2.0f)) }
-    var maxNumSentences by remember(roleName, initial?.maxNumSentences) { mutableStateOf((initial?.maxNumSentences ?: 1).coerceIn(1, 10)) }
-    var silenceScale by remember(roleName, initial?.silenceScale) { mutableStateOf((initial?.silenceScale ?: 0.2f).coerceIn(0f, 1f)) }
-    var previewText by remember(roleName) { mutableStateOf("你好，我是$roleName，这是一段语音预览。") }
-    var statusText by remember(roleName) { mutableStateOf("") }
+    var speed by remember(initial?.speechRate) { mutableStateOf((initial?.speechRate ?: 1.0f).coerceIn(0.6f, 1.8f)) }
+    var speakerId by remember(initial?.speakerId) { mutableStateOf((initial?.speakerId ?: 0).coerceIn(0, 186)) }
+    var noiseScale by remember(initial?.noiseScale) { mutableStateOf((initial?.noiseScale ?: 0.667f).coerceIn(0.1f, 2.0f)) }
+    var noiseScaleW by remember(initial?.noiseScaleW) { mutableStateOf((initial?.noiseScaleW ?: 0.8f).coerceIn(0.1f, 2.0f)) }
+    var lengthScale by remember(initial?.lengthScale) { mutableStateOf((initial?.lengthScale ?: 1.0f).coerceIn(0.5f, 2.0f)) }
+    var maxNumSentences by remember(initial?.maxNumSentences) { mutableStateOf((initial?.maxNumSentences ?: 1).coerceIn(1, 10)) }
+    var silenceScale by remember(initial?.silenceScale) { mutableStateOf((initial?.silenceScale ?: 0.2f).coerceIn(0f, 1f)) }
+    var previewText by remember(initialPreviewText) { mutableStateOf(initialPreviewText ?: "这是一段语音预览。") }
+    var statusText by remember { mutableStateOf("") }
+    var showSaveTextDialog by remember { mutableStateOf(false) }
+    var showSaveSoundDialog by remember { mutableStateOf(false) }
+    var tempAudioUri by remember { mutableStateOf<Uri?>(null) }
 
     fun currentSetting() = RoleVoiceSetting(
-        roleName = roleName,
+        roleName = VoiceSettingsViewModel.DEFAULT_ROLE_KEY,
         speechRate = speed,
         speakerId = speakerId,
         noiseScale = noiseScale,
@@ -181,45 +157,45 @@ private fun RoleVoiceSettingRow(
     fun saveCurrent() = onSave(currentSetting())
 
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
-        Text("$roleName（每项都限制在安全区间）")
+        Text("$title（每项都限制在安全区间）")
 
-        Text("speakerId: 选择音色说话人。推荐 0（可尝试不同角色分配不同 speaker）。")
+        Text("speakerId")
         Row {
             Text("$speakerId")
             Slider(value = speakerId.toFloat(), onValueChange = { speakerId = it.toInt(); saveCurrent() }, valueRange = 0f..186f, modifier = Modifier.weight(1f))
         }
 
-        Text("speed: 语速。推荐 1.0。")
+        Text("speed")
         Row {
             Text("${"%.2f".format(Locale.US, speed)}")
             Slider(value = speed, onValueChange = { speed = it; saveCurrent() }, valueRange = 0.6f..1.8f, modifier = Modifier.weight(1f))
         }
 
-        Text("noiseScale: 发音随机度，越高越活泼。推荐 0.667。")
+        Text("noiseScale")
         Row {
             Text("${"%.3f".format(Locale.US, noiseScale)}")
             Slider(value = noiseScale, onValueChange = { noiseScale = it; saveCurrent() }, valueRange = 0.1f..2.0f, modifier = Modifier.weight(1f))
         }
 
-        Text("noiseScaleW: 音素时长随机度。推荐 0.8。")
+        Text("noiseScaleW")
         Row {
             Text("${"%.3f".format(Locale.US, noiseScaleW)}")
             Slider(value = noiseScaleW, onValueChange = { noiseScaleW = it; saveCurrent() }, valueRange = 0.1f..2.0f, modifier = Modifier.weight(1f))
         }
 
-        Text("lengthScale: 句子整体时长缩放，越大越慢。推荐 1.0。")
+        Text("lengthScale")
         Row {
             Text("${"%.2f".format(Locale.US, lengthScale)}")
             Slider(value = lengthScale, onValueChange = { lengthScale = it; saveCurrent() }, valueRange = 0.5f..2.0f, modifier = Modifier.weight(1f))
         }
 
-        Text("maxNumSentences: 单次切句上限。推荐 1。")
+        Text("maxNumSentences")
         Row {
             Text("$maxNumSentences")
             Slider(value = maxNumSentences.toFloat(), onValueChange = { maxNumSentences = it.toInt().coerceIn(1, 10); saveCurrent() }, valueRange = 1f..10f, modifier = Modifier.weight(1f))
         }
 
-        Text("silenceScale: 句间停顿缩放。推荐 0.2。")
+        Text("silenceScale")
         Row {
             Text("${"%.2f".format(Locale.US, silenceScale)}")
             Slider(value = silenceScale, onValueChange = { silenceScale = it; saveCurrent() }, valueRange = 0f..1f, modifier = Modifier.weight(1f))
@@ -227,7 +203,10 @@ private fun RoleVoiceSettingRow(
 
         OutlinedTextField(
             value = previewText,
-            onValueChange = { previewText = it },
+            onValueChange = {
+                previewText = it
+                onPersistPreviewText(it)
+            },
             label = { Text("预览文本（可修改）") },
             modifier = Modifier.fillMaxWidth()
         )
@@ -247,22 +226,145 @@ private fun RoleVoiceSettingRow(
                         silenceScale = setting.silenceScale
                     )
                     scope.launch {
-                        try {
-                            statusText = "正在初始化/朗读..."
-                            speech.speak(previewText, effective, setting.speechRate)
-                            statusText = "朗读中"
-                        } catch (e: Throwable) {
-                            statusText = "失败：${e.message ?: e.javaClass.simpleName}"
-                            android.util.Log.e("VoiceSettings", "preview failed", e)
-                        }
+                        statusText = if (speech.speak(previewText, effective, setting.speechRate)) "朗读中" else "朗读失败"
                     }
                 },
                 enabled = baseProfile != null
             ) { Text("预览朗读") }
 
             Button(onClick = { scope.launch { speech.stop(); statusText = "已停止" } }) { Text("停止") }
+            Button(onClick = { showSaveTextDialog = true }) { Text("保存") }
+            Button(onClick = {
+                if (baseProfile == null) return@Button
+                val setting = currentSetting()
+                val effective = baseProfile.copy(
+                    speakerId = setting.speakerId,
+                    noiseScale = setting.noiseScale,
+                    noiseScaleW = setting.noiseScaleW,
+                    lengthScale = setting.lengthScale,
+                    maxNumSentences = setting.maxNumSentences,
+                    silenceScale = setting.silenceScale
+                )
+                scope.launch {
+                    statusText = "正在生成声音文件..."
+                    val file = speech.synthesizeToTempWav(previewText, effective, setting.speechRate)
+                    if (file != null) {
+                        tempAudioUri = Uri.fromFile(file)
+                        showSaveSoundDialog = true
+                        statusText = "已生成临时声音文件"
+                    } else {
+                        statusText = "生成失败"
+                    }
+                }
+            }) { Text("留声") }
         }
 
         if (statusText.isNotBlank()) Text(statusText)
+
+        if (showSaveTextDialog) {
+            SaveTextConfigDialog(
+                initialContent = buildConfigText(),
+                tags = allTags,
+                characters = allCharacters,
+                onDismiss = { showSaveTextDialog = false },
+                onConfirm = { saveTitle, content, tagIds, characterIds ->
+                    onSaveAsText(saveTitle, content, tagIds, characterIds)
+                    showSaveTextDialog = false
+                    statusText = "已创建文本资源"
+                }
+            )
+        }
+
+        if (showSaveSoundDialog) {
+            SaveSoundDialog(
+                tempUri = tempAudioUri,
+                tags = allTags,
+                characters = allCharacters,
+                onDismiss = {
+                    tempAudioUri?.path?.let { java.io.File(it).delete() }
+                    tempAudioUri = null
+                    showSaveSoundDialog = false
+                },
+                onConfirm = { saveTitle, uri, tagIds, characterIds ->
+                    onSaveAsSound(saveTitle, uri, tagIds, characterIds)
+                    uri.path?.let { java.io.File(it).delete() }
+                    tempAudioUri = null
+                    showSaveSoundDialog = false
+                    statusText = "已保存声音资源"
+                }
+            )
+        }
     }
+}
+
+@Composable
+private fun SaveTextConfigDialog(
+    initialContent: String,
+    tags: List<com.example.quotepicker.data.TagEntity>,
+    characters: List<com.example.quotepicker.data.CharacterEntity>,
+    onDismiss: () -> Unit,
+    onConfirm: (String, String, List<Long>, List<Long>) -> Unit
+) {
+    var title by remember { mutableStateOf("声音配置") }
+    var content by remember(initialContent) { mutableStateOf(initialContent) }
+    var tagInput by remember { mutableStateOf("") }
+    var characterInput by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("保存声音配置文本") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("文本名") })
+                OutlinedTextField(value = content, onValueChange = { content = it }, label = { Text("文本内容") })
+                OutlinedTextField(value = tagInput, onValueChange = { tagInput = it }, label = { Text("标签(逗号分隔)") })
+                OutlinedTextField(value = characterInput, onValueChange = { characterInput = it }, label = { Text("角色名(逗号分隔)") })
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                val tagNames = tagInput.split(',').map { it.trim() }
+                val roleNames = characterInput.split(',').map { it.trim() }
+                val selectedTagIds = tags.filter { t -> t.name in tagNames }.map { it.id }
+                val selectedCharacterIds = characters.filter { c -> c.name in roleNames }.map { it.id }
+                onConfirm(title.trim().ifBlank { "声音配置" }, content, selectedTagIds, selectedCharacterIds)
+            }) { Text("保存") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
+}
+
+@Composable
+private fun SaveSoundDialog(
+    tempUri: Uri?,
+    tags: List<com.example.quotepicker.data.TagEntity>,
+    characters: List<com.example.quotepicker.data.CharacterEntity>,
+    onDismiss: () -> Unit,
+    onConfirm: (String, Uri, List<Long>, List<Long>) -> Unit
+) {
+    var title by remember { mutableStateOf("留声") }
+    var tagInput by remember { mutableStateOf("") }
+    var characterInput by remember { mutableStateOf("") }
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("保存声音资源") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                OutlinedTextField(value = title, onValueChange = { title = it }, label = { Text("声音资源名") })
+                Text("文件：${tempUri?.lastPathSegment ?: "未生成"}")
+                OutlinedTextField(value = tagInput, onValueChange = { tagInput = it }, label = { Text("标签(逗号分隔)") })
+                OutlinedTextField(value = characterInput, onValueChange = { characterInput = it }, label = { Text("角色名(逗号分隔)") })
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                val uri = tempUri ?: return@TextButton
+                val tagNames = tagInput.split(',').map { it.trim() }
+                val roleNames = characterInput.split(',').map { it.trim() }
+                val selectedTagIds = tags.filter { t -> t.name in tagNames }.map { it.id }
+                val selectedCharacterIds = characters.filter { c -> c.name in roleNames }.map { it.id }
+                onConfirm(title.trim(), uri, selectedTagIds, selectedCharacterIds)
+            }) { Text("保存") }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
+    )
 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -49,8 +49,10 @@ import androidx.compose.ui.viewinterop.AndroidView
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.example.quotepicker.data.CharacterEntity
+import com.example.quotepicker.data.ResourceMarkState
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.util.PiperSpeechEngine
+import com.example.quotepicker.util.RoleVoiceSetting
 import com.example.quotepicker.util.VoiceSettingsStore
 import com.example.quotepicker.vm.ResourceViewModel
 import kotlinx.coroutines.CompletableDeferred
@@ -58,11 +60,14 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.json.JSONArray
+import org.json.JSONObject
 
 data class MagicDramaSettings(
     val defaultDelayMs: Long = 1000L,
     val imageIntervalMs: Long = 3000L
 )
+
+private const val DEFAULT_VOICE_SETTING_ROLE = "__default_voice_setting__"
 
 data class MagicDramaPlaybackOptions(
     val readNarrationAndNotice: Boolean = false
@@ -138,7 +143,8 @@ fun MagicDramaScreen(
                             text = text,
                             roleName = voiceRole,
                             voiceSettings = voiceSettings,
-                            piperSpeechEngine = piperSpeechEngine
+                            piperSpeechEngine = piperSpeechEngine,
+                            vm = vm
                         )
                     }
                     messages += DramaMessage.Narration(text = text, important = cmd.important)
@@ -151,7 +157,8 @@ fun MagicDramaScreen(
                         text = text,
                         roleName = role,
                         voiceSettings = voiceSettings,
-                        piperSpeechEngine = piperSpeechEngine
+                        piperSpeechEngine = piperSpeechEngine,
+                        vm = vm
                     )
                     messages += DramaMessage.Role(role = role, text = text)
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
@@ -263,9 +270,12 @@ private suspend fun speakByRole(
     text: String,
     roleName: String,
     voiceSettings: com.example.quotepicker.util.VoiceSettings,
-    piperSpeechEngine: PiperSpeechEngine
+    piperSpeechEngine: PiperSpeechEngine,
+    vm: ResourceViewModel
 ) {
-    val roleSetting = voiceSettings.roleSettings.firstOrNull { it.roleName == roleName }
+    val roleSetting = resolveRoleSettingFromTextResource(roleName, vm)
+        ?: voiceSettings.roleSettings.firstOrNull { it.roleName == roleName }
+        ?: voiceSettings.roleSettings.firstOrNull { it.roleName == DEFAULT_VOICE_SETTING_ROLE }
     val roleProfile = voiceSettings.profiles.firstOrNull { it.id == roleSetting?.profileId }
         ?: voiceSettings.profiles.firstOrNull { it.modelUri == "asset://tts/vits-zh-hf-fanchen-C.onnx" }
     if (roleProfile != null) {
@@ -279,6 +289,32 @@ private suspend fun speakByRole(
         )
         piperSpeechEngine.speak(text, effective, roleSetting?.speechRate ?: 1.0f)
     }
+}
+
+private fun resolveRoleSettingFromTextResource(roleName: String, vm: ResourceViewModel): RoleVoiceSetting? {
+    val candidates = vm.allResources.value.filter { item ->
+        item.resource.type == ResourceType.TEXT &&
+            item.resource.title.contains("声音配置") &&
+            item.characters.any { it.name == roleName }
+    }
+    val selected = candidates.filter { it.resource.markState == ResourceMarkState.FAVORITE }
+        .ifEmpty { candidates }
+        .firstOrNull()
+        ?: return null
+    val raw = selected.resource.quoteText ?: return null
+    return runCatching {
+        val json = JSONObject(raw)
+        RoleVoiceSetting(
+            roleName = roleName,
+            speechRate = json.optDouble("speechRate", 1.0).toFloat(),
+            speakerId = if (json.has("speakerId")) json.optInt("speakerId") else null,
+            noiseScale = if (json.has("noiseScale")) json.optDouble("noiseScale").toFloat() else null,
+            noiseScaleW = if (json.has("noiseScaleW")) json.optDouble("noiseScaleW").toFloat() else null,
+            lengthScale = if (json.has("lengthScale")) json.optDouble("lengthScale").toFloat() else null,
+            maxNumSentences = if (json.has("maxNumSentences")) json.optInt("maxNumSentences") else null,
+            silenceScale = if (json.has("silenceScale")) json.optDouble("silenceScale").toFloat() else null
+        )
+    }.getOrNull()
 }
 
 private suspend fun launchCountdown(total: Int, onTick: (Int?) -> Unit) {
@@ -392,7 +428,7 @@ private fun parseDramaCommand(raw: String): DramaCommand? {
             val (text, delay) = parseDelayText(value)
             DramaCommand.Narration(text, delay, important = false)
         }
-        key == "重要" -> {
+        key == "重要" || key == "注意" -> {
             val (text, delay) = parseDelayText(value)
             DramaCommand.Narration(text, delay, important = true)
         }

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -17,6 +17,9 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.FileOutputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.UUID
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -104,6 +107,24 @@ class PiperSpeechEngine(private val context: Context) {
 
     suspend fun stop() = withContext(Dispatchers.IO) {
         stopInternal()
+    }
+
+    suspend fun synthesizeToTempWav(text: String, profile: VoiceProfile, speechRate: Float): File? {
+        if (text.isBlank()) return null
+        return withContext(Dispatchers.IO) {
+            runCatching {
+                ensureInit(profile)
+                val engine = tts ?: error("TTS engine not initialized")
+                val sid = normalizeSpeakerId(engine, profile.speakerId)
+                val speed = speechRate.coerceIn(0.5f, 2.0f)
+                val audio = engine.generate(text = text, sid = sid, speed = speed)
+                val pcm = floatToPcm16WithGain(audio.samples)
+                val tempDir = File(context.cacheDir, "voice-preview-audio").apply { mkdirs() }
+                val out = File(tempDir, "preview_${System.currentTimeMillis()}_${UUID.randomUUID()}.wav")
+                writePcmWav(out, pcm, audio.sampleRate)
+                out
+            }.getOrNull()
+        }
     }
 
     suspend fun release() = withContext(Dispatchers.IO) {
@@ -369,6 +390,32 @@ class PiperSpeechEngine(private val context: Context) {
             }
         } finally {
             audioTrack = null
+        }
+    }
+
+    private fun writePcmWav(target: File, pcm: ShortArray, sampleRate: Int) {
+        val dataSize = pcm.size * 2
+        val header = ByteBuffer.allocate(44).order(ByteOrder.LITTLE_ENDIAN).apply {
+            put("RIFF".toByteArray())
+            putInt(36 + dataSize)
+            put("WAVE".toByteArray())
+            put("fmt ".toByteArray())
+            putInt(16)
+            putShort(1)
+            putShort(1)
+            putInt(sampleRate)
+            putInt(sampleRate * 2)
+            putShort(2)
+            putShort(16)
+            put("data".toByteArray())
+            putInt(dataSize)
+        }.array()
+        FileOutputStream(target).use { output ->
+            output.write(header)
+            val pcmBytes = ByteBuffer.allocate(dataSize).order(ByteOrder.LITTLE_ENDIAN)
+            pcm.forEach { pcmBytes.putShort(it) }
+            output.write(pcmBytes.array())
+            output.flush()
         }
     }
 }

--- a/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
+++ b/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
@@ -35,7 +35,8 @@ data class RoleVoiceSetting(
 
 data class VoiceSettings(
     val profiles: List<VoiceProfile> = emptyList(),
-    val roleSettings: List<RoleVoiceSetting> = emptyList()
+    val roleSettings: List<RoleVoiceSetting> = emptyList(),
+    val rolePreviewTexts: Map<String, String> = emptyMap()
 )
 
 class VoiceSettingsStore(context: Context) {
@@ -50,7 +51,8 @@ class VoiceSettingsStore(context: Context) {
                 val root = JSONObject(raw)
                 val profiles = root.optJSONArray("profiles").toProfiles()
                 val roleSettings = root.optJSONArray("roleSettings").toRoleSettings()
-                VoiceSettings(profiles = profiles, roleSettings = roleSettings)
+                val rolePreviewTexts = root.optJSONObject("rolePreviewTexts").toPreviewTexts()
+                VoiceSettings(profiles = profiles, roleSettings = roleSettings, rolePreviewTexts = rolePreviewTexts)
             }.getOrDefault(VoiceSettings())
         }
         return parsed.withBuiltinProfile()
@@ -89,6 +91,11 @@ class VoiceSettingsStore(context: Context) {
                             .put("maxNumSentences", item.maxNumSentences)
                             .put("silenceScale", item.silenceScale)
                     )
+                }
+            })
+            .put("rolePreviewTexts", JSONObject().apply {
+                settings.rolePreviewTexts.forEach { (role, text) ->
+                    put(role, text)
                 }
             })
         prefs.edit().putString(KEY_PAYLOAD, root.toString()).apply()
@@ -170,4 +177,13 @@ private fun JSONArray?.toRoleSettings(): List<RoleVoiceSetting> {
             )
         }
     }
+}
+
+private fun JSONObject?.toPreviewTexts(): Map<String, String> {
+    if (this == null) return emptyMap()
+    return keys().asSequence().mapNotNull { key ->
+        key?.takeIf { it.isNotBlank() }?.let { safeKey ->
+            safeKey to optString(safeKey)
+        }
+    }.toMap()
 }

--- a/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
@@ -4,6 +4,9 @@ import android.app.Application
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.quotepicker.data.Repository
+import com.example.quotepicker.data.ResourceMarkState
+import com.example.quotepicker.data.ResourceType
+import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.util.RoleVoiceSetting
 import com.example.quotepicker.util.VoiceProfile
 import com.example.quotepicker.util.VoiceSettings
@@ -15,6 +18,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import org.json.JSONObject
 import java.util.UUID
 
 data class VoiceSettingsUiState(
@@ -25,6 +29,9 @@ data class VoiceSettingsUiState(
 )
 
 class VoiceSettingsViewModel(application: Application) : AndroidViewModel(application) {
+    companion object {
+        const val DEFAULT_ROLE_KEY = "__default_voice_setting__"
+    }
     private val repo = Repository.get(application)
     private val store = VoiceSettingsStore(application)
     private val localSettings = MutableStateFlow(store.load())
@@ -101,6 +108,63 @@ class VoiceSettingsViewModel(application: Application) : AndroidViewModel(applic
             )
         }
         persist()
+    }
+
+    fun updatePreviewText(roleName: String, text: String) {
+        localSettings.update { state ->
+            state.copy(rolePreviewTexts = state.rolePreviewTexts.toMutableMap().apply { put(roleName, text) })
+        }
+        persist()
+    }
+
+
+    fun resolveRoleSettingFromResources(roleName: String, resources: List<ResourceWithTagsCharacters>): RoleVoiceSetting? {
+        val candidates = resources.filter { item ->
+            item.resource.type == ResourceType.TEXT &&
+                item.resource.title.contains("声音配置") &&
+                item.characters.any { it.name == roleName }
+        }
+        val picked = candidates
+            .filter { it.resource.markState == ResourceMarkState.FAVORITE }
+            .ifEmpty { candidates }
+            .firstOrNull()
+            ?: return null
+        return parseRoleSettingFromText(roleName, picked.resource.quoteText)
+    }
+
+    private fun parseRoleSettingFromText(roleName: String, content: String?): RoleVoiceSetting? {
+        if (content.isNullOrBlank()) return null
+        return runCatching {
+            val root = JSONObject(content)
+            RoleVoiceSetting(
+                roleName = roleName,
+                speechRate = root.optDouble("speechRate", 1.0).toFloat(),
+                speakerId = if (root.has("speakerId")) root.optInt("speakerId") else null,
+                noiseScale = if (root.has("noiseScale")) root.optDouble("noiseScale").toFloat() else null,
+                noiseScaleW = if (root.has("noiseScaleW")) root.optDouble("noiseScaleW").toFloat() else null,
+                lengthScale = if (root.has("lengthScale")) root.optDouble("lengthScale").toFloat() else null,
+                maxNumSentences = if (root.has("maxNumSentences")) root.optInt("maxNumSentences") else null,
+                silenceScale = if (root.has("silenceScale")) root.optDouble("silenceScale").toFloat() else null
+            )
+        }.getOrNull()
+    }
+
+
+    fun globalRoleSetting(settings: VoiceSettings = localSettings.value): RoleVoiceSetting? {
+        return settings.roleSettings.firstOrNull { it.roleName == DEFAULT_ROLE_KEY }
+    }
+
+    fun buildDefaultConfigText(): String {
+        val roleSetting = globalRoleSetting()
+        return JSONObject()
+            .put("speechRate", roleSetting?.speechRate ?: 1.0)
+            .put("speakerId", roleSetting?.speakerId ?: 0)
+            .put("noiseScale", roleSetting?.noiseScale ?: 0.667)
+            .put("noiseScaleW", roleSetting?.noiseScaleW ?: 0.8)
+            .put("lengthScale", roleSetting?.lengthScale ?: 1.0)
+            .put("maxNumSentences", roleSetting?.maxNumSentences ?: 1)
+            .put("silenceScale", roleSetting?.silenceScale ?: 0.2)
+            .toString(2)
     }
 
     private fun persist() {


### PR DESCRIPTION
### Motivation
- Centralize voice configuration into a single, sharable default config and allow binding that config to characters via text resources. 
- Let users persist preview texts and export synthesized previews as WAV sound resources for reuse. 
- Allow playback code (drama player) to prefer voice settings defined in text resources so resource-marked configs can override built-in role mappings.

### Description
- Replaced per-role selection UI with a `VoiceSettingEditor` in `VoiceSettingsScreen.kt` and added dialogs `SaveTextConfigDialog` and `SaveSoundDialog`, wired to `ResourceViewModel` to save configurations as text resources or audio resources, and added preview text persistence calls to the view model. 
- Added `synthesizeToTempWav` and `writePcmWav` to `PiperSpeechEngine.kt` to synthesize audio to a temporary WAV file (uses UUID-based filenames) and return a `File`; retained in-memory preview playback flow. 
- Extended `VoiceSettingsStore` to persist `rolePreviewTexts` in the stored JSON payload and load them back. 
- Extended `VoiceSettingsViewModel` with `DEFAULT_ROLE_KEY`, `updatePreviewText`, `globalRoleSetting`, `buildDefaultConfigText`, and JSON parsing helpers to parse role settings from text resources. 
- Updated `MagicDramaScreen.kt` to attempt resolving role voice settings from text resources (favorite-first) before falling back to stored role settings or the default global config, and accept the additional `ResourceViewModel` parameter in speak calls; also added support for the script token `注意` as an important narration key.

### Testing
- Ran an app build with `./gradlew :app:assembleDebug` which completed successfully. 
- Ran unit tests with `./gradlew :app:test` and the test suite completed with no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0f379d960832bba7e568b1019b87f)