### PR TITLE
魔剧设置：将停留时间和轮播间隔切换为秒单位

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -278,8 +278,8 @@ fun ResourcePreviewScreen(
                                 val quoteText = liveResource.resource.quoteText.orEmpty()
                                 val isMagicDrama = liveResource.resource.title.contains("魔剧")
                                 var showMagicDrama by remember(liveResource.resource.id) { mutableStateOf(false) }
-                                var defaultDelayInput by remember(liveResource.resource.id) { mutableStateOf("3000") }
-                                var imageIntervalInput by remember(liveResource.resource.id) { mutableStateOf("3000") }
+                                var defaultDelayInput by remember(liveResource.resource.id) { mutableStateOf("3") }
+                                var imageIntervalInput by remember(liveResource.resource.id) { mutableStateOf("3") }
                                 var voicePlaybackMode by remember(liveResource.resource.id) {
                                     mutableStateOf(MagicDramaVoicePlaybackMode.ROLE_ONLY)
                                 }
@@ -289,8 +289,10 @@ fun ResourcePreviewScreen(
                                         script = quoteText,
                                         boundCharacters = liveResource.characters,
                                         settings = MagicDramaSettings(
-                                            defaultDelayMs = defaultDelayInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 1000L,
-                                            imageIntervalMs = imageIntervalInput.toLongOrNull()?.coerceIn(300L, 10_000L) ?: 3000L
+                                            defaultDelayMs = (defaultDelayInput.toLongOrNull()?.coerceIn(1L, 10L)
+                                                ?: 3L) * 1000L,
+                                            imageIntervalMs = (imageIntervalInput.toLongOrNull()?.coerceIn(1L, 10L)
+                                                ?: 3L) * 1000L
                                         ),
                                         playbackOptions = MagicDramaPlaybackOptions(
                                             voicePlaybackMode = voicePlaybackMode
@@ -343,14 +345,14 @@ fun ResourcePreviewScreen(
                                             value = defaultDelayInput,
                                             onValueChange = { defaultDelayInput = it },
                                             singleLine = true,
-                                            label = { Text("文本默认停留毫秒(300-10000)") },
+                                            label = { Text("文本默认停留秒(1-10)") },
                                             modifier = Modifier.fillMaxWidth()
                                         )
                                         OutlinedTextField(
                                             value = imageIntervalInput,
                                             onValueChange = { imageIntervalInput = it },
                                             singleLine = true,
-                                            label = { Text("图片轮播毫秒(300-10000)") },
+                                            label = { Text("图片轮播秒(1-10)") },
                                             modifier = Modifier.fillMaxWidth()
                                         )
                                     }


### PR DESCRIPTION
### Motivation
- 将魔剧播放前设置的时间单位从毫秒改为秒，以便用户输入更直观且易于理解。

### Description
- 修改 `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt` 中两个输入默认值从 `"3000"` 改为 `"3"`，将校验范围从 `300L..10_000L` 改为 `1L..10L`，在传入 `MagicDramaSettings` 时将秒数乘以 `1000L` 转回毫秒，并更新 UI 标签为 `秒(1-10)`。

### Testing
- 进行了 `./gradlew :app:compileDebugKotlin` 编译尝试以验证改动，但因环境需下载 Gradle 发行包且代理返回 `403 Forbidden` 导致下载失败，无法在该环境完成编译验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b11cb0b4ec832b88b297dbfc7f991d)