### PR TITLE
feat: 支持魔剧变量占位（%变量%）与全角符号自动转半角

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -169,7 +169,7 @@ fun MagicDramaScreen(
 
             when (val cmd = queue.removeFirst()) {
                 is DramaCommand.Narration -> {
-                    val text = renderRandomToken(cmd.text)
+                    val text = resolveVariablePlaceholders(renderRandomToken(cmd.text), variables)
                     if (playbackOptions.voicePlaybackMode == MagicDramaVoicePlaybackMode.ALL) {
                         val narrationRoleName = if (cmd.important) "注意" else "旁白"
                         speakByRole(
@@ -186,7 +186,7 @@ fun MagicDramaScreen(
 
                 is DramaCommand.RoleLine -> {
                     val role = resolveRoleName(cmd.roleKey, boundCharacters)
-                    val text = cmd.text.replace("nn", "\n")
+                    val text = resolveVariablePlaceholders(cmd.text, variables).replace("nn", "\n")
                     if (playbackOptions.voicePlaybackMode != MagicDramaVoicePlaybackMode.SILENT) {
                         speakByRole(
                             text = text,
@@ -200,7 +200,9 @@ fun MagicDramaScreen(
                     delay(settings.defaultDelayMs)
                 }
 
-                is DramaCommand.ShowResource -> currentMedia = DramaMedia.Resource(cmd.source)
+                is DramaCommand.ShowResource -> {
+                    currentMedia = DramaMedia.Resource(resolveVariablePlaceholders(cmd.source, variables))
+                }
                 is DramaCommand.WaitSeconds -> delay(cmd.seconds.coerceAtLeast(0) * 1000L)
                 is DramaCommand.SetVariable -> applyVariableExpression(cmd.expression, variables)
                 is DramaCommand.Jump -> jumpTo(cmd.blockId, queue)
@@ -218,7 +220,9 @@ fun MagicDramaScreen(
                 }
 
                 is DramaCommand.ShowButtons -> {
-                    buttonOptions = cmd.options
+                    buttonOptions = cmd.options.map { option ->
+                        option.copy(text = resolveVariablePlaceholders(option.text, variables))
+                    }
                     val waiter = CompletableDeferred<String>()
                     pendingBranch = waiter
                     val selected = waiter.await()
@@ -590,8 +594,29 @@ private fun parseDramaScript(raw: String): ParsedDramaScript {
 }
 
 private fun sanitizeScriptLine(raw: String): String {
-    val trimmed = raw.trim()
+    val normalized = normalizeFullWidthSymbols(raw)
+    val trimmed = normalized.trim()
     return trimmed.replace(Regex("\\s\\[[^\\[\\]]*]$"), "").trim()
+}
+
+private fun normalizeFullWidthSymbols(raw: String): String {
+    val builder = StringBuilder(raw.length)
+    raw.forEach { ch ->
+        val converted = when {
+            ch == '　' -> ' '
+            ch.code in 0xFF01..0xFF5E -> (ch.code - 0xFEE0).toChar()
+            else -> ch
+        }
+        builder.append(converted)
+    }
+    return builder.toString()
+}
+
+private fun resolveVariablePlaceholders(text: String, variables: Map<String, String>): String {
+    return Regex("%([^%]+)%").replace(text) { match ->
+        val key = match.groupValues[1].trim()
+        variables[key] ?: match.value
+    }
 }
 
 private fun parseBlockCommands(lines: List<String>): List<DramaCommand> {


### PR DESCRIPTION
### Motivation
- 提升魔剧脚本表达能力，使文本/资源/按钮能引用运行时变量（如 `设:值=10` 后在 `旁白: 目前值为 %值%` 展示）。
- 减少用户输入全角标点或全角 ASCII 导致的解析失败，通过统一转换为半角提高兼容性和解析成功率。

### Description
- 在脚本执行阶段对文本加入占位符替换，新增 `resolveVariablePlaceholders` 并在 `旁白`、角色台词、资源引用和按钮文案处调用以替换 `%变量%`。 
- 在脚本清洗阶段将 `sanitizeScriptLine` 改为先调用 `normalizeFullWidthSymbols`，将全角空格 `　` 与全角 ASCII 区间（`！`..`～`）转换为对应半角字符。 
- 对 `ShowResource` 和 `ShowButtons` 分别做了占位符解析以确保资源路径与交互文本也支持变量插值。 
- 更改集中在 `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt`，新增函数 `normalizeFullWidthSymbols` 和 `resolveVariablePlaceholders` 并调整若干调用点。 

### Testing
- 尝试运行构建命令 `./gradlew :app:assembleDebug`，构建在尝试下载 Gradle 发行包时被网络代理拦截导致失败（HTTP 403），因此无法完成本地 APK 构建验证。 
- 已通过 local VCS 操作提交改动（commit created） and verified the file diffs show the intended changes; no automated unit tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b24292f794832b8a3e1ac71493f329)