### PR TITLE
Add magic drama pre-playback voice mode options

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -70,8 +70,14 @@ data class MagicDramaSettings(
 private const val DEFAULT_VOICE_SETTING_ROLE = "__default_voice_setting__"
 
 data class MagicDramaPlaybackOptions(
-    val readNarrationAndNotice: Boolean = false
+    val voicePlaybackMode: MagicDramaVoicePlaybackMode = MagicDramaVoicePlaybackMode.ROLE_ONLY
 )
+
+enum class MagicDramaVoicePlaybackMode {
+    SILENT,
+    ROLE_ONLY,
+    ALL
+}
 
 private sealed interface DramaCommand {
     data class Narration(val text: String, val delayMs: Long, val important: Boolean) : DramaCommand
@@ -143,7 +149,7 @@ fun MagicDramaScreen(
                 is DramaCommand.Narration -> {
                     val text = renderRandomToken(cmd.text)
                     val voiceRole = if (cmd.important) "注意" else "旁白"
-                    if (playbackOptions.readNarrationAndNotice) {
+                    if (playbackOptions.voicePlaybackMode == MagicDramaVoicePlaybackMode.ALL) {
                         speakByRole(
                             text = text,
                             roleName = voiceRole,
@@ -158,13 +164,15 @@ fun MagicDramaScreen(
                 is DramaCommand.RoleLine -> {
                     val role = resolveRoleName(cmd.roleKey, boundCharacters)
                     val text = cmd.text.replace("nn", "\n")
-                    speakByRole(
-                        text = text,
-                        roleName = role,
-                        voiceSettings = voiceSettings,
-                        piperSpeechEngine = piperSpeechEngine,
-                        vm = vm
-                    )
+                    if (playbackOptions.voicePlaybackMode != MagicDramaVoicePlaybackMode.SILENT) {
+                        speakByRole(
+                            text = text,
+                            roleName = role,
+                            voiceSettings = voiceSettings,
+                            piperSpeechEngine = piperSpeechEngine,
+                            vm = vm
+                        )
+                    }
                     messages += DramaMessage.Role(role = role, text = text)
                     delay(if (cmd.delayMs > 0) cmd.delayMs else settings.defaultDelayMs)
                 }

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.AssistChip
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -74,6 +73,7 @@ import androidx.compose.ui.window.DialogProperties
 import com.example.quotepicker.data.ResourceMarkState
 import com.example.quotepicker.data.ResourceType
 import com.example.quotepicker.data.ResourceWithTagsCharacters
+import com.example.quotepicker.ui.components.MagicDramaVoicePlaybackMode
 import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.ui.components.sortTagsForDisplay
 import com.example.quotepicker.vm.ResourceViewModel
@@ -280,7 +280,9 @@ fun ResourcePreviewScreen(
                                 var showMagicDrama by remember(liveResource.resource.id) { mutableStateOf(false) }
                                 var defaultDelayInput by remember(liveResource.resource.id) { mutableStateOf("3000") }
                                 var imageIntervalInput by remember(liveResource.resource.id) { mutableStateOf("3000") }
-                                var readNarrationAndNotice by remember(liveResource.resource.id) { mutableStateOf(false) }
+                                var voicePlaybackMode by remember(liveResource.resource.id) {
+                                    mutableStateOf(MagicDramaVoicePlaybackMode.ROLE_ONLY)
+                                }
                                 if (showMagicDrama) {
                                     MagicDramaScreen(
                                         title = liveResource.resource.title,
@@ -291,7 +293,7 @@ fun ResourcePreviewScreen(
                                             imageIntervalMs = imageIntervalInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 3000L
                                         ),
                                         playbackOptions = MagicDramaPlaybackOptions(
-                                            readNarrationAndNotice = readNarrationAndNotice
+                                            voicePlaybackMode = voicePlaybackMode
                                         ),
                                         vm = vm,
                                         onClose = { showMagicDrama = false }
@@ -302,12 +304,32 @@ fun ResourcePreviewScreen(
                                         verticalArrangement = Arrangement.spacedBy(10.dp),
                                         horizontalAlignment = Alignment.CenterHorizontally
                                     ) {
-                                        Row(verticalAlignment = Alignment.CenterVertically) {
-                                            Checkbox(
-                                                checked = readNarrationAndNotice,
-                                                onCheckedChange = { readNarrationAndNotice = it }
-                                            )
-                                            Text("朗读旁白和注意（关闭时仅角色朗读）")
+                                        Column(
+                                            modifier = Modifier.fillMaxWidth(),
+                                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                                        ) {
+                                            Text("开始前设置：角色朗读模式")
+                                            Row(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                                            ) {
+                                                val options = listOf(
+                                                    MagicDramaVoicePlaybackMode.SILENT to "无声",
+                                                    MagicDramaVoicePlaybackMode.ROLE_ONLY to "角色",
+                                                    MagicDramaVoicePlaybackMode.ALL to "全部"
+                                                )
+                                                options.forEach { (mode, label) ->
+                                                    AssistChip(
+                                                        onClick = { voicePlaybackMode = mode },
+                                                        label = { Text(label) },
+                                                        modifier = Modifier.weight(1f),
+                                                        colors = ButtonDefaults.assistChipColors(
+                                                            containerColor = if (voicePlaybackMode == mode) Color(0xFFE5E8FF) else Color(0xFFF5F5F5),
+                                                            labelColor = if (voicePlaybackMode == mode) Color(0xFF2D3561) else Color(0xFF444444)
+                                                        )
+                                                    )
+                                                }
+                                            }
                                         }
                                         TextButton(onClick = { showMagicDrama = true }) {
                                             Text("开始魔剧")


### PR DESCRIPTION
### Motivation
- Provide a more flexible pre-playback voice control for the Magic Drama feature so users can choose between silent, role-only, or full narration playback instead of a single boolean toggle.

### Description
- Replace the boolean `readNarrationAndNotice` option with a `MagicDramaVoicePlaybackMode` enum and change `MagicDramaPlaybackOptions` to use `voicePlaybackMode` with default `ROLE_ONLY`.
- Update `MagicDramaScreen` playback logic so narration/notice is spoken only when `voicePlaybackMode == MagicDramaVoicePlaybackMode.ALL`, role lines are spoken when `voicePlaybackMode != MagicDramaVoicePlaybackMode.SILENT`, and nothing is spoken in `SILENT` mode.
- Update the Resource preview start panel UI to expose a pre-start control using three `AssistChip` options (`无声`/`角色`/`全部`) and pass the selected `voicePlaybackMode` into `MagicDramaScreen`.
- Modified files: `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt` and `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, which failed in this environment due to Gradle distribution download being blocked by a proxy (`HTTP/1.1 403 Forbidden`), so compilation could not be validated here.
- Performed local code inspections and searches to confirm references were updated and the new enum is used consistently across the modified UI and playback code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b10db96734832b97dd873ee06d7fda)