### PR TITLE
Add '触发类别' trigger flow, dialog-based pray feedback, and fixed completion scoring

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -470,6 +470,20 @@ class Repository private constructor(context: Context) {
         )
     }
 
+
+    suspend fun addResponseRecordByCategoryPrefix(
+        characterId: Long,
+        categoryName: String,
+        prefix: String,
+        count: Int = 1
+    ) {
+        val category = categoryDao.findByName(categoryName, TagCategoryType.RESOURCE) ?: return
+        val target = tagDao.listAll().firstOrNull {
+            it.categoryId == category.id && it.name.trim().uppercase().startsWith(prefix.uppercase())
+        } ?: return
+        addResponseRecord(characterId, target.id, count)
+    }
+
     suspend fun consumeResponseRecord(characterId: Long, tagId: Long) {
         val existing = responseRecordDao.findRecord(characterId, tagId) ?: return
         val nextCount = existing.count - 1

--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -134,6 +134,8 @@ fun CharacterScreen(
     val context = LocalContext.current
     var exportFormat by remember { mutableStateOf(ExportFormat.ENCRYPTED) }
     var importDialog by remember { mutableStateOf(false) }
+    var praySuccessDialogText by remember { mutableStateOf<String?>(null) }
+    var triggerChoiceDialogVisible by remember { mutableStateOf(false) }
 
     LaunchedEffect(selectedId) {
         selectedTagIds = emptySet()
@@ -374,6 +376,12 @@ fun CharacterScreen(
                 val narrativeTags = narrativeCategory?.let { category ->
                     resourceUi.tags.filter { it.categoryId == category.id }
                 }.orEmpty()
+                val triggerCategory = resourceUi.categories.firstOrNull { it.name == "触发类别" }
+                val triggerTags = triggerCategory?.let { category ->
+                    resourceUi.tags.filter { it.categoryId == category.id }
+                }.orEmpty()
+                val triggerTagA = triggerTags.firstOrNull { it.name.trim().uppercase(Locale.getDefault()).startsWith("A") }
+                val triggerTagB = triggerTags.firstOrNull { it.name.trim().uppercase(Locale.getDefault()).startsWith("B") }
                 val weightedNarrativeTags = remember(narrativeTags) {
                     buildWeightedNarrativeTags(narrativeTags)
                 }
@@ -448,14 +456,10 @@ fun CharacterScreen(
                                                     val pick = weightedRandomNarrativeTag(weightedNarrativeTags)
                                                     if (pick != null) {
                                                         vm.addResponseRecord(current.id, pick.id)
-                                                        Toast.makeText(
-                                                            context,
-                                                            fillTemplate(
-                                                                ui.executionSettings.successToast,
-                                                                listOf(current.name, plainTagName(pick.name))
-                                                            ),
-                                                            Toast.LENGTH_SHORT
-                                                        ).show()
+                                                        praySuccessDialogText = fillTemplate(
+                                                            ui.executionSettings.successToast,
+                                                            listOf(current.name, plainTagName(pick.name))
+                                                        )
                                                     } else {
                                                         Toast.makeText(context, "未找到叙事类别标签", Toast.LENGTH_SHORT).show()
                                                     }
@@ -471,6 +475,18 @@ fun CharacterScreen(
                                                 }
                                             }
                                             vm.consumeExecutionRemaining()
+                                        },
+                                        shape = MaterialTheme.shapes.small
+                                    ) {
+                                        Text(ui.executionSettings.buttonLabel)
+                                    }
+                                    Button(
+                                        onClick = {
+                                            if (triggerTagA == null && triggerTagB == null) {
+                                                Toast.makeText(context, "未找到触发类别的 A/B 标签", Toast.LENGTH_SHORT).show()
+                                            } else {
+                                                triggerChoiceDialogVisible = true
+                                            }
                                         },
                                         shape = MaterialTheme.shapes.small
                                     ) {
@@ -650,6 +666,66 @@ fun CharacterScreen(
                 }) { Text("删除") }
             },
             dismissButton = { TextButton(onClick = { deleteTarget = null }) { Text("取消") } }
+        )
+    }
+
+    if (praySuccessDialogText != null) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("祈求结果") },
+            text = { Text(praySuccessDialogText.orEmpty()) },
+            confirmButton = {
+                TextButton(onClick = { praySuccessDialogText = null }) { Text("OK") }
+            }
+        )
+    }
+
+    if (triggerChoiceDialogVisible && selected != null) {
+        val triggerCategory = resourceUi.categories.firstOrNull { it.name == "触发类别" }
+        val triggerTags = triggerCategory?.let { category ->
+            resourceUi.tags.filter { it.categoryId == category.id }
+        }.orEmpty()
+        val triggerTagA = triggerTags.firstOrNull { it.name.trim().uppercase(Locale.getDefault()).startsWith("A") }
+        val triggerTagB = triggerTags.firstOrNull { it.name.trim().uppercase(Locale.getDefault()).startsWith("B") }
+        var selectedPrefix by remember(triggerChoiceDialogVisible) {
+            mutableStateOf(if (triggerTagA != null) "A" else "B")
+        }
+        AlertDialog(
+            onDismissRequest = { triggerChoiceDialogVisible = false },
+            title = { Text("触发类型") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    triggerTagA?.let {
+                        FilterChip(
+                            selected = selectedPrefix == "A",
+                            onClick = { selectedPrefix = "A" },
+                            label = { Text(plainTagName(it.name)) }
+                        )
+                    }
+                    triggerTagB?.let {
+                        FilterChip(
+                            selected = selectedPrefix == "B",
+                            onClick = { selectedPrefix = "B" },
+                            label = { Text(plainTagName(it.name)) }
+                        )
+                    }
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    val current = selected.character
+                    val picked = if (selectedPrefix == "A") triggerTagA else triggerTagB
+                    if (picked == null) {
+                        Toast.makeText(context, "未找到对应触发标签", Toast.LENGTH_SHORT).show()
+                    } else {
+                        vm.addResponseRecord(current.id, picked.id)
+                    }
+                    triggerChoiceDialogVisible = false
+                }) { Text("OK") }
+            },
+            dismissButton = {
+                TextButton(onClick = { triggerChoiceDialogVisible = false }) { Text("取消") }
+            }
         )
     }
 }

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -153,9 +154,16 @@ fun ExecutionScreen(
                     ) {
                         ui.records.forEach { record ->
                             val label = buildString {
-                                append(record.characterName)
-                                append("的")
-                                append(record.tagName)
+                                if (record.isTriggerCategory) {
+                                    val triggerName = record.tagName.replaceFirst(Regex("^[A-Z]"), "").trim().ifBlank { record.tagName }
+                                    append("对")
+                                    append(record.characterName)
+                                    append(triggerName)
+                                } else {
+                                    append(record.characterName)
+                                    append("的")
+                                    append(record.tagName)
+                                }
                                 if (record.count > 1) {
                                     append("×")
                                     append(record.count)
@@ -195,7 +203,12 @@ fun ExecutionScreen(
                                     .defaultMinSize(minHeight = 24.dp) // ⭐关键：覆盖 Button 默认 minHeight
                                     .height(24.dp),                    // 固定高度（不想固定就用 heightIn）
                                 shape = RoundedCornerShape(6.dp),
-                                contentPadding = compactPadding
+                                contentPadding = compactPadding,
+                                colors = if (record.isTriggerCategory) {
+                                    ButtonDefaults.buttonColors(containerColor = Color(0xFFD32F2F), contentColor = Color.White)
+                                } else {
+                                    ButtonDefaults.buttonColors()
+                                }
                             ) {
                                 Text(
                                     text = label,
@@ -249,9 +262,9 @@ fun ExecutionScreen(
     completionTarget?.let { target ->
         CompletionDialog(
             characterName = target.characterName,
-            onConfirm = { completion, belonging, emotion ->
-                val sum = completion + belonging + emotion
-                vm.applyExecutionCompletion(target.characterId, sum)
+            onConfirm = {
+                val currentPoints = ui.characters.firstOrNull { it.id == target.characterId }?.points ?: 0
+                vm.applyExecutionCompletionWithTrigger(target.characterId, currentPoints)
                 vm.removeExecutionResource(target.id)
                 completionTarget = null
             },
@@ -314,71 +327,20 @@ private fun SettingsDialog(
 @Composable
 private fun CompletionDialog(
     characterName: String,
-    onConfirm: (Int, Int, Int) -> Unit,
+    onConfirm: () -> Unit,
     onDismiss: () -> Unit
 ) {
-    var completionText by remember { mutableStateOf("") }
-    var belongingText by remember { mutableStateOf("") }
-    var emotionText by remember { mutableStateOf("") }
-    var errorText by remember { mutableStateOf<String?>(null) }
-
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("完成记录") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text("$characterName 的完成情况")
-                OutlinedTextField(
-                    value = completionText,
-                    onValueChange = {
-                        completionText = it
-                        errorText = null
-                    },
-                    label = { Text("完成度(0-10)") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                OutlinedTextField(
-                    value = belongingText,
-                    onValueChange = {
-                        belongingText = it
-                        errorText = null
-                    },
-                    label = { Text("归属感(0-10)") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                OutlinedTextField(
-                    value = emotionText,
-                    onValueChange = {
-                        emotionText = it
-                        errorText = null
-                    },
-                    label = { Text("情绪值(0-10)") },
-                    modifier = Modifier.fillMaxWidth()
-                )
-                errorText?.let {
-                    Text(it, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.labelSmall)
-                }
+                Text("完成度 +15，归属度 +15")
             }
         },
         confirmButton = {
-            TextButton(onClick = {
-                val completion = completionText.toIntOrNull()
-                val belonging = belongingText.toIntOrNull()
-                val emotion = emotionText.toIntOrNull()
-                val isValid = completion != null && belonging != null && emotion != null &&
-                    completion in 0..10 && belonging in 0..10 && emotion in 0..10
-                if (!isValid) {
-                    errorText = "三个值都必须填写 0-10 之间的整数"
-                    return@TextButton
-                }
-                if (completion != null) {
-                    if (belonging != null) {
-                        if (emotion != null) {
-                            onConfirm(completion, belonging, emotion)
-                        }
-                    }
-                }
-            }) { Text("完成") }
+            TextButton(onClick = onConfirm) { Text("完成") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.AssistChip
 import androidx.compose.material3.AssistChipDefaults
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
@@ -131,6 +132,12 @@ fun ResourcePreviewScreen(
         uiState.characters.firstOrNull { it.id == id }?.name
     }
     val eventRunner = rememberEventSequenceRunner()
+    val triggerCategory = uiState.categories.firstOrNull { it.name == "触发类别" }
+    val triggerTagC = liveResource.tags.firstOrNull {
+        it.categoryId == triggerCategory?.id && it.name.trim().uppercase(Locale.getDefault()).startsWith("C")
+    }
+    var pendingTriggerC by remember(liveResource.resource.id) { mutableStateOf(false) }
+    var triggerCDialogVisible by remember(liveResource.resource.id) { mutableStateOf(false) }
 
     LaunchedEffect(resource.resource.id, mediaReloadKey, allResources) {
         val res = liveResource.resource
@@ -180,6 +187,15 @@ fun ResourcePreviewScreen(
         sceneMessages = if (res.type == ResourceType.SCENE) parseSceneMessages(res.sceneJson.orEmpty()) else emptyList()
     }
 
+    LaunchedEffect(pendingTriggerC, liveResource.resource.id) {
+        if (pendingTriggerC && triggerTagC != null) {
+            delay(30_000)
+            if (pendingTriggerC) {
+                triggerCDialogVisible = true
+            }
+        }
+    }
+
     val handleEventSequence: (EventSequence) -> Unit = { sequence ->
         eventRunner.start(sequence)
     }
@@ -221,6 +237,7 @@ fun ResourcePreviewScreen(
                             if (liveResource.tags.isNotEmpty()) {
                                 val next = if (liveResource.resource.markState == ResourceMarkState.CHECKED) ResourceMarkState.NONE else ResourceMarkState.CHECKED
                                 vm.updateResource(liveResource.resource.copy(markState = next))
+                                pendingTriggerC = next == ResourceMarkState.CHECKED && triggerTagC != null
                             }
                         }
                     )
@@ -231,8 +248,10 @@ fun ResourcePreviewScreen(
                         onClick = {
                             if (liveResource.tags.isNotEmpty() && liveResource.resource.markState == ResourceMarkState.CHECKED) {
                                 vm.updateResource(liveResource.resource.copy(markState = ResourceMarkState.FAVORITE))
+                                pendingTriggerC = triggerTagC != null
                             } else if (liveResource.resource.markState == ResourceMarkState.FAVORITE) {
                                 vm.updateResource(liveResource.resource.copy(markState = ResourceMarkState.CHECKED))
+                                pendingTriggerC = triggerTagC != null
                             }
                         }
                     )
@@ -529,6 +548,21 @@ fun ResourcePreviewScreen(
                 }
             }
         }
+    }
+
+    if (triggerCDialogVisible && triggerTagC != null && liveResource.characters.isNotEmpty()) {
+        AlertDialog(
+            onDismissRequest = {},
+            title = { Text("触发提醒") },
+            text = { Text("触发事件已记录") },
+            confirmButton = {
+                TextButton(onClick = {
+                    vm.addResponseRecord(liveResource.characters.first().id, triggerTagC.id)
+                    pendingTriggerC = false
+                    triggerCDialogVisible = false
+                }) { Text("OK") }
+            }
+        )
     }
 }
 

--- a/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
@@ -26,7 +26,8 @@ data class ResponseRecordDisplay(
     val tagId: Long,
     val count: Int,
     val characterName: String,
-    val tagName: String
+    val tagName: String,
+    val isTriggerCategory: Boolean = false
 )
 
 data class ExecutionUiState(
@@ -35,7 +36,8 @@ data class ExecutionUiState(
     val executionItems: List<ExecutionResourceDisplay> = emptyList(),
     val resources: List<ResourceWithTagsCharacters> = emptyList(),
     val characters: List<CharacterEntity> = emptyList(),
-    val tags: List<TagEntity> = emptyList()
+    val tags: List<TagEntity> = emptyList(),
+    val categories: List<com.example.quotepicker.data.TagCategoryEntity> = emptyList()
 )
 
 data class ExecutionResourceDisplay(
@@ -60,14 +62,16 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
         repo.observeCharacters(),
         repo.observeAllTags(),
         repo.observeResourcesWithRelations(),
-        repo.observeExecutionSettings()
-    ) { records, characters, tags, resources, settings ->
+        repo.observeExecutionSettings(),
+        repo.observeCategories()
+    ) { records, characters, tags, resources, settings, categories ->
         BaseExecutionData(
             records = records,
             characters = characters,
             tags = tags,
             resources = resources,
-            settings = settings
+            settings = settings,
+            categories = categories
         )
     }
 
@@ -77,6 +81,7 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
     ) { baseData, executionItems ->
         val characterMap = baseData.characters.associateBy { it.id }
         val tagMap = baseData.tags.associateBy { it.id }
+        val categoryMap = baseData.categories.associateBy { it.id }
         val resourcesById = baseData.resources.associateBy { it.resource.id }
         val displayRecords = baseData.records.map { record ->
             ResponseRecordDisplay(
@@ -84,7 +89,8 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
                 tagId = record.tagId,
                 count = record.count,
                 characterName = characterMap[record.characterId]?.name ?: "角色",
-                tagName = tagMap[record.tagId]?.name?.let(::plainTagName) ?: "标签"
+                tagName = tagMap[record.tagId]?.name?.let(::plainTagName) ?: "标签",
+                isTriggerCategory = categoryMap[tagMap[record.tagId]?.categoryId]?.name == "触发类别"
             )
         }
         val displayExecutionItems = executionItems.mapNotNull { item ->
@@ -97,7 +103,8 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
             executionItems = displayExecutionItems,
             resources = baseData.resources,
             characters = baseData.characters,
-            tags = baseData.tags
+            tags = baseData.tags,
+            categories = baseData.categories
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, ExecutionUiState())
 
@@ -133,6 +140,18 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
 
     fun applyExecutionCompletion(characterId: Long, completionScoreSum: Int) = viewModelScope.launch {
         repo.applyExecutionCompletion(characterId, completionScoreSum)
+    }
+
+    fun applyExecutionCompletionWithTrigger(characterId: Long, currentPoints: Int) = viewModelScope.launch {
+        repo.applyExecutionCompletion(characterId, 30)
+        when {
+            currentPoints < 10 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "E")
+            currentPoints < 20 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "D")
+        }
+    }
+
+    fun addTriggerRecordByPrefix(characterId: Long, prefix: String) = viewModelScope.launch {
+        repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", prefix)
     }
 
     fun incrementCharacterFamiliarity(characterId: Long) = viewModelScope.launch {
@@ -188,7 +207,8 @@ private data class BaseExecutionData(
     val characters: List<CharacterEntity>,
     val tags: List<TagEntity>,
     val resources: List<ResourceWithTagsCharacters>,
-    val settings: ExecutionSettingsEntity?
+    val settings: ExecutionSettingsEntity?,
+    val categories: List<com.example.quotepicker.data.TagCategoryEntity>
 )
 
 private fun ExecutionResourceEntity.toDisplay(resource: ResourceWithTagsCharacters): ExecutionResourceDisplay =

--- a/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt
@@ -160,6 +160,9 @@ class ResourceViewModel(app: Application) : AndroidViewModel(app) {
     fun updateMarkStateFilter(state: ResourceMarkState?) {
         filters.value = filters.value.copy(selectedMarkState = state)
     }
+    fun addResponseRecord(characterId: Long, tagId: Long, count: Int = 1) =
+        viewModelScope.launch { repo.addResponseRecord(characterId, tagId, count) }
+
     fun resolveMediaUri(type: ResourceType, name: String, resourceId: Long? = null): Uri? {
         val targetName = name.trim()
         if (targetName.isBlank()) return null


### PR DESCRIPTION
### Motivation
- Implement new "触发类别" tag category and UI flows to support A/B/C/D/E trigger behaviors and match requested interaction changes.
- Change pray (祈求) feedback to show a dialog on success and keep toast on ignore/failure, and ensure trigger-related response records are shown and executed differently.
- Simplify completion recording to fixed two-value scoring (完成度 +15, 归属度 +15) and automatically emit D/E trigger records based on current points thresholds.

### Description
- Added repository helper `addResponseRecordByCategoryPrefix(...)` to locate a tag by category name and prefix and create a response record (app/src/main/java/com/example/quotepicker/data/Repository.kt). 
- Added trigger-aware UI on the Character screen to: show a second same-labeled button that opens a choice dialog for A/B triggers and write the selected trigger record on OK, and show success results in an OK-only dialog instead of a toast (app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt). 
- Updated Execution flow to mark response records that belong to the "触发类别" and render those record buttons in red with label format `对[角色]...`, and wired consumption/completion to emit D/E triggers when applicable (app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt and app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt). 
- Modified Completion dialog to a fixed two-value confirmation UI and changed the completion handling to apply a total of 30 points (15+15) and to invoke repository methods that add D/E trigger records depending on current character points (app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt and app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt). 
- Added resource-preview behavior for C-class triggers so that when a resource is set to CHECKED/FAVORITE and the preview is maintained for 30 seconds, a dialog prompts and on OK adds the C-class response record for a bound character, and exposed `addResponseRecord` on `ResourceViewModel` for preview to call (app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt and app/src/main/java/com/example/quotepicker/vm/ResourceViewModel.kt). 
- Minor UI formatting adjustments to label trigger names (strip leading prefix letter for display) and button coloring for trigger records in the Execution screen (app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt and related components). 

### Testing
- Attempted to compile Kotlin sources with `./gradlew :app:compileDebugKotlin`, but the environment failed to download the Gradle distribution due to a network/proxy error (HTTP 403), so no successful local build was produced. 
- Performed code inspection and grep-based checks to validate that new methods are referenced and dialogs are wired (static checks only), and no database schema changes were required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7c0090140832b883d4b8a263df9c0)