### PR TITLE
Add secondary execution button and adjustable completion/familiarity; update DB schema

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
+++ b/app/src/main/java/com/example/quotepicker/data/AppDatabase.kt
@@ -41,7 +41,7 @@ class Converters {
         ExecutionResourceEntity::class,
         TextResourceUsageHistoryEntity::class
     ],
-    version = 10,
+    version = 11,
     exportSchema = false
 )
 @TypeConverters(Converters::class)

--- a/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
+++ b/app/src/main/java/com/example/quotepicker/data/BackupSnapshot.kt
@@ -130,6 +130,7 @@ private fun executionSettingsToJson(settings: ExecutionSettingsEntity): JSONObje
     JSONObject()
         .put("id", settings.id)
         .put("buttonLabel", settings.buttonLabel)
+        .put("secondaryButtonLabel", settings.secondaryButtonLabel)
         .put("successToast", settings.successToast)
         .put("failureToast", settings.failureToast)
         .put("pastAverage", settings.pastAverage)
@@ -235,6 +236,7 @@ private fun executionSettingsFromJson(obj: JSONObject): ExecutionSettingsEntity 
     ExecutionSettingsEntity(
         id = obj.optLong("id", 1),
         buttonLabel = obj.optString("buttonLabel", "祈求"),
+        secondaryButtonLabel = obj.optString("secondaryButtonLabel", "祈求"),
         successToast = obj.optString("successToast", "[]赐予了你[]"),
         failureToast = obj.optString("failureToast", "[]无视了你"),
         pastAverage = obj.optInt("pastAverage", 100),

--- a/app/src/main/java/com/example/quotepicker/data/Entities.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Entities.kt
@@ -68,6 +68,7 @@ data class ResponseRecordEntity(
 data class ExecutionSettingsEntity(
     @PrimaryKey val id: Long = 1,
     val buttonLabel: String = "祈求",
+    val secondaryButtonLabel: String = "祈求",
     val successToast: String = "[]赐予了你[]",
     val failureToast: String = "[]无视了你",
     val pastAverage: Int = 100,

--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -390,7 +390,7 @@ class Repository private constructor(context: Context) {
         characterDao.update(target.copy(points = points.coerceIn(0, 30), updatedAt = System.currentTimeMillis()))
     }
 
-    suspend fun applyExecutionCompletion(characterId: Long, completionScoreSum: Int) {
+    suspend fun applyExecutionCompletion(characterId: Long, completionScoreSum: Int, familiarityIncrement: Int = 1) {
         db.withTransaction {
             val characters = characterDao.listAll()
             val target = characters.firstOrNull { it.id == characterId } ?: return@withTransaction
@@ -398,7 +398,7 @@ class Repository private constructor(context: Context) {
             characterDao.update(
                 target.copy(
                     points = nextPoints.coerceIn(0, 30),
-                    familiarity = target.familiarity + 1,
+                    familiarity = (target.familiarity + familiarityIncrement).coerceAtLeast(0),
                     updatedAt = System.currentTimeMillis()
                 )
             )

--- a/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/CharacterScreen.kt
@@ -478,7 +478,7 @@ fun CharacterScreen(
                                         },
                                         shape = MaterialTheme.shapes.small
                                     ) {
-                                        Text(ui.executionSettings.buttonLabel)
+                                        Text(ui.executionSettings.secondaryButtonLabel)
                                     }
                                     Button(
                                         onClick = {

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TopAppBar
@@ -87,7 +88,8 @@ fun ExecutionScreen(
             onBack = {
                 showPreview = false
                 previewTarget = null
-            }
+            },
+            triggerCEnabled = false
         )
         return
     }
@@ -262,9 +264,14 @@ fun ExecutionScreen(
     completionTarget?.let { target ->
         CompletionDialog(
             characterName = target.characterName,
-            onConfirm = {
+            onConfirm = { completionScore, familiarityIncrement ->
                 val currentPoints = ui.characters.firstOrNull { it.id == target.characterId }?.points ?: 0
-                vm.applyExecutionCompletionWithTrigger(target.characterId, currentPoints)
+                vm.applyExecutionCompletionWithTrigger(
+                    characterId = target.characterId,
+                    currentPoints = currentPoints,
+                    completionScoreSum = completionScore,
+                    familiarityIncrement = familiarityIncrement
+                )
                 vm.removeExecutionResource(target.id)
                 completionTarget = null
             },
@@ -280,6 +287,7 @@ private fun SettingsDialog(
     onDismiss: () -> Unit
 ) {
     var buttonLabel by remember { mutableStateOf(settings.buttonLabel) }
+    var secondaryButtonLabel by remember { mutableStateOf(settings.secondaryButtonLabel) }
     var successToast by remember { mutableStateOf(settings.successToast) }
     var failureToast by remember { mutableStateOf(settings.failureToast) }
 
@@ -291,7 +299,13 @@ private fun SettingsDialog(
                 OutlinedTextField(
                     value = buttonLabel,
                     onValueChange = { buttonLabel = it },
-                    label = { Text("按钮名") },
+                    label = { Text("按钮1名") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = secondaryButtonLabel,
+                    onValueChange = { secondaryButtonLabel = it },
+                    label = { Text("按钮2名") },
                     modifier = Modifier.fillMaxWidth()
                 )
                 OutlinedTextField(
@@ -314,6 +328,7 @@ private fun SettingsDialog(
                 onConfirm(
                     settings.copy(
                         buttonLabel = buttonLabel.trim().ifBlank { settings.buttonLabel },
+                        secondaryButtonLabel = secondaryButtonLabel.trim().ifBlank { settings.secondaryButtonLabel },
                         successToast = successToast.trim().ifBlank { settings.successToast },
                         failureToast = failureToast.trim().ifBlank { settings.failureToast }
                     )
@@ -327,20 +342,40 @@ private fun SettingsDialog(
 @Composable
 private fun CompletionDialog(
     characterName: String,
-    onConfirm: () -> Unit,
+    onConfirm: (Int, Int) -> Unit,
     onDismiss: () -> Unit
 ) {
+    var completionScore by remember { mutableStateOf(15f) }
+    var familiarityIncrement by remember { mutableStateOf(15f) }
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text("完成记录") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text("$characterName 的完成情况")
-                Text("完成度 +15，归属度 +15")
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text("完成度 +${completionScore.toInt()}")
+                    Slider(
+                        value = completionScore,
+                        onValueChange = { completionScore = it },
+                        valueRange = 0f..30f,
+                        steps = 29
+                    )
+                }
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text("归属度 +${familiarityIncrement.toInt()}")
+                    Slider(
+                        value = familiarityIncrement,
+                        onValueChange = { familiarityIncrement = it },
+                        valueRange = 0f..30f,
+                        steps = 29
+                    )
+                }
             }
         },
         confirmButton = {
-            TextButton(onClick = onConfirm) { Text("完成") }
+            TextButton(onClick = { onConfirm(completionScore.toInt(), familiarityIncrement.toInt()) }) { Text("完成") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )

--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -110,7 +110,8 @@ private data class FlowPreviewItem(
 fun ResourcePreviewScreen(
     resource: ResourceWithTagsCharacters,
     vm: ResourceViewModel,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    triggerCEnabled: Boolean = true
 ) {
     var quoteImages by remember { mutableStateOf<List<ImagePreviewItem>>(emptyList()) }
     var mediaUris by remember { mutableStateOf<List<Uri>>(emptyList()) }
@@ -133,9 +134,10 @@ fun ResourcePreviewScreen(
     }
     val eventRunner = rememberEventSequenceRunner()
     val triggerCategory = uiState.categories.firstOrNull { it.name == "触发类别" }
-    val triggerTagC = liveResource.tags.firstOrNull {
+    val triggerTagC = uiState.tags.firstOrNull {
         it.categoryId == triggerCategory?.id && it.name.trim().uppercase(Locale.getDefault()).startsWith("C")
     }
+    val isTriggerCEligible = triggerCEnabled && liveResource.resource.markState != ResourceMarkState.NONE
     var pendingTriggerC by remember(liveResource.resource.id) { mutableStateOf(false) }
     var triggerCDialogVisible by remember(liveResource.resource.id) { mutableStateOf(false) }
 
@@ -187,10 +189,12 @@ fun ResourcePreviewScreen(
         sceneMessages = if (res.type == ResourceType.SCENE) parseSceneMessages(res.sceneJson.orEmpty()) else emptyList()
     }
 
-    LaunchedEffect(pendingTriggerC, liveResource.resource.id) {
-        if (pendingTriggerC && triggerTagC != null) {
+    LaunchedEffect(isTriggerCEligible, liveResource.resource.id) {
+        pendingTriggerC = isTriggerCEligible
+        triggerCDialogVisible = false
+        if (isTriggerCEligible) {
             delay(30_000)
-            if (pendingTriggerC) {
+            if (pendingTriggerC && liveResource.resource.markState != ResourceMarkState.NONE) {
                 triggerCDialogVisible = true
             }
         }
@@ -237,7 +241,7 @@ fun ResourcePreviewScreen(
                             if (liveResource.tags.isNotEmpty()) {
                                 val next = if (liveResource.resource.markState == ResourceMarkState.CHECKED) ResourceMarkState.NONE else ResourceMarkState.CHECKED
                                 vm.updateResource(liveResource.resource.copy(markState = next))
-                                pendingTriggerC = next == ResourceMarkState.CHECKED && triggerTagC != null
+                                pendingTriggerC = next != ResourceMarkState.NONE
                             }
                         }
                     )
@@ -248,10 +252,10 @@ fun ResourcePreviewScreen(
                         onClick = {
                             if (liveResource.tags.isNotEmpty() && liveResource.resource.markState == ResourceMarkState.CHECKED) {
                                 vm.updateResource(liveResource.resource.copy(markState = ResourceMarkState.FAVORITE))
-                                pendingTriggerC = triggerTagC != null
+                                pendingTriggerC = true
                             } else if (liveResource.resource.markState == ResourceMarkState.FAVORITE) {
                                 vm.updateResource(liveResource.resource.copy(markState = ResourceMarkState.CHECKED))
-                                pendingTriggerC = triggerTagC != null
+                                pendingTriggerC = true
                             }
                         }
                     )

--- a/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
@@ -142,12 +142,17 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
         repo.updateCharacterPoints(characterId, points)
     }
 
-    fun applyExecutionCompletion(characterId: Long, completionScoreSum: Int) = viewModelScope.launch {
-        repo.applyExecutionCompletion(characterId, completionScoreSum)
+    fun applyExecutionCompletion(characterId: Long, completionScoreSum: Int, familiarityIncrement: Int = 1) = viewModelScope.launch {
+        repo.applyExecutionCompletion(characterId, completionScoreSum, familiarityIncrement)
     }
 
-    fun applyExecutionCompletionWithTrigger(characterId: Long, currentPoints: Int) = viewModelScope.launch {
-        repo.applyExecutionCompletion(characterId, 30)
+    fun applyExecutionCompletionWithTrigger(
+        characterId: Long,
+        currentPoints: Int,
+        completionScoreSum: Int,
+        familiarityIncrement: Int
+    ) = viewModelScope.launch {
+        repo.applyExecutionCompletion(characterId, completionScoreSum, familiarityIncrement)
         when {
             currentPoints < 10 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "E")
             currentPoints < 20 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "D")


### PR DESCRIPTION
### Motivation

- Introduce a second execution button label and allow configurable completion and familiarity increments to make execution behavior more flexible.
- Persist the new setting and keep backup/restore compatible by including the new field in JSON snapshots and bumping the database schema version.

### Description

- Add `secondaryButtonLabel` to `ExecutionSettingsEntity` with default value and include it in `BackupSnapshot` serialization/deserialization.
- Update UI: expose `secondaryButtonLabel` in `SettingsDialog`, show it in `CharacterScreen` as the secondary action, and add sliders in `CompletionDialog` to pick `completionScore` and `familiarityIncrement` passed as `(Int, Int)` to the confirm callback.
- Propagate the new values through the VM and repository by changing `applyExecutionCompletion` to accept `familiarityIncrement` and wiring `applyExecutionCompletionWithTrigger` to forward both `completionScoreSum` and `familiarityIncrement`.
- Adjust `ResourcePreviewScreen` to add a `triggerCEnabled` flag and refine the pending trigger logic for mark state changes.
- Bump Room database schema `version` from `10` to `11` and retain `fallbackToDestructiveMigration()` to handle migrations.

### Testing

- Built the app with `./gradlew assembleDebug` and the build succeeded.
- Ran unit tests with `./gradlew test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b9f652367c832b9058275dcb8e732a)