### PR TITLE
Fix MagicDramaScreen suspend cleanup calls

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -164,14 +164,16 @@ fun MagicDramaScreen(
         backgroundVideoUri = null
     }
 
-    DisposableEffect(Unit) {
+    DisposableEffect(piperSpeechEngine) {
         onDispose {
             countdownJob?.cancel()
             pendingBranch?.cancel()
             stopBackgroundPlayback()
-            piperSpeechEngine.stop()
-            piperSpeechEngine.cleanupPreviewTempFiles()
-            piperSpeechEngine.release()
+            coroutineScope.launch {
+                piperSpeechEngine.stop()
+                piperSpeechEngine.cleanupPreviewTempFiles()
+                piperSpeechEngine.release()
+            }
         }
     }
     val variables = remember { mutableStateMapOf<String, String>() }


### PR DESCRIPTION
### Motivation
- Prevent calling suspend functions directly in `DisposableEffect.onDispose`, which caused Kotlin compile-time errors, and align the cleanup lifecycle with the existing `VoiceSettingsScreen` pattern.

### Description
- Change `DisposableEffect(Unit)` to `DisposableEffect(piperSpeechEngine)` and run `piperSpeechEngine.stop()`, `piperSpeechEngine.cleanupPreviewTempFiles()`, and `piperSpeechEngine.release()` inside `coroutineScope.launch { ... }` so the suspend teardown runs in a coroutine while keeping background media cleanup synchronous.

### Testing
- Attempted `./gradlew :app:compileDebugKotlin` but the Gradle wrapper download failed due to a proxy returning `HTTP/1.1 403 Forbidden`, so compilation could not be verified in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba38ea0e50832b9d81d9257dcb3cd3)