### PR TITLE
Add per-speaker memo editing and export in Voice Settings

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -137,9 +137,12 @@ fun VoiceSettingsScreen(
                         )
                     },
                     onPersistPreviewText = { vm.updatePreviewText(VoiceSettingsViewModel.DEFAULT_ROLE_KEY, it) },
+                    speakerMemos = ui.settings.speakerMemos,
+                    onSaveSpeakerMemo = { speakerId, memo -> vm.updateSpeakerMemo(speakerId, memo) },
                     onOpenSaveTextPage = { content -> saveMode = VoiceSaveMode.Text(content) },
                     onOpenSaveSoundPage = { uri -> saveMode = VoiceSaveMode.Sound(uri) },
-                    buildConfigText = { vm.buildDefaultConfigText() }
+                    buildConfigText = { vm.buildDefaultConfigText() },
+                    buildSpeakerMemoExportText = { vm.buildSpeakerMemoExportText() }
                 )
             }
         }
@@ -154,9 +157,12 @@ private fun VoiceSettingEditor(
     initialPreviewText: String?,
     onSave: (RoleVoiceSetting) -> Unit,
     onPersistPreviewText: (String) -> Unit,
+    speakerMemos: Map<Int, String>,
+    onSaveSpeakerMemo: (Int, String) -> Unit,
     onOpenSaveTextPage: (String) -> Unit,
     onOpenSaveSoundPage: (Uri) -> Unit,
-    buildConfigText: () -> String
+    buildConfigText: () -> String,
+    buildSpeakerMemoExportText: () -> String
 ) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
@@ -181,6 +187,12 @@ private fun VoiceSettingEditor(
     var silenceScale by remember(initial?.silenceScale) { mutableStateOf((initial?.silenceScale ?: 0.2f).coerceIn(0f, 1f)) }
     var previewText by remember(initialPreviewText) { mutableStateOf(initialPreviewText ?: "这是一段语音预览。") }
     var statusText by remember { mutableStateOf("") }
+    var previousSpeakerId by remember { mutableStateOf(speakerId) }
+    var speakerMemo by remember(speakerId, speakerMemos) { mutableStateOf(speakerMemos[speakerId].orEmpty()) }
+
+    fun persistSpeakerMemo(targetSpeakerId: Int, memo: String) {
+        onSaveSpeakerMemo(targetSpeakerId, memo)
+    }
 
     fun currentSetting() = RoleVoiceSetting(
         roleName = VoiceSettingsViewModel.DEFAULT_ROLE_KEY,
@@ -216,12 +228,36 @@ private fun VoiceSettingEditor(
             }
         }
 
+        OutlinedTextField(
+            value = speakerMemo,
+            onValueChange = {
+                speakerMemo = it
+                persistSpeakerMemo(speakerId, it)
+            },
+            label = { Text("说话者 Memo（$speakerId）") },
+            modifier = Modifier.fillMaxWidth(),
+            placeholder = { Text("为当前说话者记录备注") }
+        )
+
         SliderSettingRow(
             label = "说话者",
             hint = "speakerId · 0-186",
             valueText = "$speakerId"
         ) {
-            Slider(value = speakerId.toFloat(), onValueChange = { speakerId = it.toInt(); saveCurrent() }, valueRange = 0f..186f, modifier = Modifier.fillMaxWidth())
+            Slider(
+                value = speakerId.toFloat(),
+                onValueChange = {
+                    val newSpeakerId = it.toInt().coerceIn(0, 186)
+                    if (newSpeakerId == speakerId) return@Slider
+                    persistSpeakerMemo(previousSpeakerId, speakerMemo)
+                    previousSpeakerId = newSpeakerId
+                    speakerId = newSpeakerId
+                    speakerMemo = speakerMemos[newSpeakerId].orEmpty()
+                    saveCurrent()
+                },
+                valueRange = 0f..186f,
+                modifier = Modifier.fillMaxWidth()
+            )
         }
 
         SliderSettingRow(
@@ -309,6 +345,16 @@ private fun VoiceSettingEditor(
 
         Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
             Button(onClick = { onOpenSaveTextPage(buildConfigText()) }, modifier = Modifier.weight(1f)) { Text("保存文本") }
+            Button(
+                onClick = {
+                    persistSpeakerMemo(speakerId, speakerMemo)
+                    onOpenSaveTextPage(buildSpeakerMemoExportText())
+                },
+                modifier = Modifier.weight(1f)
+            ) { Text("导出Memo") }
+        }
+
+        Row(horizontalArrangement = Arrangement.spacedBy(8.dp), modifier = Modifier.fillMaxWidth()) {
             Button(onClick = {
                 if (baseProfile == null) return@Button
                 val setting = currentSetting()

--- a/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
+++ b/app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt
@@ -36,7 +36,8 @@ data class RoleVoiceSetting(
 data class VoiceSettings(
     val profiles: List<VoiceProfile> = emptyList(),
     val roleSettings: List<RoleVoiceSetting> = emptyList(),
-    val rolePreviewTexts: Map<String, String> = emptyMap()
+    val rolePreviewTexts: Map<String, String> = emptyMap(),
+    val speakerMemos: Map<Int, String> = emptyMap()
 )
 
 class VoiceSettingsStore(context: Context) {
@@ -52,7 +53,13 @@ class VoiceSettingsStore(context: Context) {
                 val profiles = root.optJSONArray("profiles").toProfiles()
                 val roleSettings = root.optJSONArray("roleSettings").toRoleSettings()
                 val rolePreviewTexts = root.optJSONObject("rolePreviewTexts").toPreviewTexts()
-                VoiceSettings(profiles = profiles, roleSettings = roleSettings, rolePreviewTexts = rolePreviewTexts)
+                val speakerMemos = root.optJSONObject("speakerMemos").toSpeakerMemos()
+                VoiceSettings(
+                    profiles = profiles,
+                    roleSettings = roleSettings,
+                    rolePreviewTexts = rolePreviewTexts,
+                    speakerMemos = speakerMemos
+                )
             }.getOrDefault(VoiceSettings())
         }
         return parsed.withBuiltinProfile()
@@ -96,6 +103,11 @@ class VoiceSettingsStore(context: Context) {
             .put("rolePreviewTexts", JSONObject().apply {
                 settings.rolePreviewTexts.forEach { (role, text) ->
                     put(role, text)
+                }
+            })
+            .put("speakerMemos", JSONObject().apply {
+                settings.speakerMemos.forEach { (speakerId, memo) ->
+                    put(speakerId.toString(), memo)
                 }
             })
         prefs.edit().putString(KEY_PAYLOAD, root.toString()).apply()
@@ -185,5 +197,13 @@ private fun JSONObject?.toPreviewTexts(): Map<String, String> {
         key?.takeIf { it.isNotBlank() }?.let { safeKey ->
             safeKey to optString(safeKey)
         }
+    }.toMap()
+}
+
+private fun JSONObject?.toSpeakerMemos(): Map<Int, String> {
+    if (this == null) return emptyMap()
+    return keys().asSequence().mapNotNull { key ->
+        val speakerId = key?.toIntOrNull() ?: return@mapNotNull null
+        speakerId to optString(key)
     }.toMap()
 }

--- a/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
@@ -118,6 +118,28 @@ class VoiceSettingsViewModel(application: Application) : AndroidViewModel(applic
     }
 
 
+
+    fun updateSpeakerMemo(speakerId: Int, memo: String) {
+        val normalizedId = speakerId.coerceIn(0, 186)
+        localSettings.update { state ->
+            val updated = state.speakerMemos.toMutableMap()
+            if (memo.isBlank()) {
+                updated.remove(normalizedId)
+            } else {
+                updated[normalizedId] = memo
+            }
+            state.copy(speakerMemos = updated)
+        }
+        persist()
+    }
+
+    fun buildSpeakerMemoExportText(): String {
+        if (localSettings.value.speakerMemos.isEmpty()) return ""
+        return localSettings.value.speakerMemos.toSortedMap().entries.joinToString("\n") { (speakerId, memo) ->
+            "$speakerId：$memo"
+        }
+    }
+
     fun resolveRoleSettingFromResources(roleName: String, resources: List<ResourceWithTagsCharacters>): RoleVoiceSetting? {
         val candidates = resources.filter { item ->
             item.resource.type == ResourceType.TEXT &&


### PR DESCRIPTION
### Motivation
- Provide a way to record short persistent notes for each speaker (0–186) in the voice settings so users can annotate voices while tuning parameters.
- Ensure memos are automatically loaded/edited when switching speakers and persist alongside other voice settings.
- Allow exporting all memos into the existing text creation flow in a simple `speakerId：memo` format for sharing or bulk editing.

### Description
- Add `speakerMemos: Map<Int, String>` to the persisted `VoiceSettings` payload and JSON (load/save) in `app/src/main/java/com/example/quotepicker/util/VoiceSettingsStore.kt` and add a parser `toSpeakerMemos()` for the JSON object.
- Add `updateSpeakerMemo()` and `buildSpeakerMemoExportText()` helper APIs to `VoiceSettingsViewModel` to update per-speaker memo entries and produce the export text in `"0：memo\n1：memo"` format.
- Update `VoiceSettingsScreen`/`VoiceSettingEditor` UI to show an `OutlinedTextField` memo above the speaker slider, save the previous speaker's memo when the slider changes, load the new speaker's memo for editing, and add a `导出Memo` button that opens the text creation page prefilled by `buildSpeakerMemoExportText()`; key edits are in `app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt`.

### Testing
- Attempted to compile Kotlin with `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper download was blocked by an environment proxy (HTTP 403), so the build could not be executed in this environment (failed).
- Verified code diffs and committed changes; repository status and diffs were inspected locally (`git status`, `git diff`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1314b372c832b8772e132f98f12c4)