### PR TITLE
Adjust magic drama narration voice role and variable status layout

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.widget.VideoView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -36,6 +37,7 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberScrollState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -169,9 +171,10 @@ fun MagicDramaScreen(
                 is DramaCommand.Narration -> {
                     val text = renderRandomToken(cmd.text)
                     if (playbackOptions.voicePlaybackMode == MagicDramaVoicePlaybackMode.ALL) {
+                        val narrationRoleName = if (cmd.important) "注意" else "旁白"
                         speakByRole(
                             text = text,
-                            roleName = "注意",
+                            roleName = narrationRoleName,
                             voiceSettings = voiceSettings,
                             piperSpeechEngine = piperSpeechEngine,
                             vm = vm
@@ -265,6 +268,29 @@ fun MagicDramaScreen(
                     }
                 }
             }
+            if (variables.isNotEmpty()) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .background(Color(0xFFF2F6FF))
+                        .padding(horizontal = 10.dp, vertical = 4.dp)
+                        .horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(text = "状态", style = MaterialTheme.typography.labelSmall, color = Color(0xFF42506A))
+                    variables.forEach { (k, v) ->
+                        Text(
+                            text = "$k:$v",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = Color(0xFF1F2433),
+                            modifier = Modifier
+                                .background(Color.White, RoundedCornerShape(10.dp))
+                                .padding(horizontal = 8.dp, vertical = 2.dp)
+                        )
+                    }
+                }
+            }
             Column(
                 modifier = Modifier
                     .weight(2f)
@@ -274,32 +300,15 @@ fun MagicDramaScreen(
             ) {
                 Text(text = title, color = Color(0xFF2D3561), style = MaterialTheme.typography.labelMedium)
                 Spacer(modifier = Modifier.height(8.dp))
-                Row(modifier = Modifier.weight(1f)) {
-                    LazyColumn(
-                        modifier = Modifier.weight(1f),
-                        verticalArrangement = Arrangement.spacedBy(8.dp),
-                        state = listState
-                    ) {
-                        items(messages) { message ->
-                            when (message) {
-                                is DramaMessage.Narration -> NarrationBubble(message)
-                                is DramaMessage.Role -> RoleBubble(message)
-                            }
-                        }
-                    }
-                    if (variables.isNotEmpty()) {
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Column(
-                            modifier = Modifier
-                                .width(120.dp)
-                                .background(Color(0xFFF2F6FF), RoundedCornerShape(8.dp))
-                                .padding(8.dp),
-                            verticalArrangement = Arrangement.spacedBy(4.dp)
-                        ) {
-                            Text(text = "状态", style = MaterialTheme.typography.labelSmall, color = Color(0xFF42506A))
-                            variables.forEach { (k, v) ->
-                                Text(text = "$k:$v", style = MaterialTheme.typography.labelSmall, color = Color(0xFF1F2433))
-                            }
+                LazyColumn(
+                    modifier = Modifier.weight(1f),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
+                    state = listState
+                ) {
+                    items(messages) { message ->
+                        when (message) {
+                            is DramaMessage.Narration -> NarrationBubble(message)
+                            is DramaMessage.Role -> RoleBubble(message)
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation
- Narration lines (`旁白` and `注意`) were using the same voice lookup behavior and should each resolve to their own role when loading voice configurations from text resources.
- The variable state display in the Magic Drama view was occupying the dialogue side panel and should instead be presented as a compact, low-height strip between the media and dialogue areas.

### Description
- Updated narration playback in `MagicDramaScreen.kt` to compute `narrationRoleName` (`"注意"` for important narration, otherwise `"旁白"`) and pass it to `speakByRole` so each narration type can resolve its own `声音配置` resource.
- Moved variables UI out of the dialogue right-side panel into a new compact horizontal strip between the media and dialogue areas and removed the old right-side status panel.
- Made the status strip low-height, pack items in a single row, and enabled horizontal scrolling using `horizontalScroll` and `rememberScrollState`; added related imports and small styling tweaks (rounded white chips, color tokens).
- Simplified the dialogue column layout to only host the message list (no longer showing the right-side variables column).

### Testing
- Attempted to run the Kotlin build with `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper download failed due to an external proxy blocking the download (`HTTP/1.1 403 Forbidden`).
- Verified the change was committed to the repository with `git commit` and inspected the diff via `git show` / `git diff` (commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b123d1828c832bbf6a3d12778f7a93)