### PR TITLE
feat: add additional magic drama control commands

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -1,6 +1,7 @@
 package com.example.quotepicker.ui.components
 
 import android.net.Uri
+import android.media.MediaPlayer
 import android.widget.VideoView
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -90,8 +91,15 @@ private sealed interface DramaCommand {
     data class Countdown(val seconds: Int, val timeoutBlock: String) : DramaCommand
     data class WaitSeconds(val seconds: Int) : DramaCommand
     data class SetVariable(val expression: String) : DramaCommand
+    data class RemoveVariable(val variableName: String) : DramaCommand
     data class Jump(val blockId: String) : DramaCommand
     data class ConditionalJump(val condition: String, val targetBlock: String) : DramaCommand
+    data object ClearResourceArea : DramaCommand
+    data object ClearAllVariables : DramaCommand
+    data object ClearDialogue : DramaCommand
+    data class SetBackgroundMusic(val source: String) : DramaCommand
+    data object StopBackgroundMusic : DramaCommand
+    data object StopCountdown : DramaCommand
 }
 
 private data class DramaButtonOption(val text: String, val branchId: String)
@@ -122,6 +130,7 @@ fun MagicDramaScreen(
     var buttonOptions by remember { mutableStateOf<List<DramaButtonOption>>(emptyList()) }
     var pendingBranch by remember { mutableStateOf<CompletableDeferred<String>?>(null) }
     var countdownJob by remember { mutableStateOf<Job?>(null) }
+    var backgroundPlayer by remember { mutableStateOf<MediaPlayer?>(null) }
 
     val parsed = remember(script) { parseDramaScript(script) }
     val coroutineScope = rememberCoroutineScope()
@@ -135,6 +144,8 @@ fun MagicDramaScreen(
             countdownJob?.cancel()
             pendingBranch?.cancel()
             coroutineScope.launch {
+                backgroundPlayer?.stop()
+                backgroundPlayer?.release()
                 piperSpeechEngine.stop()
                 piperSpeechEngine.cleanupPreviewTempFiles()
                 piperSpeechEngine.release()
@@ -154,6 +165,9 @@ fun MagicDramaScreen(
         timeoutBlockToJump = null
         countdownJob?.cancel()
         countdownJob = null
+        backgroundPlayer?.stop()
+        backgroundPlayer?.release()
+        backgroundPlayer = null
 
         fun jumpTo(blockId: String, queue: ArrayDeque<DramaCommand>) {
             queue.clear()
@@ -205,9 +219,29 @@ fun MagicDramaScreen(
                 }
                 is DramaCommand.WaitSeconds -> delay(cmd.seconds.coerceAtLeast(0) * 1000L)
                 is DramaCommand.SetVariable -> applyVariableExpression(cmd.expression, variables)
+                is DramaCommand.RemoveVariable -> variables.remove(cmd.variableName)
                 is DramaCommand.Jump -> jumpTo(cmd.blockId, queue)
                 is DramaCommand.ConditionalJump -> {
                     if (evaluateCondition(cmd.condition, variables)) jumpTo(cmd.targetBlock, queue)
+                }
+                is DramaCommand.ClearResourceArea -> currentMedia = null
+                is DramaCommand.ClearAllVariables -> variables.clear()
+                is DramaCommand.ClearDialogue -> messages.clear()
+                is DramaCommand.SetBackgroundMusic -> {
+                    backgroundPlayer?.stop()
+                    backgroundPlayer?.release()
+                    backgroundPlayer = createLoopMediaPlayer(resolveVariablePlaceholders(cmd.source, variables), vm)
+                }
+                is DramaCommand.StopBackgroundMusic -> {
+                    backgroundPlayer?.stop()
+                    backgroundPlayer?.release()
+                    backgroundPlayer = null
+                }
+                is DramaCommand.StopCountdown -> {
+                    countdownJob?.cancel()
+                    countdownJob = null
+                    countdownSeconds = null
+                    timeoutBlockToJump = null
                 }
 
                 is DramaCommand.Countdown -> {
@@ -634,6 +668,10 @@ private fun parseBlockCommands(lines: List<String>): List<DramaCommand> {
             line.startsWith("旁白:") -> commands += DramaCommand.Narration(line.substringAfter(':').trim(), important = false)
             line.startsWith("注意:") -> commands += DramaCommand.Narration(line.substringAfter(':').trim(), important = true)
             line.startsWith("设:") -> commands += DramaCommand.SetVariable(line.substringAfter(':').trim())
+            line.startsWith("删:") -> {
+                val name = line.substringAfter(':').trim()
+                if (name.isNotBlank()) commands += DramaCommand.RemoveVariable(name)
+            }
             line.startsWith("跳:") -> commands += DramaCommand.Jump(line.substringAfter(':').trim())
             line.startsWith("判:") -> {
                 val body = line.substringAfter(':').trim()
@@ -647,6 +685,15 @@ private fun parseBlockCommands(lines: List<String>): List<DramaCommand> {
                 val target = parts.getOrNull(1)?.trim()
                 if (sec != null && !target.isNullOrBlank()) commands += DramaCommand.Countdown(sec, target)
             }
+            line.equals("c1", ignoreCase = true) -> commands += DramaCommand.ClearResourceArea
+            line.equals("c2", ignoreCase = true) -> commands += DramaCommand.ClearAllVariables
+            line.equals("c3", ignoreCase = true) -> commands += DramaCommand.ClearDialogue
+            line.startsWith("背景:") -> {
+                val source = line.substringAfter(':').trim()
+                if (source.isNotBlank()) commands += DramaCommand.SetBackgroundMusic(source)
+            }
+            line.equals("停:背景", ignoreCase = true) -> commands += DramaCommand.StopBackgroundMusic
+            line.equals("停:计时", ignoreCase = true) -> commands += DramaCommand.StopCountdown
             line.startsWith("按钮:") -> {
                 val options = mutableListOf<DramaButtonOption>()
                 var j = i + 1
@@ -669,6 +716,18 @@ private fun parseBlockCommands(lines: List<String>): List<DramaCommand> {
         i++
     }
     return commands
+}
+
+private fun createLoopMediaPlayer(source: String, vm: ResourceViewModel): MediaPlayer? {
+    val uri = vm.resolveMediaUriByCodeOrPath(source)
+        ?: runCatching { Uri.parse(source) }.getOrNull()?.takeIf { it.scheme != null }
+        ?: return null
+    return runCatching {
+        MediaPlayer.create(vm.getApplication(), uri)?.apply {
+            isLooping = true
+            start()
+        }
+    }.getOrNull()
 }
 
 private fun resolveRoleName(input: String, boundCharacters: List<CharacterEntity>): String {


### PR DESCRIPTION
### Motivation

- 增强魔剧脚本能力以支持用户指定的控制指令（例如删除变量、清空展示区/变量/对话、背景音乐控制、终止计时）。
- 让脚本能够直接通过简单文本指令控制播放状态与界面元素，便于创作更丰富的交互剧本。
- 在播放生命周期中管理背景音播放器以避免叠音或资源泄漏。

### Description

- 在 `MagicDramaScreen.kt` 的 `DramaCommand` 中新增命令类型：`RemoveVariable`、`ClearResourceArea`、`ClearAllVariables`、`ClearDialogue`、`SetBackgroundMusic`、`StopBackgroundMusic` 和 `StopCountdown`，并加入 `android.media.MediaPlayer` 依赖导入。 
- 扩展解析器 `parseBlockCommands`，支持脚本文本形式：`删:<变量名>`、`c1`、`c2`、`c3`、`背景:<资源>`、`停:背景` 和 `停:计时`，将其映射为对应的内部命令。 
- 在脚本执行主循环中实现命令执行逻辑，包括变量删除、资源区清空、变量清空、对话区清空、启动/停止循环背景音乐（使用 `MediaPlayer`）、以及停止当前倒计时和清理计时状态。 
- 新增 `createLoopMediaPlayer` 工具函数以根据资源编码或 URI 创建并启动循环播放的 `MediaPlayer`，并在脚本重新启动或屏幕关闭时对播放器进行停止与释放以清理生命周期。 

### Testing

- 在仓库中使用 code search 和 local inspections 验证了新命令的解析处与执行分支已插入（静态检查通过）。
- 尝试用 `./gradlew :app:compileDebugKotlin` 编译项目以进行完整验证，但在当前环境中 Gradle wrapper 下载被网络代理阻断返回 `403 Forbidden`，因此无法完成编译测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b251c24f84832ba42d8c9a9b006dd7)