### PR TITLE
Support hidden video background audio in magic drama

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -133,6 +133,7 @@ fun MagicDramaScreen(
     var pendingBranch by remember { mutableStateOf<CompletableDeferred<String>?>(null) }
     var countdownJob by remember { mutableStateOf<Job?>(null) }
     var backgroundPlayer by remember { mutableStateOf<MediaPlayer?>(null) }
+    var backgroundVideoUri by remember { mutableStateOf<Uri?>(null) }
 
     val parsed = remember(script) { parseDramaScript(script) }
     val coroutineScope = rememberCoroutineScope()
@@ -163,6 +164,7 @@ fun MagicDramaScreen(
             coroutineScope.launch {
                 backgroundPlayer?.stop()
                 backgroundPlayer?.release()
+                backgroundVideoUri = null
                 piperSpeechEngine.stop()
                 piperSpeechEngine.cleanupPreviewTempFiles()
                 piperSpeechEngine.release()
@@ -188,6 +190,7 @@ fun MagicDramaScreen(
         backgroundPlayer?.stop()
         backgroundPlayer?.release()
         backgroundPlayer = null
+        backgroundVideoUri = null
 
         fun jumpTo(blockId: String, queue: ArrayDeque<DramaCommand>) {
             queue.clear()
@@ -255,12 +258,21 @@ fun MagicDramaScreen(
                 is DramaCommand.SetBackgroundMusic -> {
                     backgroundPlayer?.stop()
                     backgroundPlayer?.release()
-                    backgroundPlayer = createLoopMediaPlayer(resolveVariablePlaceholders(cmd.source, variables), vm)
+                    backgroundPlayer = null
+                    val backgroundSource = resolveVariablePlaceholders(cmd.source, variables)
+                    val resolvedUri = resolveMediaPlaybackUri(backgroundSource, vm)
+                    if (resolvedUri != null && vm.isVideoUri(resolvedUri)) {
+                        backgroundVideoUri = resolvedUri
+                    } else {
+                        backgroundVideoUri = null
+                        backgroundPlayer = createLoopMediaPlayer(backgroundSource, vm)
+                    }
                 }
                 is DramaCommand.StopBackgroundMusic -> {
                     backgroundPlayer?.stop()
                     backgroundPlayer?.release()
                     backgroundPlayer = null
+                    backgroundVideoUri = null
                 }
                 is DramaCommand.StopCountdown -> {
                     countdownJob?.cancel()
@@ -311,6 +323,7 @@ fun MagicDramaScreen(
                 .fillMaxSize()
                 .background(currentTheme.dialogBackground)
         ) {
+            backgroundVideoUri?.let { HiddenBackgroundVideoPlayer(uri = it) }
             Column(modifier = Modifier.fillMaxSize()) {
             Box(
                 modifier = Modifier
@@ -563,6 +576,39 @@ private fun resolveTokenValue(token: String, variables: Map<String, String>): St
     return token
 }
 
+
+@Composable
+private fun HiddenBackgroundVideoPlayer(uri: Uri) {
+    val holder = remember { mutableStateOf<VideoView?>(null) }
+    DisposableEffect(uri) {
+        onDispose {
+            holder.value?.stopPlayback()
+            holder.value = null
+        }
+    }
+    AndroidView(
+        factory = { context ->
+            VideoView(context).apply {
+                alpha = 0f
+                setVideoURI(uri)
+                setOnPreparedListener { player ->
+                    player.isLooping = true
+                    start()
+                }
+                holder.value = this
+            }
+        },
+        update = { view ->
+            if (view.tag != uri) {
+                view.tag = uri
+                view.setVideoURI(uri)
+                view.start()
+            }
+        },
+        modifier = Modifier.size(1.dp)
+    )
+}
+
 @Composable
 private fun LoopVideo(uri: Uri, onCompleted: (() -> Unit)? = null) {
     val holder = remember { mutableStateOf<VideoView?>(null) }
@@ -748,10 +794,13 @@ private fun parseBlockCommands(lines: List<String>): List<DramaCommand> {
     return commands
 }
 
-private fun createLoopMediaPlayer(source: String, vm: ResourceViewModel): MediaPlayer? {
-    val uri = vm.resolveMediaUriByCodeOrPath(source)
+private fun resolveMediaPlaybackUri(source: String, vm: ResourceViewModel): Uri? {
+    return vm.resolveMediaUriByCodeOrPath(source)
         ?: runCatching { Uri.parse(source) }.getOrNull()?.takeIf { it.scheme != null }
-        ?: return null
+}
+
+private fun createLoopMediaPlayer(source: String, vm: ResourceViewModel): MediaPlayer? {
+    val uri = resolveMediaPlaybackUri(source, vm) ?: return null
     return runCatching {
         MediaPlayer.create(vm.getApplication(), uri)?.apply {
             isLooping = true


### PR DESCRIPTION
### Motivation
- Allow the magic-drama `背景:` command to use video files as background sources while keeping the video visually hidden and only using its audio as background sound.
- Ensure background media (audio or hidden video) is correctly started, stopped and cleaned up when scripts restart, the dialog closes, or background playback is cleared.

### Description
- Added a `backgroundVideoUri` state to `MagicDramaScreen` and a new composable `HiddenBackgroundVideoPlayer` that plays a video in a hidden 1.dp, transparent `VideoView` to provide audio-only playback from video files.
- Updated `SetBackgroundMusic` handling to resolve the media URI (`resolveMediaPlaybackUri`) and choose between the existing looping `MediaPlayer` for audio and the hidden `VideoView` when the resolved URI is a video (using `vm.isVideoUri`).
- Introduced `resolveMediaPlaybackUri` helper and changed `createLoopMediaPlayer` to use it, and added lifecycle cleanup to null out `backgroundVideoUri` when stopping background or tearing down the screen.
- Mounted `HiddenBackgroundVideoPlayer` in the dialog root when `backgroundVideoUri` is set so hidden video playback starts automatically without visible UI impact.

### Testing
- Attempted `./gradlew :app:compileDebugKotlin` using the Gradle wrapper, which failed due to the container being unable to download the wrapper distribution (HTTP 403) so the wrapper-based compile could not run.
- Attempted `gradle :app:compileDebugKotlin` which failed because the environment has Java 21 while the project requests a Java 17 toolchain, so compilation could not complete in this container.
- Committed the change successfully (`git commit`) and created the PR metadata; no successful Kotlin compilation was performed in this environment due to the above constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba12aed39c832b8189247d9756badd)