### PR TITLE
Add '不设置' option to voice settings and simplify offline TTS config

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -185,6 +186,15 @@ private fun VoiceSettingEditor(
     var lengthScale by remember(initial?.lengthScale) { mutableStateOf((initial?.lengthScale ?: 1.0f).coerceIn(0.5f, 2.0f)) }
     var maxNumSentences by remember(initial?.maxNumSentences) { mutableStateOf((initial?.maxNumSentences ?: 1).coerceIn(1, 10)) }
     var silenceScale by remember(initial?.silenceScale) { mutableStateOf((initial?.silenceScale ?: 0.2f).coerceIn(0f, 1f)) }
+    var skipAdvancedConfig by remember(initial) {
+        mutableStateOf(
+            initial?.noiseScale == null &&
+                initial?.noiseScaleW == null &&
+                initial?.lengthScale == null &&
+                initial?.maxNumSentences == null &&
+                initial?.silenceScale == null
+        )
+    }
     var previewText by remember(initialPreviewText) { mutableStateOf(initialPreviewText ?: "这是一段语音预览。") }
     var statusText by remember { mutableStateOf("") }
     var previousSpeakerId by remember { mutableStateOf(speakerId) }
@@ -198,11 +208,11 @@ private fun VoiceSettingEditor(
         roleName = VoiceSettingsViewModel.DEFAULT_ROLE_KEY,
         speechRate = speed,
         speakerId = speakerId,
-        noiseScale = noiseScale,
-        noiseScaleW = noiseScaleW,
-        lengthScale = lengthScale,
-        maxNumSentences = maxNumSentences,
-        silenceScale = silenceScale
+        noiseScale = if (skipAdvancedConfig) null else noiseScale,
+        noiseScaleW = if (skipAdvancedConfig) null else noiseScaleW,
+        lengthScale = if (skipAdvancedConfig) null else lengthScale,
+        maxNumSentences = if (skipAdvancedConfig) null else maxNumSentences,
+        silenceScale = if (skipAdvancedConfig) null else silenceScale
     )
 
     fun saveCurrent() = onSave(currentSetting())
@@ -268,44 +278,70 @@ private fun VoiceSettingEditor(
             Slider(value = speed, onValueChange = { speed = it; saveCurrent() }, valueRange = 0.6f..1.8f, modifier = Modifier.fillMaxWidth())
         }
 
-        SliderSettingRow(
-            label = "情绪随机度",
-            hint = "noiseScale · 0.1-2.0",
-            valueText = "${"%.3f".format(Locale.US, noiseScale)}"
-        ) {
-            Slider(value = noiseScale, onValueChange = { noiseScale = it; saveCurrent() }, valueRange = 0.1f..2.0f, modifier = Modifier.fillMaxWidth())
+        Card {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 14.dp, vertical = 8.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Checkbox(
+                    checked = skipAdvancedConfig,
+                    onCheckedChange = {
+                        skipAdvancedConfig = it
+                        saveCurrent()
+                    }
+                )
+                Column {
+                    Text("不设置")
+                    Text(
+                        "选中后，仅保留说话者和语速",
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            }
         }
 
-        SliderSettingRow(
-            label = "音素随机间隔",
-            hint = "noiseScaleW · 0.1-2.0",
-            valueText = "${"%.3f".format(Locale.US, noiseScaleW)}"
-        ) {
-            Slider(value = noiseScaleW, onValueChange = { noiseScaleW = it; saveCurrent() }, valueRange = 0.1f..2.0f, modifier = Modifier.fillMaxWidth())
-        }
+        if (!skipAdvancedConfig) {
+            SliderSettingRow(
+                label = "情绪随机度",
+                hint = "noiseScale · 0.1-2.0",
+                valueText = "${"%.3f".format(Locale.US, noiseScale)}"
+            ) {
+                Slider(value = noiseScale, onValueChange = { noiseScale = it; saveCurrent() }, valueRange = 0.1f..2.0f, modifier = Modifier.fillMaxWidth())
+            }
 
-        SliderSettingRow(
-            label = "句子时长",
-            hint = "lengthScale · 0.5-2.0",
-            valueText = "${"%.2f".format(Locale.US, lengthScale)}"
-        ) {
-            Slider(value = lengthScale, onValueChange = { lengthScale = it; saveCurrent() }, valueRange = 0.5f..2.0f, modifier = Modifier.fillMaxWidth())
-        }
+            SliderSettingRow(
+                label = "音素随机间隔",
+                hint = "noiseScaleW · 0.1-2.0",
+                valueText = "${"%.3f".format(Locale.US, noiseScaleW)}"
+            ) {
+                Slider(value = noiseScaleW, onValueChange = { noiseScaleW = it; saveCurrent() }, valueRange = 0.1f..2.0f, modifier = Modifier.fillMaxWidth())
+            }
 
-        SliderSettingRow(
-            label = "句子处理量",
-            hint = "maxNumSentences · 1-10",
-            valueText = "$maxNumSentences"
-        ) {
-            Slider(value = maxNumSentences.toFloat(), onValueChange = { maxNumSentences = it.toInt().coerceIn(1, 10); saveCurrent() }, valueRange = 1f..10f, modifier = Modifier.fillMaxWidth())
-        }
+            SliderSettingRow(
+                label = "句子时长",
+                hint = "lengthScale · 0.5-2.0",
+                valueText = "${"%.2f".format(Locale.US, lengthScale)}"
+            ) {
+                Slider(value = lengthScale, onValueChange = { lengthScale = it; saveCurrent() }, valueRange = 0.5f..2.0f, modifier = Modifier.fillMaxWidth())
+            }
 
-        SliderSettingRow(
-            label = "句子间隔",
-            hint = "silenceScale · 0-1",
-            valueText = "${"%.2f".format(Locale.US, silenceScale)}"
-        ) {
-            Slider(value = silenceScale, onValueChange = { silenceScale = it; saveCurrent() }, valueRange = 0f..1f, modifier = Modifier.fillMaxWidth())
+            SliderSettingRow(
+                label = "句子处理量",
+                hint = "maxNumSentences · 1-10",
+                valueText = "$maxNumSentences"
+            ) {
+                Slider(value = maxNumSentences.toFloat(), onValueChange = { maxNumSentences = it.toInt().coerceIn(1, 10); saveCurrent() }, valueRange = 1f..10f, modifier = Modifier.fillMaxWidth())
+            }
+
+            SliderSettingRow(
+                label = "句子间隔",
+                hint = "silenceScale · 0-1",
+                valueText = "${"%.2f".format(Locale.US, silenceScale)}"
+            ) {
+                Slider(value = silenceScale, onValueChange = { silenceScale = it; saveCurrent() }, valueRange = 0f..1f, modifier = Modifier.fillMaxWidth())
+            }
         }
 
         OutlinedTextField(

--- a/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
+++ b/app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt
@@ -29,10 +29,6 @@ class PiperSpeechEngine(private val context: Context) {
         private const val MODEL_FILE_NAME = "vits-zh-hf-fanchen-C.onnx"
         private const val LEXICON_FILE_NAME = "lexicon.txt"
         private const val TOKENS_FILE_NAME = "tokens.txt"
-        private const val PHONE_FST_FILE_NAME = "phone.fst"
-        private const val NUMBER_FST_FILE_NAME = "number.fst"
-        private const val RULE_FAR_FILE_NAME = "rule.far"
-        private const val DICT_DIR_NAME = "dict"
 
         private const val MAX_GAIN = 8.0f
         private const val TARGET_PEAK = 0.75f
@@ -145,18 +141,7 @@ class PiperSpeechEngine(private val context: Context) {
     }
 
     private suspend fun ensureInit(profile: VoiceProfile) = withContext(Dispatchers.IO) {
-        val effectiveNoiseScale = (profile.noiseScale ?: 0.2f).coerceIn(0.1f, 2.0f)
-        val effectiveNoiseScaleW = (profile.noiseScaleW ?: 0.2f).coerceIn(0.1f, 2.0f)
-        val effectiveLengthScale = (profile.lengthScale ?: 1.0f).coerceIn(0.5f, 2.0f)
-        val effectiveMaxNumSentences = (profile.maxNumSentences ?: 1).coerceIn(1, 10)
-        val effectiveSilenceScale = (profile.silenceScale ?: 0.2f).coerceIn(0f, 1f)
-        val targetSignature = listOf(
-            effectiveNoiseScale,
-            effectiveNoiseScaleW,
-            effectiveLengthScale,
-            effectiveMaxNumSentences,
-            effectiveSilenceScale
-        ).joinToString("|")
+        val targetSignature = "minimal-config"
 
         mutex.withLock {
             if (tts != null && configSignature == targetSignature) return@withLock
@@ -169,22 +154,11 @@ class PiperSpeechEngine(private val context: Context) {
             val modelPath = File(modelDir, MODEL_FILE_NAME).absolutePath
             val lexiconPath = File(modelDir, LEXICON_FILE_NAME).absolutePath
             val tokensPath = File(modelDir, TOKENS_FILE_NAME).absolutePath
-            val phoneFstPath = File(modelDir, PHONE_FST_FILE_NAME).absolutePath
-            val numberFstPath = File(modelDir, NUMBER_FST_FILE_NAME).absolutePath
-            val ruleFarPath = File(modelDir, RULE_FAR_FILE_NAME).absolutePath
-            val dictDirPath = File(modelDir, DICT_DIR_NAME).absolutePath
-
-            val ruleFsts = buildRuleFsts(phoneFstPath, numberFstPath)
-            val ruleFars = if (File(ruleFarPath).exists()) ruleFarPath else ""
 
             val vits = OfflineTtsVitsModelConfig(
                 model = modelPath,
                 lexicon = lexiconPath,
-                tokens = tokensPath,
-                dictDir = dictDirPath,
-                noiseScale = effectiveNoiseScale,
-                noiseScaleW = effectiveNoiseScaleW,
-                lengthScale = effectiveLengthScale
+                tokens = tokensPath
             )
 
             val config = OfflineTtsConfig(
@@ -193,11 +167,7 @@ class PiperSpeechEngine(private val context: Context) {
                     numThreads = 2,
                     debug = false,
                     provider = "cpu"
-                ),
-                ruleFsts = ruleFsts,
-                ruleFars = ruleFars,
-                maxNumSentences = effectiveMaxNumSentences,
-                silenceScale = effectiveSilenceScale
+                )
             )
 
             tts = OfflineTts(config = config)
@@ -268,13 +238,6 @@ class PiperSpeechEngine(private val context: Context) {
                 output.flush()
             }
         }
-    }
-
-    private fun buildRuleFsts(phoneFstPath: String, numberFstPath: String): String {
-        val list = mutableListOf<String>()
-        if (File(phoneFstPath).exists()) list += phoneFstPath
-        if (File(numberFstPath).exists()) list += numberFstPath
-        return list.joinToString(",")
     }
 
     private fun normalizeSpeakerId(engine: OfflineTts, speakerId: Int?): Int {

--- a/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt
@@ -178,15 +178,15 @@ class VoiceSettingsViewModel(application: Application) : AndroidViewModel(applic
 
     fun buildDefaultConfigText(): String {
         val roleSetting = globalRoleSetting()
-        return JSONObject()
-            .put("speechRate", roleSetting?.speechRate ?: 1.0)
-            .put("speakerId", roleSetting?.speakerId ?: 0)
-            .put("noiseScale", roleSetting?.noiseScale ?: 0.2)
-            .put("noiseScaleW", roleSetting?.noiseScaleW ?: 0.2)
-            .put("lengthScale", roleSetting?.lengthScale ?: 1.0)
-            .put("maxNumSentences", roleSetting?.maxNumSentences ?: 1)
-            .put("silenceScale", roleSetting?.silenceScale ?: 0.2)
-            .toString(2)
+        return JSONObject().apply {
+            put("speechRate", roleSetting?.speechRate ?: 1.0)
+            put("speakerId", roleSetting?.speakerId ?: 0)
+            roleSetting?.noiseScale?.let { put("noiseScale", it) }
+            roleSetting?.noiseScaleW?.let { put("noiseScaleW", it) }
+            roleSetting?.lengthScale?.let { put("lengthScale", it) }
+            roleSetting?.maxNumSentences?.let { put("maxNumSentences", it) }
+            roleSetting?.silenceScale?.let { put("silenceScale", it) }
+        }.toString(2)
     }
 
     private fun persist() {


### PR DESCRIPTION
### Motivation
- Provide a lightweight "do not set" option on the Voice Settings screen so users can persist only speaker and speed and skip advanced tuning.
- Exported configuration should be minimal and omit advanced fields when not explicitly set.
- Initialize the offline TTS engine with the simplest necessary configuration (model/lexicon/tokens + cpu provider) to match the reduced settings surface.

### Description
- Added a `不设置` checkbox to the voice settings UI that toggles `skipAdvancedConfig` and hides advanced sliders when enabled (file: `app/src/main/java/com/example/quotepicker/ui/VoiceSettingsScreen.kt`).
- When `skipAdvancedConfig` is true, `RoleVoiceSetting` persists only `speakerId` and `speechRate`, and sets `noiseScale`, `noiseScaleW`, `lengthScale`, `maxNumSentences`, and `silenceScale` to `null` (file: `VoiceSettingsScreen.kt`).
- Changed `buildDefaultConfigText()` to only include optional advanced fields when they are actually set, keeping `speechRate` and `speakerId` always present (file: `app/src/main/java/com/example/quotepicker/vm/VoiceSettingsViewModel.kt`).
- Simplified TTS initialization in `PiperSpeechEngine` to construct `OfflineTtsVitsModelConfig` with only `model`, `lexicon`, and `tokens`, and `OfflineTtsConfig` with the minimal `model` block (`numThreads=2`, `debug=false`, `provider="cpu"`); removed rule FST/far/dict references and the `buildRuleFsts` helper (file: `app/src/main/java/com/example/quotepicker/util/PiperSpeechEngine.kt`).
- Changes were committed with the message: `Add no-config option and simplify TTS config`.

### Testing
- Ran `git` checks: `git status` and `git diff` show the three modified files and the intended changes, and changes were committed successfully.
- Attempted to compile with Gradle using `./gradlew :app:compileDebugKotlin`, but the environment lacks a Java 17 toolchain so compilation could not be completed (build failed due to missing Java 17 toolchain).
- No automated unit tests were added or executed in this environment due to toolchain limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b21b5e88a4832bb7740eb6fd586ed8)