### PR TITLE
Redesign magic drama script editor layout

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -3589,7 +3589,6 @@ private fun MagicDramaScriptEditorScreen(
     var selectedBlockIndex by remember { mutableStateOf(if (blocks.isEmpty()) -1 else 0) }
     var activeDialog by remember { mutableStateOf<DramaDialogType?>(null) }
     var commandEditorState by remember { mutableStateOf<DramaCommandEditorState?>(null) }
-    var showBlockDetail by remember { mutableStateOf(false) }
     val selectedBlock = blocks.getOrNull(selectedBlockIndex)
     val scriptPreview = remember(blocks) { buildDramaEditorScript(blocks) }
     val mediaResources = remember(availableResources) {
@@ -3598,19 +3597,41 @@ private fun MagicDramaScriptEditorScreen(
         }
     }
     val blockNames = remember(blocks) { blocks.map { it.name } }
+    val commandGroups = remember {
+        listOf(
+            "结构" to listOf(
+                "添加分段" to DramaDialogType.BLOCK,
+                "角色对白" to DramaDialogType.ROLE,
+                "旁白/注意" to DramaDialogType.NARRATION,
+                "资源" to DramaDialogType.RESOURCE,
+                "按钮组" to DramaDialogType.BUTTONS
+            ),
+            "流程" to listOf(
+                "设变量" to DramaDialogType.VARIABLE,
+                "删变量" to DramaDialogType.REMOVE_VARIABLE,
+                "跳转/条件/计时" to DramaDialogType.JUMP,
+                "等待" to DramaDialogType.WAIT,
+                "氛围" to DramaDialogType.ATMOSPHERE
+            ),
+            "收尾" to listOf(
+                "背景" to DramaDialogType.BACKGROUND,
+                "停背景" to DramaDialogType.STOP_BACKGROUND,
+                "停计时" to DramaDialogType.STOP_COUNTDOWN,
+                "原始行" to DramaDialogType.RAW
+            )
+        )
+    }
 
     fun normalizeSelection() {
         if (selectedBlockIndex !in blocks.indices) {
             selectedBlockIndex = if (blocks.isEmpty()) -1 else blocks.lastIndex
         }
-        if (blocks.isEmpty()) showBlockDetail = false
     }
 
     fun addBlock(name: String) {
         if (name.isBlank()) return
         blocks = blocks + DramaEditorBlock(name = name.trim(), commands = emptyList())
         selectedBlockIndex = blocks.lastIndex
-        showBlockDetail = false
     }
 
     fun addCommand(command: DramaEditorCommand) {
@@ -3619,7 +3640,6 @@ private fun MagicDramaScriptEditorScreen(
             val block = list[index]
             list[index] = block.copy(commands = block.commands + command)
         }
-        showBlockDetail = true
     }
 
     fun updateCommand(targetIndex: Int, command: DramaEditorCommand) {
@@ -3805,18 +3825,17 @@ private fun MagicDramaScriptEditorScreen(
         topBar = {
             TopAppBar(
                 title = {
-                    Text(
-                        if (showBlockDetail && selectedBlock != null) "@${selectedBlock.name}" else "魔剧脚本编辑"
-                    )
+                    Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
+                        Text("魔剧脚本编辑")
+                        Text(
+                            text = selectedBlock?.let { "当前分段：@${it.name}" } ?: "先建立分段，再逐段添加命令。",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
                 },
                 navigationIcon = {
-                    IconButton(onClick = {
-                        if (showBlockDetail) {
-                            showBlockDetail = false
-                        } else {
-                            onBack()
-                        }
-                    }) {
+                    IconButton(onClick = onBack) {
                         Icon(Icons.Default.ArrowBack, contentDescription = "返回")
                     }
                 },
@@ -3826,206 +3845,96 @@ private fun MagicDramaScriptEditorScreen(
             )
         }
     ) { inner ->
-        Row(
+        LazyColumn(
             modifier = Modifier
                 .padding(inner)
-                .fillMaxSize()
-                .padding(horizontal = 8.dp, vertical = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                .fillMaxSize(),
+            contentPadding = PaddingValues(horizontal = 12.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp)
         ) {
-            Column(
-                modifier = Modifier
-                    .weight(1.55f)
-                    .fillMaxSize(),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                if (!showBlockDetail) {
-                    Text("左侧模块一览", style = MaterialTheme.typography.titleSmall)
-                    if (blocks.isEmpty()) {
-                        Text("暂无脚本块，请先从右侧添加分段。", style = MaterialTheme.typography.labelMedium)
-                    } else {
-                        LazyColumn(
+            item {
+                OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 12.dp, vertical = 10.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Column(
                             modifier = Modifier.weight(1f),
-                            verticalArrangement = Arrangement.spacedBy(6.dp)
+                            verticalArrangement = Arrangement.spacedBy(4.dp)
                         ) {
-                            items(blocks.size) { index ->
-                                val block = blocks[index]
-                                val isSelected = index == selectedBlockIndex
-                                OutlinedCard(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .clickable { selectedBlockIndex = index },
-                                    colors = androidx.compose.material3.CardDefaults.outlinedCardColors(
-                                        containerColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.45f) else MaterialTheme.colorScheme.surface
-                                    )
-                                ) {
-                                    Column(
-                                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
-                                        verticalArrangement = Arrangement.spacedBy(6.dp)
-                                    ) {
-                                        Text(
-                                            text = "@${block.name}",
-                                            style = MaterialTheme.typography.titleSmall,
-                                            color = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
-                                            modifier = Modifier.clickable {
-                                                selectedBlockIndex = index
-                                                showBlockDetail = true
-                                            }
-                                        )
-                                        Text(
-                                            text = block.commands.firstOrNull()?.let(::summarizeDramaEditorCommand) ?: "空分段",
-                                            style = MaterialTheme.typography.bodySmall,
-                                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                                            maxLines = 2,
-                                            overflow = TextOverflow.Ellipsis
-                                        )
-                                        Row(
-                                            modifier = Modifier.fillMaxWidth(),
-                                            horizontalArrangement = Arrangement.spacedBy(4.dp)
-                                        ) {
-                                            TextButton(
-                                                onClick = {
-                                                    if (index > 0) {
-                                                        blocks = blocks.toMutableList().also { list ->
-                                                            list.add(index - 1, list.removeAt(index))
-                                                        }
-                                                        selectedBlockIndex = index - 1
-                                                    }
-                                                },
-                                                modifier = Modifier.weight(1f),
-                                                contentPadding = PaddingValues(horizontal = 6.dp, vertical = 2.dp)
-                                            ) { Text("上移") }
-                                            TextButton(
-                                                onClick = {
-                                                    if (index < blocks.lastIndex) {
-                                                        blocks = blocks.toMutableList().also { list ->
-                                                            list.add(index + 1, list.removeAt(index))
-                                                        }
-                                                        selectedBlockIndex = index + 1
-                                                    }
-                                                },
-                                                modifier = Modifier.weight(1f),
-                                                contentPadding = PaddingValues(horizontal = 6.dp, vertical = 2.dp)
-                                            ) { Text("下移") }
-                                            TextButton(
-                                                onClick = {
-                                                    blocks = blocks.toMutableList().also { it.removeAt(index) }
-                                                    normalizeSelection()
-                                                },
-                                                modifier = Modifier.weight(1f),
-                                                contentPadding = PaddingValues(horizontal = 6.dp, vertical = 2.dp)
-                                            ) { Text("删除") }
-                                        }
-                                    }
-                                }
-                            }
+                            Text("编辑总览", style = MaterialTheme.typography.titleMedium)
+                            Text(
+                                "共 ${blocks.size} 个分段，已写入 ${blocks.sumOf { it.commands.size }} 条命令。",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
                         }
+                        TextButton(onClick = { activeDialog = DramaDialogType.BLOCK }) { Text("新建分段") }
                     }
-                } else {
-                    selectedBlock?.let { block ->
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                                Text("模块内容", style = MaterialTheme.typography.titleSmall)
-                                Text("@${block.name}", style = MaterialTheme.typography.titleSmall, color = MaterialTheme.colorScheme.primary)
-                            }
-                            TextButton(onClick = { showBlockDetail = false }, contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp)) { Text("返回模块一览") }
-                        }
-                        if (block.commands.isEmpty()) {
-                            Box(modifier = Modifier.weight(1f), contentAlignment = Alignment.Center) {
-                                Text("当前模块还没有内容，先从右侧添加指令。", style = MaterialTheme.typography.bodyMedium)
-                            }
+                }
+            }
+            item {
+                OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        Text("分段导航", style = MaterialTheme.typography.titleSmall)
+                        if (blocks.isEmpty()) {
+                            Text("暂无脚本块，请先创建一个分段。", style = MaterialTheme.typography.bodyMedium)
                         } else {
-                            LazyColumn(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.spacedBy(6.dp)
+                            FlowRow(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp)
                             ) {
-                                items(block.commands.size) { commandIndex ->
-                                    val command = block.commands[commandIndex]
-                                    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
-                                        Column(
-                                            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp),
-                                            verticalArrangement = Arrangement.spacedBy(6.dp)
-                                        ) {
+                                blocks.forEachIndexed { index, block ->
+                                    FilterChip(
+                                        selected = index == selectedBlockIndex,
+                                        onClick = {
+                                            selectedBlockIndex = index
+                                                                            },
+                                        label = {
                                             Text(
-                                                text = summarizeDramaEditorCommand(command),
-                                                style = MaterialTheme.typography.bodyMedium
+                                                "@${block.name} · ${block.commands.size}",
+                                                maxLines = 1,
+                                                overflow = TextOverflow.Ellipsis
                                             )
-                                            Row(
-                                                modifier = Modifier.fillMaxWidth(),
-                                                horizontalArrangement = Arrangement.spacedBy(4.dp)
-                                            ) {
-                                                TextButton(onClick = { if (commandIndex > 0) moveCommand(commandIndex, -1) }, modifier = Modifier.weight(1f), contentPadding = PaddingValues(horizontal = 6.dp, vertical = 2.dp)) { Text("上移") }
-                                                TextButton(onClick = { if (commandIndex < block.commands.lastIndex) moveCommand(commandIndex, 1) }, modifier = Modifier.weight(1f), contentPadding = PaddingValues(horizontal = 6.dp, vertical = 2.dp)) { Text("下移") }
-                                                TextButton(onClick = { commandEditorState = DramaCommandEditorState(commandIndex, command) }, modifier = Modifier.weight(1f), contentPadding = PaddingValues(horizontal = 6.dp, vertical = 2.dp)) { Text("编辑") }
-                                                TextButton(onClick = { removeCommand(commandIndex) }, modifier = Modifier.weight(1f), contentPadding = PaddingValues(horizontal = 6.dp, vertical = 2.dp)) { Text("删除") }
-                                            }
                                         }
-                                    }
+                                    )
                                 }
                             }
                         }
                     }
                 }
             }
-            OutlinedCard(
-                modifier = Modifier
-                    .weight(0.72f)
-                    .fillMaxSize()
-                    .widthIn(max = 188.dp)
-                    .navigationBarsPadding()
-            ) {
-                Column(
-                    modifier = Modifier.padding(8.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    Text("命令面板", style = MaterialTheme.typography.titleSmall)
-                    Text(
-                        if (selectedBlock == null) "先选择或新建分段，再插入命令。" else "当前分段：@${selectedBlock.name}",
-                        style = MaterialTheme.typography.labelSmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    val commandGroups = listOf(
-                        "基础" to listOf(
-                            "添加分段" to DramaDialogType.BLOCK,
-                            "角色对白" to DramaDialogType.ROLE,
-                            "旁白/注意" to DramaDialogType.NARRATION,
-                            "资源" to DramaDialogType.RESOURCE,
-                            "按钮组" to DramaDialogType.BUTTONS
-                        ),
-                        "变量/流程" to listOf(
-                            "设变量" to DramaDialogType.VARIABLE,
-                            "删变量" to DramaDialogType.REMOVE_VARIABLE,
-                            "跳转/条件/计时" to DramaDialogType.JUMP,
-                            "等待" to DramaDialogType.WAIT,
-                            "氛围" to DramaDialogType.ATMOSPHERE
-                        ),
-                        "背景/停止" to listOf(
-                            "背景" to DramaDialogType.BACKGROUND,
-                            "停背景" to DramaDialogType.STOP_BACKGROUND,
-                            "停计时" to DramaDialogType.STOP_COUNTDOWN,
-                            "原始行" to DramaDialogType.RAW
-                        )
-                    )
+            item {
+                OutlinedCard(modifier = Modifier.fillMaxWidth()) {
                     Column(
-                        modifier = Modifier.fillMaxWidth(),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
                     ) {
+                        Text("快捷命令", style = MaterialTheme.typography.titleSmall)
+                        Text(
+                            if (selectedBlock == null) "只有“添加分段”可用；选中分段后即可继续写内容。" else "命令会追加到 @${selectedBlock.name} 末尾。",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
                         commandGroups.forEach { (groupTitle, groupButtons) ->
-                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                            Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                                 Text(
                                     text = groupTitle,
-                                    style = MaterialTheme.typography.labelSmall,
+                                    style = MaterialTheme.typography.labelMedium,
                                     fontWeight = FontWeight.SemiBold,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
                                 FlowRow(
                                     modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                    verticalArrangement = Arrangement.spacedBy(4.dp)
+                                    horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                    verticalArrangement = Arrangement.spacedBy(6.dp)
                                 ) {
                                     groupButtons.forEach { (label, type) ->
                                         val enabled = type == DramaDialogType.BLOCK || selectedBlock != null
@@ -4038,29 +3947,158 @@ private fun MagicDramaScriptEditorScreen(
                                 }
                             }
                         }
-                    }
-                    Text(
-                        "快捷清理",
-                        style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.SemiBold,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        listOf(
-                            "c1" to DramaDialogType.CLEAR_RESOURCE,
-                            "c2" to DramaDialogType.CLEAR_VARIABLES,
-                            "c3" to DramaDialogType.CLEAR_DIALOGUE
-                        ).forEach { (label, type) ->
-                            AssistChip(
-                                onClick = { activeDialog = type },
-                                enabled = selectedBlock != null,
-                                modifier = Modifier.weight(1f),
-                                label = { Text(label, style = MaterialTheme.typography.labelSmall) }
+                        Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                            Text(
+                                "快捷清理",
+                                style = MaterialTheme.typography.labelMedium,
+                                fontWeight = FontWeight.SemiBold,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
                             )
+                            FlowRow(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                verticalArrangement = Arrangement.spacedBy(6.dp)
+                            ) {
+                                listOf(
+                                    "清资源 c1" to DramaDialogType.CLEAR_RESOURCE,
+                                    "清变量 c2" to DramaDialogType.CLEAR_VARIABLES,
+                                    "清对白 c3" to DramaDialogType.CLEAR_DIALOGUE
+                                ).forEach { (label, type) ->
+                                    AssistChip(
+                                        onClick = { activeDialog = type },
+                                        enabled = selectedBlock != null,
+                                        label = { Text(label, style = MaterialTheme.typography.labelSmall) }
+                                    )
+                                }
+                            }
                         }
+                    }
+                }
+            }
+            item {
+                OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                Text("分段内容", style = MaterialTheme.typography.titleSmall)
+                                Text(
+                                    selectedBlock?.let { "正在编辑 @${it.name}" } ?: "请选择一个分段",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            if (selectedBlock != null) {
+                                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    TextButton(
+                                        onClick = {
+                                            val index = selectedBlockIndex
+                                            if (index > 0) {
+                                                blocks = blocks.toMutableList().also { list ->
+                                                    list.add(index - 1, list.removeAt(index))
+                                                }
+                                                selectedBlockIndex = index - 1
+                                            }
+                                        }
+                                    ) { Text("分段上移") }
+                                    TextButton(
+                                        onClick = {
+                                            val index = selectedBlockIndex
+                                            if (index in 0 until blocks.lastIndex) {
+                                                blocks = blocks.toMutableList().also { list ->
+                                                    list.add(index + 1, list.removeAt(index))
+                                                }
+                                                selectedBlockIndex = index + 1
+                                            }
+                                        }
+                                    ) { Text("分段下移") }
+                                    TextButton(
+                                        onClick = {
+                                            blocks = blocks.toMutableList().also { it.removeAt(selectedBlockIndex) }
+                                            normalizeSelection()
+                                        }
+                                    ) { Text("删除分段") }
+                                }
+                            }
+                        }
+                        if (selectedBlock == null) {
+                            Text("从上方“分段导航”选择一个分段后，这里会显示可编辑的命令列表。", style = MaterialTheme.typography.bodyMedium)
+                        } else if (selectedBlock.commands.isEmpty()) {
+                            Text("当前分段还是空的，可以先从上面的快捷命令开始。", style = MaterialTheme.typography.bodyMedium)
+                        } else {
+                            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                                selectedBlock.commands.forEachIndexed { commandIndex, command ->
+                                    OutlinedCard(modifier = Modifier.fillMaxWidth()) {
+                                        Column(
+                                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+                                            verticalArrangement = Arrangement.spacedBy(8.dp)
+                                        ) {
+                                            Text(
+                                                text = "${commandIndex + 1}. ${summarizeDramaEditorCommand(command)}",
+                                                style = MaterialTheme.typography.bodyMedium
+                                            )
+                                            FlowRow(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                horizontalArrangement = Arrangement.spacedBy(6.dp),
+                                                verticalArrangement = Arrangement.spacedBy(6.dp)
+                                            ) {
+                                                AssistChip(
+                                                    onClick = { if (commandIndex > 0) moveCommand(commandIndex, -1) },
+                                                    label = { Text("上移") }
+                                                )
+                                                AssistChip(
+                                                    onClick = { if (commandIndex < selectedBlock.commands.lastIndex) moveCommand(commandIndex, 1) },
+                                                    label = { Text("下移") }
+                                                )
+                                                AssistChip(
+                                                    onClick = { commandEditorState = DramaCommandEditorState(commandIndex, command) },
+                                                    label = { Text("编辑") }
+                                                )
+                                                AssistChip(
+                                                    onClick = { removeCommand(commandIndex) },
+                                                    label = { Text("删除") }
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            item {
+                OutlinedCard(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .navigationBarsPadding()
+                ) {
+                    Column(
+                        modifier = Modifier.padding(12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                    ) {
+                        Text("脚本预览", style = MaterialTheme.typography.titleSmall)
+                        Text(
+                            "保存前可快速检查最终脚本结构，避免分段名和跳转目标写错。",
+                            style = MaterialTheme.typography.bodySmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                        OutlinedTextField(
+                            value = scriptPreview,
+                            onValueChange = {},
+                            modifier = Modifier.fillMaxWidth(),
+                            readOnly = true,
+                            minLines = 8,
+                            maxLines = 14,
+                            textStyle = MaterialTheme.typography.bodySmall,
+                            label = { Text("生成后的脚本") }
+                        )
                     }
                 }
             }


### PR DESCRIPTION
### Motivation
- 现在的魔剧脚本编辑页信息拥挤且难以操作，需要一个更清晰、可扫描且易用的编辑布局以提升脚本制作效率和可读性。 
- 优化分段管理与命令添加的流程，让用户能更快地建立分段、切换并编辑命令。 

### Description
- 将原来的左右挤压式编辑区改为纵向卡片式堆叠布局（使用 `LazyColumn`），按顺序展示：编辑总览、分段导航、快捷命令、分段内容与脚本预览，改善信息层级与可视焦点。 
- 在 `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt` 中新增 `commandGroups`，并把命令面板改为按组显示（"结构" / "流程" / "收尾" / "快捷清理"），命令入口统一采用 `AssistChip`/`FilterChip`/`FlowRow` 以提升扫描效率。 
- 精简了顶部 `TopAppBar`（增加当前分段的副标题提示）并简化返回逻辑，移除了旧的 `showBlockDetail` 状态，统一通过选中 Chip 来切换分段与展示内容。 
- 重构了分段内容区与命令项呈现：命令列表改为卡片与操作 Chip（上移/下移/编辑/删除），并保留只读的脚本预览框以便保存前检查生成脚本。 

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin`, 编译在此环境中失败，原因是 Gradle wrapper 在下载 Gradle 8.10 时受网络/代理限制返回 `HTTP/1.1 403 Forbidden`，因此无法在本环境完成编译验证。 
- 已在本地仓库提交变更（commit）并生成差异用于审阅，代码变更在 `git diff` 中可见。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bba0b8653c832baeb96e9878b88af5)