### PR TITLE
优化资源列表角色显示：最多显示4个并折叠其余

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -87,6 +87,7 @@ import com.example.quotepicker.ui.components.ResourceListRow
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.SquareGridItem
 import com.example.quotepicker.ui.components.sortTagsForDisplay
+import com.example.quotepicker.ui.components.formatRoleListForResourceRow
 import com.example.quotepicker.ui.components.isPrefixGroupingCategory
 import com.example.quotepicker.ui.components.splitTagsByPrefix
 import com.example.quotepicker.vm.CharacterViewModel
@@ -945,7 +946,7 @@ private fun CharacterGroupedResourcePage(
                 ResourceListRow(
                     resource = resource,
                     categories = categories,
-                    roleText = resource.characters.joinToString("/") { it.name }.ifBlank { "无角色" },
+                    roleText = formatRoleListForResourceRow(resource.characters.map { it.name }),
                     onClick = { onPreview(resource) },
                     onLongClick = {}
                 )

--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -95,6 +95,7 @@ import com.example.quotepicker.ui.components.ResourceListRow
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
 import com.example.quotepicker.ui.components.TagBadge
 import com.example.quotepicker.ui.components.sortTagsForDisplay
+import com.example.quotepicker.ui.components.formatRoleListForResourceRow
 import com.example.quotepicker.ui.components.tagTextColor
 import com.example.quotepicker.vm.FlowUpdateItem
 import com.example.quotepicker.vm.ImageUpdateItem
@@ -363,7 +364,7 @@ fun ResourceScreen(modifier: Modifier = Modifier, vm: ResourceViewModel = viewMo
                             ResourceListRow(
                                 resource = res,
                                 categories = ui.categories,
-                                roleText = res.characters.joinToString("/") { it.name }.ifBlank { "无角色" },
+                                roleText = formatRoleListForResourceRow(res.characters.map { it.name }),
                                 onClick = { previewTarget = res },
                                 onLongClick = { bottomSheetTarget = res }
                             )
@@ -1378,7 +1379,7 @@ private fun ResourceGroupedPage(
                 ResourceListRow(
                     resource = resource,
                     categories = categories,
-                    roleText = resource.characters.joinToString("/") { it.name }.ifBlank { "无角色" },
+                    roleText = formatRoleListForResourceRow(resource.characters.map { it.name }),
                     onClick = { onPreview(resource) },
                     onLongClick = { onLongClick(resource) }
                 )

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt
@@ -94,6 +94,21 @@ fun ResourceListRow(
     }
 }
 
+fun formatRoleListForResourceRow(roleNames: List<String>): String {
+    val cleanedNames = roleNames.map { it.trim() }.filter { it.isNotEmpty() }
+    if (cleanedNames.isEmpty()) return "无角色"
+
+    val prioritizedNames = cleanedNames.sortedByDescending { it.length }
+    val visibleNames = prioritizedNames.take(4)
+    val hasMoreRoles = prioritizedNames.size > visibleNames.size
+    return buildString {
+        append(visibleNames.joinToString("/"))
+        if (hasMoreRoles) {
+            append("/...")
+        }
+    }
+}
+
 @Composable
 private fun CompactTagLabel(tag: TagEntity) {
     val bgColor = Color(tag.colorArgb)


### PR DESCRIPTION
### Motivation
- 资源列表在绑定过多角色时会挤压资源名导致布局显示异常，需要限制展示量以改善布局。
- 优先保留信息量更高的角色（名字更长的），以便在限制展示数量时仍保留更有意义的标签。

### Description
- 在 `app/src/main/java/com/example/quotepicker/ui/components/ResourceListRow.kt` 中新增 `formatRoleListForResourceRow` 方法以格式化角色展示，方法会清理空白名、按名字长度降序排序、最多显示 4 个角色并在超过时追加 `/...`，空列表返回 `无角色`。
- 将 `ResourceScreen`（普通列表与分组列表）和 `CharacterScreen`（分组资源页面）中原先的 `joinToString` 角色拼接调用替换为 `formatRoleListForResourceRow`，并添加相应的导入。 
- 该变更只影响角色文本拼接与显示逻辑，未修改视图布局或标签绘制实现。

### Testing
- 运行了编译尝试 `./gradlew :app:compileDebugKotlin`，但构建环境无法下载 Gradle 分发包（代理返回 `HTTP/1.1 403 Forbidden`），因此未能完成编译验证。 
- 代码搜索/替换和静态检查（基于 `rg` / 文件读取）用于确认所有列表渲染点已替换为新方法，未发现遗漏。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b127bb9734832b8c298c0d2351b090)