### PR TITLE
支持叙事标签权重(+N)、重置标记(#)及标签元信息展示范围控制

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -82,6 +82,9 @@ import com.example.quotepicker.data.TagEntity
 import com.example.quotepicker.ui.components.PreviewTextBlock
 import com.example.quotepicker.ui.components.NameDialog
 import com.example.quotepicker.ui.components.formatTagLabel
+import com.example.quotepicker.ui.components.hasResetMarker
+import com.example.quotepicker.ui.components.plainTagName
+import com.example.quotepicker.ui.components.tagWeight
 import com.example.quotepicker.ui.components.tagTextColor
 import com.example.quotepicker.ui.components.ResourceListRow
 import com.example.quotepicker.ui.components.ResourcePreviewScreen
@@ -371,6 +374,9 @@ fun CharacterScreen(
                 val narrativeTags = narrativeCategory?.let { category ->
                     resourceUi.tags.filter { it.categoryId == category.id }
                 }.orEmpty()
+                val weightedNarrativeTags = remember(narrativeTags) {
+                    buildWeightedNarrativeTags(narrativeTags)
+                }
                 val introCandidates = resources.filter { res ->
                     res.characters.any { c -> c.id == char.id } &&
                         res.resource.type == ResourceType.TEXT &&
@@ -421,14 +427,14 @@ fun CharacterScreen(
                                             val current = char
                                             if (current.points <= 0) {
                                                 vm.updateCharacter(current.copy(points = 30))
-                                                val fallbackTag = narrativeTags.firstOrNull()
+                                                val fallbackTag = narrativeTags.firstOrNull { hasResetMarker(it.name) }
                                                 if (fallbackTag != null) {
                                                     vm.addResponseRecord(current.id, fallbackTag.id, count = 3)
                                                     Toast.makeText(
                                                         context,
                                                         fillTemplate(
                                                             ui.executionSettings.successToast,
-                                                            listOf(current.name, fallbackTag.name)
+                                                            listOf(current.name, plainTagName(fallbackTag.name))
                                                         ),
                                                         Toast.LENGTH_SHORT
                                                     ).show()
@@ -439,14 +445,14 @@ fun CharacterScreen(
                                                 vm.updateCharacterPoints(current.id, current.points - 1)
                                                 val hit = (1..100).random() <= current.probability
                                                 if (hit) {
-                                                    val pick = narrativeTags.randomOrNull()
+                                                    val pick = weightedRandomNarrativeTag(weightedNarrativeTags)
                                                     if (pick != null) {
                                                         vm.addResponseRecord(current.id, pick.id)
                                                         Toast.makeText(
                                                             context,
                                                             fillTemplate(
                                                                 ui.executionSettings.successToast,
-                                                                listOf(current.name, pick.name)
+                                                                listOf(current.name, plainTagName(pick.name))
                                                             ),
                                                             Toast.LENGTH_SHORT
                                                         ).show()
@@ -871,6 +877,35 @@ private fun CharacterResourceFilterBar(
             FilterChip(selected = groupLevel3Selected, onClick = onToggleLevel3, label = { Text("3") })
         }
     }
+}
+
+private data class WeightedNarrativeTag(
+    val tag: TagEntity,
+    val weight: Int
+)
+
+private fun buildWeightedNarrativeTags(tags: List<TagEntity>): List<WeightedNarrativeTag> {
+    if (tags.isEmpty()) return emptyList()
+    val explicitWeights = tags.mapNotNull { tagWeight(it.name) }
+    val fallbackWeight = explicitWeights.minOrNull() ?: 1
+    return tags.map { tag ->
+        WeightedNarrativeTag(
+            tag = tag,
+            weight = (tagWeight(tag.name) ?: fallbackWeight).coerceAtLeast(1)
+        )
+    }
+}
+
+private fun weightedRandomNarrativeTag(weightedTags: List<WeightedNarrativeTag>): TagEntity? {
+    if (weightedTags.isEmpty()) return null
+    val totalWeight = weightedTags.sumOf { it.weight }
+    if (totalWeight <= 0) return weightedTags.randomOrNull()?.tag
+    var draw = (1..totalWeight).random()
+    weightedTags.forEach { entry ->
+        draw -= entry.weight
+        if (draw <= 0) return entry.tag
+    }
+    return weightedTags.lastOrNull()?.tag
 }
 
 private data class CharacterResourceGroup(

--- a/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/TagScreen.kt
@@ -146,7 +146,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
             TopAppBar(
                 title = {
                     val title = when {
-                        isInSubTagPage -> formatTagLabel(selectedParentTag?.displayName.orEmpty())
+                        isInSubTagPage -> formatTagLabel(selectedParentTag?.displayName.orEmpty(), keepMeta = true)
                         isInCategory -> categoryDisplayName(ui.currentCategory?.name)
                         else -> "标签类别"
                     }
@@ -284,7 +284,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                                     val textColor = if (bg.luminance() < 0.5f) Color.White else Color.Black
                                     val displayName = parentTag?.let { ctx -> tag.name.substringAfter("${ctx.parentKey}-", tag.name) } ?: tag.name
                                     SquareGridItem(
-                                        title = formatTagLabel(displayName),
+                                        title = formatTagLabel(displayName, keepMeta = true),
                                         backgroundColor = bg,
                                         contentColor = textColor,
                                         itemAspectRatio = 1.55f,
@@ -322,7 +322,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                                 val textColor = if (bg.luminance() < 0.5f) Color.White else Color.Black
                                 val isUsed = tag.id in ui.usedTagIds
                                 SquareGridItem(
-                                    title = formatTagLabel(tag.name),
+                                    title = formatTagLabel(tag.name, keepMeta = true),
                                     backgroundColor = bg,
                                     contentColor = textColor,
                                     borderColor = if (isUsed) Color.Black else null,
@@ -379,7 +379,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                                         val textColor = if (bg.luminance() < 0.5f) Color.White else Color.Black
                                         val isUsed = tag.id in ui.usedTagIds
                                         SquareGridItem(
-                                            title = formatTagLabel(groupedTag.displayName),
+                                            title = formatTagLabel(groupedTag.displayName, keepMeta = true),
                                             backgroundColor = bg,
                                             contentColor = textColor,
                                             borderColor = if (isUsed) Color.Black else null,
@@ -415,7 +415,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                                     val textColor = if (bg.luminance() < 0.5f) Color.White else Color.Black
                                     val isUsed = tag.id in ui.usedTagIds
                                     SquareGridItem(
-                                        title = formatTagLabel(groupedTag.displayName),
+                                        title = formatTagLabel(groupedTag.displayName, keepMeta = true),
                                         backgroundColor = bg,
                                         contentColor = textColor,
                                         borderColor = if (isUsed) Color.Black else null,
@@ -537,7 +537,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
                         val tagsText = ui.allTags
                             .filter { it.categoryId == target.id }
                             .sortedBy { it.name.lowercase() }
-                            .joinToString("\n") { formatTagLabel(it.name) }
+                            .joinToString("\n") { formatTagLabel(it.name, keepMeta = true) }
                         clipboard.setText(AnnotatedString(tagsText))
                         Toast.makeText(context, "已复制${target.name}全部标签", Toast.LENGTH_SHORT).show()
                         bottomSheetTarget = null
@@ -564,7 +564,7 @@ fun TagScreen(modifier: Modifier = Modifier, vm: TagViewModel = viewModel()) {
     deleteTag?.let { tag ->
         ConfirmDeleteDialog(
             title = "删除标签",
-            message = "确定删除“${formatTagLabel(tag.name)}”吗？",
+            message = "确定删除“${formatTagLabel(tag.name, keepMeta = true)}”吗？",
             onConfirm = { vm.deleteTag(tag) },
             onDismiss = { deleteTag = null }
         )

--- a/app/src/main/java/com/example/quotepicker/ui/components/DisplayFormatters.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/DisplayFormatters.kt
@@ -9,12 +9,26 @@ import kotlin.random.Random
 
 private val birthdayFormatter = DateTimeFormatter.ofPattern("yyyy年MM月dd日")
 private val randomTokenRegex = Regex("【【(.*?)】】")
+private val tagWeightRegex = Regex("^(.*)\\+(\\d+)$")
 
-fun formatTagLabel(name: String, today: LocalDate = LocalDate.now()): String {
-    val birthday = runCatching { LocalDate.parse(name, birthdayFormatter) }.getOrNull() ?: return name
+fun formatTagLabel(name: String, today: LocalDate = LocalDate.now(), keepMeta: Boolean = false): String {
+    val cleanedName = if (keepMeta) name else plainTagName(name)
+    val birthday = runCatching { LocalDate.parse(cleanedName, birthdayFormatter) }.getOrNull() ?: return cleanedName
     val age = if (birthday.isAfter(today)) 0 else Period.between(birthday, today).years
-    return "$name($age)"
+    return "$cleanedName($age)"
 }
+
+fun plainTagName(name: String): String {
+    val withoutMarker = name.replace("#", "").trim()
+    return tagWeightRegex.matchEntire(withoutMarker)?.groupValues?.getOrNull(1)?.trim().orEmpty().ifBlank {
+        withoutMarker
+    }
+}
+
+fun tagWeight(name: String): Int? =
+    tagWeightRegex.matchEntire(name.replace("#", "").trim())?.groupValues?.getOrNull(2)?.toIntOrNull()
+
+fun hasResetMarker(name: String): Boolean = name.contains('#')
 
 fun formatDisplayText(text: String, random: Random = Random.Default): String {
     if (text.isBlank()) return text

--- a/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
@@ -10,6 +10,7 @@ import com.example.quotepicker.data.Repository
 import com.example.quotepicker.data.ResourceWithTagsCharacters
 import com.example.quotepicker.data.ResponseRecordEntity
 import com.example.quotepicker.data.TagEntity
+import com.example.quotepicker.ui.components.plainTagName
 import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 import kotlin.math.roundToInt
@@ -83,7 +84,7 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
                 tagId = record.tagId,
                 count = record.count,
                 characterName = characterMap[record.characterId]?.name ?: "角色",
-                tagName = tagMap[record.tagId]?.name ?: "标签"
+                tagName = tagMap[record.tagId]?.name?.let(::plainTagName) ?: "标签"
             )
         }
         val displayExecutionItems = executionItems.mapNotNull { item ->


### PR DESCRIPTION
### Motivation
- 允许在叙事类别标签中通过 `标签名+权重` 指定抽取权重以影响祈求按钮和抽取概率。 
- 当角色点数重置（30 次数重置）时，应优先使用带 `#` 的叙事标签作为默认重置标签并添加次数。 
- 只在标签管理（列表/编辑/创建）场景保留 `+`/`#` 元信息，其他页面只展示纯标签名以避免泄露元数据。

### Description
- 在 `app/src/main/java/com/example/quotepicker/ui/components/DisplayFormatters.kt` 新增 `plainTagName`、`tagWeight`、`hasResetMarker` 并将 `formatTagLabel` 增加 `keepMeta` 参数以控制是否保留 `+`/`#` 元信息。 
- 在 `app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt` 中改为按权重抽取叙事标签（新增 `buildWeightedNarrativeTags` 与 `weightedRandomNarrativeTag`），未显式设置权重的标签在计算时使用已设置权重的最小值作为回退权重，且点数归零重置时优先选择带 `#` 的叙事标签并 `count = 3`。 
- 在 `app/src/main/java/com/example/quotepicker/ui/TagScreen.kt` 中只在标签管理界面调用 `formatTagLabel(..., keepMeta = true)`，从而在标签列表/编辑/复制/删除确认等页面展示包含 `+`/`#` 的原始文本，而其他 UI 仍使用纯标签名显示。 
- 在 `app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt` 中将执行记录中的标签名通过 `plainTagName` 展示，避免在执行页泄露标签元信息。 
- 涉及变更文件：`CharacterScreen.kt`, `TagScreen.kt`, `DisplayFormatters.kt`, `ExecutionViewModel.kt`。

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 进行本地 Kotlin 编译验证，但构建失败因为环境无法下载 Gradle 分发包（代理返回 `HTTP/1.1 403 Forbidden`），因此未能完成本地编译通过验证。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7b9a5b594832bb65423cf11fc60ce)