### PR TITLE
清理语音相关临时文件，避免中断后占用存储

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -154,6 +155,16 @@ private fun VoiceSettingEditor(
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val speech = remember(context) { PiperSpeechEngine(context) }
+
+    DisposableEffect(speech) {
+        onDispose {
+            scope.launch {
+                speech.stop()
+                speech.cleanupPreviewTempFiles()
+                speech.release()
+            }
+        }
+    }
 
     var speed by remember(initial?.speechRate) { mutableStateOf((initial?.speechRate ?: 1.0f).coerceIn(0.6f, 1.8f)) }
     var speakerId by remember(initial?.speakerId) { mutableStateOf((initial?.speakerId ?: 0).coerceIn(0, 186)) }

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -121,6 +121,11 @@ fun MagicDramaScreen(
         onDispose {
             countdownJob?.cancel()
             pendingBranch?.cancel()
+            coroutineScope.launch {
+                piperSpeechEngine.stop()
+                piperSpeechEngine.cleanupPreviewTempFiles()
+                piperSpeechEngine.release()
+            }
         }
     }
 

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -19,6 +19,7 @@ import java.io.File
 import java.io.FileOutputStream
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
+import java.util.concurrent.TimeUnit
 import java.util.UUID
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -38,6 +39,9 @@ class PiperSpeechEngine(private val context: Context) {
 
         private const val MAX_GAIN = 8.0f
         private const val TARGET_PEAK = 0.75f
+        private const val PREVIEW_TEMP_DIR = "voice-preview-audio"
+        private val PREVIEW_TEMP_MAX_AGE_MS = TimeUnit.HOURS.toMillis(12)
+        private const val PREVIEW_TEMP_MAX_FILE_COUNT = 5
     }
 
     private val mutex = Mutex()
@@ -114,16 +118,35 @@ class PiperSpeechEngine(private val context: Context) {
         return withContext(Dispatchers.IO) {
             runCatching {
                 ensureInit(profile)
+                cleanupPreviewTempFiles()
                 val engine = tts ?: error("TTS engine not initialized")
                 val sid = normalizeSpeakerId(engine, profile.speakerId)
                 val speed = speechRate.coerceIn(0.5f, 2.0f)
                 val audio = engine.generate(text = text, sid = sid, speed = speed)
                 val pcm = floatToPcm16WithGain(audio.samples)
-                val tempDir = File(context.cacheDir, "voice-preview-audio").apply { mkdirs() }
+                val tempDir = File(context.cacheDir, PREVIEW_TEMP_DIR).apply { mkdirs() }
                 val out = File(tempDir, "preview_${System.currentTimeMillis()}_${UUID.randomUUID()}.wav")
                 writePcmWav(out, pcm, audio.sampleRate)
                 out
             }.getOrNull()
+        }
+    }
+
+    suspend fun cleanupPreviewTempFiles() = withContext(Dispatchers.IO) {
+        val tempDir = File(context.cacheDir, PREVIEW_TEMP_DIR)
+        if (!tempDir.exists()) return@withContext
+        val now = System.currentTimeMillis()
+        val files = tempDir.listFiles()
+            ?.filter { it.isFile }
+            ?.sortedByDescending { it.lastModified() }
+            .orEmpty()
+
+        files.forEachIndexed { index, file ->
+            val isExpired = now - file.lastModified() > PREVIEW_TEMP_MAX_AGE_MS
+            val exceedsCountLimit = index >= PREVIEW_TEMP_MAX_FILE_COUNT
+            if (isExpired || exceedsCountLimit) {
+                runCatching { file.delete() }
+            }
         }
     }
 

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -876,6 +876,11 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
         }.getOrDefault(false)
         if (!deleted) {
             runCatching { app.contentResolver.delete(uri, null, null) }
+            if (uri.scheme == "file") {
+                runCatching {
+                    uri.path?.let { File(it).delete() }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- 防止在“留声”、“预览朗读”和魔剧播放过程中产生的临时 wav 文件因中断或页面返回未被删除，长期占用应用存储空间。
- 在页面退出或组件销毁时确保语音引擎资源被正确停止和释放，避免音频播放/资源泄露。

### Description
- 在 `PiperSpeechEngine` 新增 `cleanupPreviewTempFiles()` 并在 `synthesizeToTempWav()` 生成前调用，清理 `cache/voice-preview-audio` 下过期/过多的临时文件；实现策略为超过 12 小时的文件会被删除并且最多保留最近 5 个文件（通过 `PREVIEW_TEMP_MAX_AGE_MS` 与 `PREVIEW_TEMP_MAX_FILE_COUNT` 控制）。
- 在声音设置页的 `VoiceSettingEditor` 中添加 `DisposableEffect` 生命周期回调，页面退出时执行 `speech.stop()`、`speech.cleanupPreviewTempFiles()` 与 `speech.release()`，确保销毁路径也会回收资源与临时文件（`app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt`）。
- 在魔剧播放页 `MagicDramaScreen` 的 `onDispose` 中同样调用 `piperSpeechEngine.stop()`、`cleanupPreviewTempFiles()` 与 `release()` 以处理播放中断/关闭场景（`app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt`）。
- 增强导入后源文件删除的兜底逻辑：`ResourceViewModel.deleteSourceUri()` 在 `contentResolver.delete` 失败且为 `file://` URI 时额外尝试按文件路径删除，减少导入时遗留临时源文件的风险（`app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt`）。

### Testing
- 尝试运行编译命令 `./gradlew :app:compileDebugKotlin` 作为自动化验证，但在本环境中 Gradle Wrapper 下载被代理拦截返回 HTTP 403，导致编译未能完成（环境网络限制），因此无法在 CI/本地完成二进制编译验证。
- 已将修改提交（commit `72ccbb1`），并包含上述文件改动以供代码审查与在可联网环境下的构建/测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1020beefc832b9ee63391159584be)