### PR TITLE
Stop magic drama background playback on close

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -157,18 +157,21 @@ fun MagicDramaScreen(
             ?: availableThemes.first()
     }
 
+    fun stopBackgroundPlayback() {
+        backgroundPlayer?.stop()
+        backgroundPlayer?.release()
+        backgroundPlayer = null
+        backgroundVideoUri = null
+    }
+
     DisposableEffect(Unit) {
         onDispose {
             countdownJob?.cancel()
             pendingBranch?.cancel()
-            coroutineScope.launch {
-                backgroundPlayer?.stop()
-                backgroundPlayer?.release()
-                backgroundVideoUri = null
-                piperSpeechEngine.stop()
-                piperSpeechEngine.cleanupPreviewTempFiles()
-                piperSpeechEngine.release()
-            }
+            stopBackgroundPlayback()
+            piperSpeechEngine.stop()
+            piperSpeechEngine.cleanupPreviewTempFiles()
+            piperSpeechEngine.release()
         }
     }
     val variables = remember { mutableStateMapOf<String, String>() }
@@ -187,10 +190,7 @@ fun MagicDramaScreen(
             ?: availableThemes.first().id
         countdownJob?.cancel()
         countdownJob = null
-        backgroundPlayer?.stop()
-        backgroundPlayer?.release()
-        backgroundPlayer = null
-        backgroundVideoUri = null
+        stopBackgroundPlayback()
 
         fun jumpTo(blockId: String, queue: ArrayDeque<DramaCommand>) {
             queue.clear()
@@ -256,9 +256,7 @@ fun MagicDramaScreen(
                 is DramaCommand.ClearAllVariables -> variables.clear()
                 is DramaCommand.ClearDialogue -> messages.clear()
                 is DramaCommand.SetBackgroundMusic -> {
-                    backgroundPlayer?.stop()
-                    backgroundPlayer?.release()
-                    backgroundPlayer = null
+                    stopBackgroundPlayback()
                     val backgroundSource = resolveVariablePlaceholders(cmd.source, variables)
                     val resolvedUri = resolveMediaPlaybackUri(backgroundSource, vm)
                     if (resolvedUri != null && vm.isVideoUri(resolvedUri)) {
@@ -269,10 +267,7 @@ fun MagicDramaScreen(
                     }
                 }
                 is DramaCommand.StopBackgroundMusic -> {
-                    backgroundPlayer?.stop()
-                    backgroundPlayer?.release()
-                    backgroundPlayer = null
-                    backgroundVideoUri = null
+                    stopBackgroundPlayback()
                 }
                 is DramaCommand.StopCountdown -> {
                     countdownJob?.cancel()
@@ -402,7 +397,10 @@ fun MagicDramaScreen(
             }
         }
             IconButton(
-                onClick = onClose,
+                onClick = {
+                    stopBackgroundPlayback()
+                    onClose()
+                },
                 modifier = Modifier
                     .align(Alignment.TopEnd)
                     .padding(10.dp)


### PR DESCRIPTION
### Motivation
- The magic-drama dialog could be closed while background audio or hidden background video continued playing, so background playback must be stopped when the drama is dismissed.

### Description
- Add a helper `stopBackgroundPlayback()` in `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt` that stops and releases `backgroundPlayer` and clears `backgroundVideoUri`.
- Replace duplicated stop/release logic with calls to `stopBackgroundPlayback()` during script restarts and in `DramaCommand.SetBackgroundMusic` / `DramaCommand.StopBackgroundMusic` handling.
- Call `stopBackgroundPlayback()` from the close button handler before invoking the supplied `onClose()` callback to ensure playback is stopped immediately when the dialog is closed.

### Testing
- Attempted `./gradlew :app:compileDebugKotlin`, but the Gradle wrapper download failed due to network/proxy restrictions (`HTTP/1.1 403 Forbidden`), so a local compile could not be completed.
- Changes were committed (`Stop magic drama background playback on close`) and diffs were produced; no further automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba2aa175fc832b92c3e8bfabeb2cf5)