### PR TITLE
Unify execution completion scoring and UI sliders to 0-15

### DIFF
--- a/app/src/main/java/com/example/quotepicker/data/Repository.kt
+++ b/app/src/main/java/com/example/quotepicker/data/Repository.kt
@@ -390,15 +390,25 @@ class Repository private constructor(context: Context) {
         characterDao.update(target.copy(points = points.coerceIn(0, 30), updatedAt = System.currentTimeMillis()))
     }
 
-    suspend fun applyExecutionCompletion(characterId: Long, completionScoreSum: Int, familiarityIncrement: Int = 1) {
+    suspend fun applyExecutionCompletion(characterId: Long, completionValue: Int, belongingValue: Int) {
         db.withTransaction {
             val characters = characterDao.listAll()
             val target = characters.firstOrNull { it.id == characterId } ?: return@withTransaction
-            val nextPoints = ((target.points + completionScoreSum) / 2.0).roundToInt()
+            val normalizedCompletion = completionValue.coerceIn(0, 15)
+            val normalizedBelonging = belongingValue.coerceIn(0, 15)
+            val scoreSum = normalizedCompletion + normalizedBelonging
+            val nextPoints = ((normalizedCompletion + normalizedBelonging + (target.points / 2.0)) / 3.0)
+                .roundToInt()
+                .coerceIn(0, 30)
+            val nextFamiliarity = when {
+                scoreSum < 10 -> target.familiarity - 1
+                scoreSum > 20 -> target.familiarity + 1
+                else -> target.familiarity
+            }.coerceAtLeast(0)
             characterDao.update(
                 target.copy(
-                    points = nextPoints.coerceIn(0, 30),
-                    familiarity = (target.familiarity + familiarityIncrement).coerceAtLeast(0),
+                    points = nextPoints,
+                    familiarity = nextFamiliarity,
                     updatedAt = System.currentTimeMillis()
                 )
             )

--- a/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt
@@ -264,11 +264,11 @@ fun ExecutionScreen(
     completionTarget?.let { target ->
         CompletionDialog(
             characterName = target.characterName,
-            onConfirm = { completionScore, familiarityIncrement ->
+            onConfirm = { completionValue, belongingValue ->
                 vm.applyExecutionCompletionWithTrigger(
                     characterId = target.characterId,
-                    completionScoreSum = completionScore,
-                    familiarityIncrement = familiarityIncrement
+                    completionValue = completionValue,
+                    belongingValue = belongingValue
                 )
                 vm.removeExecutionResource(target.id)
                 completionTarget = null
@@ -343,8 +343,8 @@ private fun CompletionDialog(
     onConfirm: (Int, Int) -> Unit,
     onDismiss: () -> Unit
 ) {
-    var completionScore by remember { mutableStateOf(15f) }
-    var familiarityIncrement by remember { mutableStateOf(15f) }
+    var completionValue by remember { mutableStateOf(7f) }
+    var belongingValue by remember { mutableStateOf(7f) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -353,27 +353,28 @@ private fun CompletionDialog(
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
                 Text("$characterName 的完成情况")
                 Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                    Text("完成度 +${completionScore.toInt()}")
+                    Text("完成度 ${completionValue.toInt()} / 15")
                     Slider(
-                        value = completionScore,
-                        onValueChange = { completionScore = it },
-                        valueRange = 0f..30f,
-                        steps = 29
+                        value = completionValue,
+                        onValueChange = { completionValue = it },
+                        valueRange = 0f..15f,
+                        steps = 14
                     )
                 }
                 Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                    Text("归属度 +${familiarityIncrement.toInt()}")
+                    Text("归属度 ${belongingValue.toInt()} / 15")
                     Slider(
-                        value = familiarityIncrement,
-                        onValueChange = { familiarityIncrement = it },
-                        valueRange = 0f..30f,
-                        steps = 29
+                        value = belongingValue,
+                        onValueChange = { belongingValue = it },
+                        valueRange = 0f..15f,
+                        steps = 14
                     )
                 }
+                Text("合计 ${(completionValue + belongingValue).toInt()} / 30")
             }
         },
         confirmButton = {
-            TextButton(onClick = { onConfirm(completionScore.toInt(), familiarityIncrement.toInt()) }) { Text("完成") }
+            TextButton(onClick = { onConfirm(completionValue.toInt(), belongingValue.toInt()) }) { Text("完成") }
         },
         dismissButton = { TextButton(onClick = onDismiss) { Text("取消") } }
     )

--- a/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
+++ b/app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt
@@ -142,19 +142,20 @@ class ExecutionViewModel(app: Application) : AndroidViewModel(app) {
         repo.updateCharacterPoints(characterId, points)
     }
 
-    fun applyExecutionCompletion(characterId: Long, completionScoreSum: Int, familiarityIncrement: Int = 1) = viewModelScope.launch {
-        repo.applyExecutionCompletion(characterId, completionScoreSum, familiarityIncrement)
+    fun applyExecutionCompletion(characterId: Long, completionValue: Int, belongingValue: Int) = viewModelScope.launch {
+        repo.applyExecutionCompletion(characterId, completionValue, belongingValue)
     }
 
     fun applyExecutionCompletionWithTrigger(
         characterId: Long,
-        completionScoreSum: Int,
-        familiarityIncrement: Int
+        completionValue: Int,
+        belongingValue: Int
     ) = viewModelScope.launch {
-        repo.applyExecutionCompletion(characterId, completionScoreSum, familiarityIncrement)
+        val scoreSum = completionValue.coerceIn(0, 15) + belongingValue.coerceIn(0, 15)
+        repo.applyExecutionCompletion(characterId, completionValue, belongingValue)
         when {
-            completionScoreSum < 10 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "E")
-            completionScoreSum < 20 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "D")
+            scoreSum < 10 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "E")
+            scoreSum < 20 -> repo.addResponseRecordByCategoryPrefix(characterId, "触发类别", "D")
         }
     }
 


### PR DESCRIPTION
### Motivation
- 统一并简化“完成执行资源”相关的数值规则：把混乱的数值区间与触发判定规范化为两项 0–15 的输入、合计 0–30 的判定逻辑。 

### Description
- 修改执行完成的后端接口签名为 `applyExecutionCompletion(characterId: Long, completionValue: Int, belongingValue: Int)` 并在 `Repository` 中将传入值限制到 `0-15`、计算合计分 `scoreSum` 并据此更新角色数值与熟悉度。 
- 在 `Repository.applyExecutionCompletion` 中新增计算：对 `completionValue` 与 `belongingValue` 做 `coerceIn(0,15)`，用这两项与当前 `points` 做加权平均得到新的 `points`（并限制在 `0-30`），并按合计分数调整 `familiarity`：`scoreSum < 10` 则 `-1`，`scoreSum > 20` 则 `+1`，其它不变，且结果不低于 0。 (file: `app/src/main/java/com/example/quotepicker/data/Repository.kt`) 
- 调整 `ExecutionViewModel` 中对应方法签名与触发逻辑，`applyExecutionCompletionWithTrigger` 现在接受 `completionValue` 和 `belongingValue`，在调用后基于合计分写入触发记录：合计 `<10` 触发 `E`，合计 `<20` 触发 `D`。 (file: `app/src/main/java/com/example/quotepicker/vm/ExecutionViewModel.kt`) 
- 将完成弹窗的两个滑块从原来的 `0-30` 区间改为 `0-15` 并更新展示文案为“完成度 X / 15”、“归属度 Y / 15”并显示合计 ` / 30`，完成按钮把两个规范化值传给 VM。 (file: `app/src/main/java/com/example/quotepicker/ui/RandomScreen.kt`) 

### Testing
- Ran `git diff` to inspect changes between modified files and confirmed expected diffs. (succeeded) 
- Ran `gradle -v` to validate the local Gradle environment. (succeeded) 
- Attempted to build Kotlin with `./gradlew :app:compileDebugKotlin` and `gradle :app:compileDebugKotlin` to validate compilation, but a full successful compile result was not obtained within the environment session (Gradle wrapper download was blocked by network/proxy and local build did not complete within the session). (attempted, incomplete)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba3893fd88832b917472f7715e84b2)