### PR TITLE
Use completionScoreSum to determine triggers and simplify applyExecutionCompletionWithTrigger

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -265,10 +265,8 @@ fun ExecutionScreen(
         CompletionDialog(
             characterName = target.characterName,
             onConfirm = { completionScore, familiarityIncrement ->
-                val currentPoints = ui.characters.firstOrNull { it.id == target.characterId }?.points ?: 0
                 vm.applyExecutionCompletionWithTrigger(
                     characterId = target.characterId,
-                    currentPoints = currentPoints,
                     completionScoreSum = completionScore,
                     familiarityIncrement = familiarityIncrement
                 )

--- a/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
@@ -148,14 +148,13 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
 
     fun applyExecutionCompletionWithTrigger(
         characterId: Long,
-        currentPoints: Int,
         completionScoreSum: Int,
         familiarityIncrement: Int
     ) = viewModelScope.launch {
         repo.applyExecutionCompletion(characterId, completionScoreSum, familiarityIncrement)
         when {
-            currentPoints < 10 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "E")
-            currentPoints < 20 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "D")
+            completionScoreSum < 10 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "E")
+            completionScoreSum < 20 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "D")
         }
     }
 


### PR DESCRIPTION
### Motivation
- The trigger-record logic should be based on the completion score from the execution result rather than the character's previously-stored points to more directly reflect the current execution outcome.

### Description
- Updated `applyExecutionCompletionWithTrigger` signature to remove the `currentPoints` parameter and use `completionScoreSum` for threshold checks.
- Adjusted trigger creation logic to call `repo.addResponseRecordByCategoryPrefix` when `completionScoreSum` is less than 10 or less than 20 with prefixes "E" and "D" respectively.
- Removed UI-side lookup of `currentPoints` in `RandomScreen/CompletionDialog` and updated the confirm callback to call the simplified `applyExecutionCompletionWithTrigger` without the extra argument.

### Testing
- Built the Android app successfully after the changes with no compilation errors reported.
- Ran the project's unit tests and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba022aab20832bbe8eb0ea60b3fec8)