### PR TITLE
支持魔剧命令的骰子设值与组合判定

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -405,35 +405,43 @@ private fun applyVariableExpression(expression: String, variables: MutableMap<St
         raw.contains("+=") -> {
             val (name, deltaRaw) = raw.split("+=", limit = 2)
             val key = name.trim()
-            val delta = deltaRaw.trim().toIntOrNull() ?: 0
+            val delta = evaluateNumericExpression(deltaRaw.trim(), variables) ?: 0
             val current = variables[key]?.toIntOrNull() ?: 0
             variables[key] = (current + delta).toString()
         }
         raw.contains("-=") -> {
             val (name, deltaRaw) = raw.split("-=", limit = 2)
             val key = name.trim()
-            val delta = deltaRaw.trim().toIntOrNull() ?: 0
+            val delta = evaluateNumericExpression(deltaRaw.trim(), variables) ?: 0
             val current = variables[key]?.toIntOrNull() ?: 0
             variables[key] = (current - delta).toString()
         }
         raw.contains("=") -> {
             val (name, value) = raw.split("=", limit = 2)
-            if (name.isNotBlank()) variables[name.trim()] = value.trim()
+            if (name.isNotBlank()) {
+                val resolved = evaluateNumericExpression(value.trim(), variables)?.toString() ?: value.trim()
+                variables[name.trim()] = resolved
+            }
         }
     }
 }
 
 private fun evaluateCondition(condition: String, variables: Map<String, String>): Boolean {
+    val clauses = condition.split("&").map { it.trim() }.filter { it.isNotBlank() }
+    if (clauses.isEmpty()) return false
+    return clauses.all { clause -> evaluateSingleCondition(clause, variables) }
+}
+
+private fun evaluateSingleCondition(condition: String, variables: Map<String, String>): Boolean {
     val ops = listOf(">=", "<=", "!=", ">", "<", "=")
     val op = ops.firstOrNull { condition.contains(it) } ?: return false
     val parts = condition.split(op, limit = 2)
     if (parts.size != 2) return false
-    val key = parts[0].trim()
-    val right = parts[1].trim()
-    val leftValue = variables[key] ?: ""
+    val leftRaw = parts[0].trim()
+    val rightRaw = parts[1].trim()
 
-    val leftInt = leftValue.toIntOrNull()
-    val rightInt = right.toIntOrNull()
+    val leftInt = evaluateNumericExpression(leftRaw, variables)
+    val rightInt = evaluateNumericExpression(rightRaw, variables)
     return if (leftInt != null && rightInt != null) {
         when (op) {
             "=" -> leftInt == rightInt
@@ -445,12 +453,49 @@ private fun evaluateCondition(condition: String, variables: Map<String, String>)
             else -> false
         }
     } else {
+        val leftValue = resolveTokenValue(leftRaw, variables)
+        val rightValue = resolveTokenValue(rightRaw, variables)
         when (op) {
-            "=" -> leftValue == right
-            "!=" -> leftValue != right
+            "=" -> leftValue == rightValue
+            "!=" -> leftValue != rightValue
             else -> false
         }
     }
+}
+
+private fun evaluateNumericExpression(expression: String, variables: Map<String, String>): Int? {
+    val normalized = expression.replace(" ", "")
+    if (normalized.isBlank()) return null
+    val terms = Regex("[+-]?[^+-]+")
+        .findAll(normalized)
+        .map { it.value }
+        .toList()
+    if (terms.isEmpty()) return null
+
+    var total = 0
+    for (term in terms) {
+        val sign = if (term.startsWith("-")) -1 else 1
+        val token = term.removePrefix("+").removePrefix("-")
+        val value = resolveNumericToken(token, variables) ?: return null
+        total += sign * value
+    }
+    return total
+}
+
+private fun resolveNumericToken(token: String, variables: Map<String, String>): Int? {
+    val dice = Regex("^(\\d+)d(\\d+)$", RegexOption.IGNORE_CASE).matchEntire(token)
+    if (dice != null) {
+        val count = dice.groupValues[1].toIntOrNull() ?: return null
+        val side = dice.groupValues[2].toIntOrNull() ?: return null
+        if (count <= 0 || side <= 0) return null
+        return (1..count).sumOf { (1..side).random() }
+    }
+    return token.toIntOrNull() ?: variables[token]?.toIntOrNull()
+}
+
+private fun resolveTokenValue(token: String, variables: Map<String, String>): String {
+    if (variables.containsKey(token)) return variables[token].orEmpty()
+    return token
 }
 
 @Composable


### PR DESCRIPTION
### Motivation
- 为魔剧脚本增强变量赋值与条件判断能力以支持类似 `设:生命值=1d20` 的骰子设值与在 `判:` 中使用加减表达式及多条件组合的需求。

### Description
- 在 `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt` 中扩展 `applyVariableExpression`，将 `+=`/`-=`/`=` 的右值解析为可计算的数值表达式（使用 `evaluateNumericExpression`），若无法解析为数值则保留原始字符串赋值以兼容此前行为。
- 将条件判断逻辑由单一表达式扩展为支持 `&` 连接多个子条件的逻辑，新增 `evaluateSingleCondition` 来处理单条比较，并在左右两侧支持算术表达式的求值。
- 新增辅助函数：`evaluateNumericExpression`（解析加减项）、`resolveNumericToken`（解析常数、变量或骰子表达式 `NdM` 并随机取值）、以及 `resolveTokenValue`（字符串值解析），并在比较时优先以数值比较为准。
- 骰子表达式 `NdM` 会按规范生成 `N` 次 `1..M` 的随机结果并求和，支持在赋值和比较表达式中使用。

### Testing
- 运行 `./gradlew :app:compileDebugKotlin` 用于验证 Kotlin 编译，执行失败，原因是环境中缺少所需的 Java 17 toolchain（与本次代码逻辑无关的环境问题）。
- 未能在本地完成二进制编译验证，因此功能行为（骰子随机、复合判定）尚未通过编译级别的自动化测试在此环境中确认。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b22ebfcce8832bb78ce28309da7e45)