### PR TITLE
Tighten drama command dialogs and improve resource preview

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -31,6 +32,8 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -48,7 +51,6 @@ import androidx.compose.material.icons.filled.MusicNote
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Videocam
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.AssistChip
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
@@ -3573,12 +3575,20 @@ private sealed interface DramaEditorCommand {
 }
 
 private enum class DramaDialogType {
-    BLOCK, ROLE, NARRATION, RESOURCE, VARIABLE, REMOVE_VARIABLE, JUMP, WAIT, BUTTONS, ATMOSPHERE, CLEAR_RESOURCE, CLEAR_VARIABLES, CLEAR_DIALOGUE, BACKGROUND, STOP_BACKGROUND, STOP_COUNTDOWN, RAW
+    BLOCK, ROLE, NARRATION, RESOURCE, VARIABLE, REMOVE_VARIABLE, JUMP, CONDITION, COUNTDOWN, WAIT, BUTTONS, ATMOSPHERE, CLEAR_RESOURCE, CLEAR_VARIABLES, CLEAR_DIALOGUE, BACKGROUND, STOP_BACKGROUND, STOP_COUNTDOWN, RAW
 }
 
 private data class DramaCommandEditorState(
     val index: Int? = null,
     val initialCommand: DramaEditorCommand? = null
+)
+
+private data class DramaResourcePreviewItem(
+    val key: String,
+    val label: String,
+    val title: String,
+    val type: ResourceType,
+    val path: String? = null
 )
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -3616,7 +3626,9 @@ private fun MagicDramaScriptEditorScreen(
             "流程" to listOf(
                 "设变量" to DramaDialogType.VARIABLE,
                 "删变量" to DramaDialogType.REMOVE_VARIABLE,
-                "跳转/条件/计时" to DramaDialogType.JUMP,
+                "跳转" to DramaDialogType.JUMP,
+                "条件" to DramaDialogType.CONDITION,
+                "计时" to DramaDialogType.COUNTDOWN,
                 "等待" to DramaDialogType.WAIT,
                 "停背" to DramaDialogType.STOP_BACKGROUND,
                 "停计" to DramaDialogType.STOP_COUNTDOWN,
@@ -3726,14 +3738,30 @@ private fun MagicDramaScriptEditorScreen(
             )
             DramaDialogType.JUMP -> DramaJumpDialog(
                 blockNames = blockNames,
-                onConfirm = { mode, primary, secondary ->
-                    val command = when (mode) {
-                        "jump" -> DramaEditorCommand.Jump(primary.trim())
-                        "condition" -> DramaEditorCommand.Conditional(primary.trim(), secondary.trim())
-                        "countdown" -> DramaEditorCommand.Countdown(primary.trim().toIntOrNull() ?: 0, secondary.trim())
-                        else -> DramaEditorCommand.Wait(primary.trim().toIntOrNull() ?: 0)
-                    }
-                    addCommand(command)
+                initialMode = "jump",
+                title = "添加跳转",
+                onConfirm = { _, primary, _ ->
+                    addCommand(DramaEditorCommand.Jump(primary.trim()))
+                    activeDialog = null
+                },
+                onDismiss = { activeDialog = null }
+            )
+            DramaDialogType.CONDITION -> DramaJumpDialog(
+                blockNames = blockNames,
+                initialMode = "condition",
+                title = "添加条件",
+                onConfirm = { _, primary, secondary ->
+                    addCommand(DramaEditorCommand.Conditional(primary.trim(), secondary.trim()))
+                    activeDialog = null
+                },
+                onDismiss = { activeDialog = null }
+            )
+            DramaDialogType.COUNTDOWN -> DramaJumpDialog(
+                blockNames = blockNames,
+                initialMode = "countdown",
+                title = "添加计时",
+                onConfirm = { _, primary, secondary ->
+                    addCommand(DramaEditorCommand.Countdown(primary.trim().toIntOrNull() ?: 0, secondary.trim()))
                     activeDialog = null
                 },
                 onDismiss = { activeDialog = null }
@@ -4199,7 +4227,7 @@ private fun MagicDramaScriptEditorScreen(
 
 private val dramaDialogModifier = Modifier
     .fillMaxWidth()
-    .widthIn(max = 420.dp)
+    .widthIn(max = 360.dp)
 
 @Composable
 private fun DramaCommandEditDialog(
@@ -4425,14 +4453,26 @@ private fun DramaRoleLineDialog(
                     )
                     FlowRow(
                         modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(4.dp),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                        horizontalArrangement = Arrangement.spacedBy(3.dp),
+                        verticalArrangement = Arrangement.spacedBy(3.dp)
                     ) {
                         roleOptions.forEach { option ->
                             FilterChip(
                                 selected = role == option,
                                 onClick = { role = option },
-                                label = { Text(option, maxLines = 1, overflow = TextOverflow.Ellipsis, style = MaterialTheme.typography.labelSmall) }
+                                label = {
+                                    Text(
+                                        option,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        style = MaterialTheme.typography.labelSmall
+                                    )
+                                },
+                                modifier = Modifier.height(28.dp),
+                                colors = FilterChipDefaults.filterChipColors(
+                                    selectedContainerColor = MaterialTheme.colorScheme.secondaryContainer,
+                                    selectedLabelColor = MaterialTheme.colorScheme.onSecondaryContainer
+                                )
                             )
                         }
                     }
@@ -4476,43 +4516,45 @@ private fun DramaNarrationDialog(
 private fun DramaResourceDialog(
     resourceOptions: List<ResourceWithTagsCharacters>,
     vm: ResourceViewModel,
-    initialSource: String = resourceOptions.firstOrNull()?.resource?.resourceCode
-        ?: resourceOptions.firstOrNull()?.resource?.title.orEmpty(),
+    initialSource: String = "",
     title: String = "添加资源",
     onConfirm: (String) -> Unit,
     onDismiss: () -> Unit
 ) {
     var source by remember(initialSource, resourceOptions) { mutableStateOf(initialSource) }
-    val query = source.trim()
-    val filteredResources = remember(query, resourceOptions) {
+    var searchQuery by remember(initialSource) { mutableStateOf("") }
+    val selectedTokens = remember(source) { parseDramaResourceTokens(source) }
+    val selectedResources = remember(selectedTokens, resourceOptions) {
+        selectedTokens.mapNotNull { token ->
+            resourceOptions.firstOrNull { item ->
+                item.resource.resourceCode.equals(token, ignoreCase = true) ||
+                    item.resource.title.equals(token, ignoreCase = true)
+            }
+        }
+    }
+    val previewItems = remember(selectedResources) {
+        selectedResources.flatMap { item -> buildDramaResourcePreviewItems(item) }
+    }
+    val effectiveQuery = searchQuery.trim().ifBlank { selectedTokens.lastOrNull().orEmpty() }
+    val filteredResources = remember(effectiveQuery, resourceOptions) {
         resourceOptions.filter { item ->
             val resource = item.resource
-            query.isBlank() || listOfNotNull(resource.title, resource.resourceCode)
-                .any { it.contains(query, ignoreCase = true) }
+            effectiveQuery.isBlank() || listOfNotNull(resource.title, resource.resourceCode)
+                .any { it.contains(effectiveQuery, ignoreCase = true) }
         }.sortedBy { it.resource.title }
     }
-    var selectedResourceId by remember(resourceOptions, initialSource) {
-        mutableStateOf(
-            resourceOptions.firstOrNull { item ->
-                item.resource.resourceCode == initialSource || item.resource.title == initialSource
-            }?.resource?.id
-        )
-    }
-    val selectedResource = filteredResources.firstOrNull { it.resource.id == selectedResourceId }
-        ?: resourceOptions.firstOrNull { it.resource.id == selectedResourceId }
-    val previewBitmap by produceState<android.graphics.Bitmap?>(initialValue = null, selectedResource?.resource?.id) {
+    val previewPagerState = rememberPagerState(pageCount = { previewItems.size.coerceAtLeast(1) })
+    val previewBitmaps by produceState<Map<String, android.graphics.Bitmap?>>(initialValue = emptyMap(), previewItems.map { it.key }) {
         value = withContext(Dispatchers.IO) {
-            val resource = selectedResource?.resource ?: return@withContext null
-            when (resource.type) {
-                ResourceType.IMAGE -> {
-                    val image = parseImageItems(resource.contentUriOrPath, resource.quoteImageBase64).firstOrNull { !it.path.isNullOrBlank() }
-                    image?.path?.let { vm.decodeUriToBitmap(Uri.parse(it)) }
+            previewItems.associate { item ->
+                val bitmap = when (item.type) {
+                    ResourceType.IMAGE -> item.path
+                        ?.let { vm.decodeUriToBitmap(Uri.parse(it)) }
+                    ResourceType.VIDEO -> item.path
+                        ?.let { vm.decodeVideoFrame(Uri.parse(it)) }
+                    else -> null
                 }
-                ResourceType.VIDEO -> {
-                    val video = parseVideoItems(resource.contentUriOrPath).firstOrNull { !it.path.isNullOrBlank() }
-                    video?.path?.let { vm.decodeVideoFrame(Uri.parse(it)) }
-                }
-                else -> null
+                item.key to bitmap
             }
         }
     }
@@ -4524,41 +4566,67 @@ private fun DramaResourceDialog(
             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                 OutlinedTextField(
                     value = source,
-                    onValueChange = {
-                        source = it
-                        selectedResourceId = null
-                    },
-                    label = { Text("输入资源名 / 资源ID") },
+                    onValueChange = { source = it },
+                    label = { Text("命令值（可填多个ID）") },
+                    supportingText = { Text("多个资源请用英文/中文逗号分隔。") },
                     modifier = Modifier.fillMaxWidth(),
                     singleLine = true
                 )
-                if (selectedResource != null && (selectedResource.resource.type == ResourceType.IMAGE || selectedResource.resource.type == ResourceType.VIDEO)) {
+                OutlinedTextField(
+                    value = searchQuery,
+                    onValueChange = { searchQuery = it },
+                    label = { Text("搜索预览（不写入命令）") },
+                    modifier = Modifier.fillMaxWidth(),
+                    singleLine = true
+                )
+                if (previewItems.isNotEmpty()) {
+                    val previewPage = minOf(previewPagerState.currentPage, previewItems.lastIndex)
                     OutlinedCard(modifier = Modifier.fillMaxWidth()) {
-                        Row(
-                            modifier = Modifier.padding(6.dp),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                        Column(
+                            modifier = Modifier.padding(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp)
                         ) {
-                            if (previewBitmap != null) {
-                                Image(
-                                    bitmap = previewBitmap!!.asImageBitmap(),
-                                    contentDescription = "资源缩略图",
-                                    modifier = Modifier
-                                        .size(64.dp)
-                                        .clip(MaterialTheme.shapes.small)
-                                )
-                            } else {
-                                Box(modifier = Modifier.size(64.dp), contentAlignment = Alignment.Center) {
-                                    Icon(
-                                        imageVector = if (selectedResource.resource.type == ResourceType.IMAGE) Icons.Default.Image else Icons.Default.Videocam,
-                                        contentDescription = null
+                            Text(
+                                "已选预览 ${previewItems.size} 个",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                            HorizontalPager(
+                                state = previewPagerState,
+                                modifier = Modifier.fillMaxWidth()
+                            ) { page ->
+                                val previewItem = previewItems[page]
+                                val bitmap = previewBitmaps[previewItem.key]
+                                Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                                    Box(
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .aspectRatio(1.6f)
+                                            .clip(MaterialTheme.shapes.small),
+                                        contentAlignment = Alignment.Center
+                                    ) {
+                                        when {
+                                            bitmap != null -> Image(
+                                                bitmap = bitmap.asImageBitmap(),
+                                                contentDescription = "资源缩略图",
+                                                modifier = Modifier.fillMaxSize()
+                                            )
+                                            previewItem.type == ResourceType.IMAGE -> Icon(Icons.Default.Image, contentDescription = null)
+                                            previewItem.type == ResourceType.VIDEO -> Icon(Icons.Default.Videocam, contentDescription = null)
+                                            else -> Icon(Icons.Default.MusicNote, contentDescription = null)
+                                        }
+                                    }
+                                    Text(
+                                        "${previewItem.label} · ${previewItem.title}",
+                                        style = MaterialTheme.typography.labelMedium,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
                                     )
                                 }
                             }
-                            Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
-                                Text(selectedResource.resource.title, style = MaterialTheme.typography.bodyMedium, maxLines = 1, overflow = TextOverflow.Ellipsis)
+                            if (previewItems.size > 1) {
                                 Text(
-                                    selectedResource.resource.resourceCode ?: "ID ${selectedResource.resource.id}",
+                                    "${previewPage + 1}/${previewItems.size} · ${previewItems[previewPage].label}",
                                     style = MaterialTheme.typography.labelSmall,
                                     color = MaterialTheme.colorScheme.primary
                                 )
@@ -4580,13 +4648,12 @@ private fun DramaResourceDialog(
                     items(filteredResources.take(30), key = { it.resource.id }) { item ->
                         val resource = item.resource
                         val displayId = resource.resourceCode ?: "ID ${resource.id}"
-                        val selected = selectedResourceId == resource.id
+                        val selected = selectedResources.any { it.resource.id == resource.id }
                         OutlinedCard(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .clickable {
-                                    selectedResourceId = resource.id
-                                    source = resource.resourceCode ?: resource.title
+                                    source = appendDramaResourceToken(source, resource.resourceCode ?: resource.title)
                                 }
                         ) {
                             Column(modifier = Modifier.padding(horizontal = 8.dp, vertical = 6.dp)) {
@@ -4639,9 +4706,9 @@ private fun DramaVariableDialog(
 private fun DramaJumpDialog(
     blockNames: List<String>,
     initialMode: String = "jump",
-    initialPrimary: String = blockNames.firstOrNull().orEmpty(),
-    initialSecondary: String = blockNames.firstOrNull().orEmpty(),
-    title: String = "跳转/计时",
+    initialPrimary: String = "",
+    initialSecondary: String = "",
+    title: String = "添加跳转",
     onConfirm: (String, String, String) -> Unit,
     onDismiss: () -> Unit
 ) {
@@ -4654,7 +4721,7 @@ private fun DramaJumpDialog(
         title = { Text(title) },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
-                if (initialMode != "wait") {
+                if (initialMode !in listOf("jump", "condition", "countdown", "wait")) {
                     FlowRow(horizontalArrangement = Arrangement.spacedBy(4.dp), verticalArrangement = Arrangement.spacedBy(4.dp)) {
                         listOf("jump" to "跳转", "condition" to "条件", "countdown" to "计时").forEach { (value, label) ->
                             FilterChip(selected = mode == value, onClick = { mode = value }, label = { Text(label) })
@@ -4662,15 +4729,15 @@ private fun DramaJumpDialog(
                     }
                 }
                 if (mode == "jump") {
-                    OutlinedTextField(value = primary, onValueChange = { primary = it }, label = { Text("目标分段") }, modifier = Modifier.fillMaxWidth())
+                    OutlinedTextField(value = primary, onValueChange = { primary = it }, label = { Text("跳转目标分段") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
                 } else if (mode == "condition") {
-                    OutlinedTextField(value = primary, onValueChange = { primary = it }, label = { Text("条件表达式") }, modifier = Modifier.fillMaxWidth())
-                    OutlinedTextField(value = secondary, onValueChange = { secondary = it }, label = { Text("目标分段") }, modifier = Modifier.fillMaxWidth())
+                    OutlinedTextField(value = primary, onValueChange = { primary = it }, label = { Text("条件表达式") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
+                    OutlinedTextField(value = secondary, onValueChange = { secondary = it }, label = { Text("条件成立后跳转") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
                 } else if (mode == "countdown") {
-                    OutlinedTextField(value = primary, onValueChange = { primary = it }, label = { Text("秒数") }, modifier = Modifier.fillMaxWidth())
-                    OutlinedTextField(value = secondary, onValueChange = { secondary = it }, label = { Text("超时跳转") }, modifier = Modifier.fillMaxWidth())
+                    OutlinedTextField(value = primary, onValueChange = { primary = it }, label = { Text("计时秒数") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
+                    OutlinedTextField(value = secondary, onValueChange = { secondary = it }, label = { Text("超时后跳转") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
                 } else {
-                    OutlinedTextField(value = primary, onValueChange = { primary = it }, label = { Text("等待秒数") }, modifier = Modifier.fillMaxWidth())
+                    OutlinedTextField(value = primary, onValueChange = { primary = it }, label = { Text("等待秒数") }, modifier = Modifier.fillMaxWidth(), singleLine = true)
                 }
                 if (blockNames.isNotEmpty()) {
                     Text("可用分段：${blockNames.joinToString("、")}", style = MaterialTheme.typography.labelSmall)
@@ -4703,7 +4770,7 @@ private fun DramaButtonsDialog(
             repeat(optionCount) { index ->
                 add(
                     initialOptions.getOrNull(index)
-                        ?: ("" to blockNames.getOrNull(index).orEmpty())
+                        ?: ("" to "")
                 )
             }
         }
@@ -4836,6 +4903,66 @@ private fun parseDramaEditorCommands(lines: List<String>): List<DramaEditorComma
         index++
     }
     return commands
+}
+
+private fun parseDramaResourceTokens(raw: String): List<String> {
+    return raw
+        .split(',', '，', '\n')
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+}
+
+private fun appendDramaResourceToken(raw: String, token: String): String {
+    val items = parseDramaResourceTokens(raw).toMutableList()
+    if (items.none { it.equals(token, ignoreCase = true) }) items += token
+    return items.joinToString(",")
+}
+
+private fun buildDramaResourcePreviewItems(item: ResourceWithTagsCharacters): List<DramaResourcePreviewItem> {
+    val resource = item.resource
+    val baseLabel = resource.resourceCode ?: "ID ${resource.id}"
+    fun buildLabel(index: Int, total: Int): String {
+        return if (total <= 1) baseLabel else "$baseLabel.${index + 1}"
+    }
+    return when (resource.type) {
+        ResourceType.IMAGE -> {
+            val images = parseImageItems(resource.contentUriOrPath, resource.quoteImageBase64)
+            images.mapIndexed { index, image ->
+                DramaResourcePreviewItem(
+                    key = "${resource.id}-img-$index",
+                    label = buildLabel(index, images.size),
+                    title = resource.title,
+                    type = ResourceType.IMAGE,
+                    path = image.path
+                )
+            }
+        }
+        ResourceType.VIDEO -> {
+            val videos = parseVideoItems(resource.contentUriOrPath)
+            videos.mapIndexed { index, video ->
+                DramaResourcePreviewItem(
+                    key = "${resource.id}-video-$index",
+                    label = buildLabel(index, videos.size),
+                    title = resource.title,
+                    type = ResourceType.VIDEO,
+                    path = video.path
+                )
+            }
+        }
+        ResourceType.SOUND -> {
+            val sounds = parseSoundItems(resource.contentUriOrPath)
+            sounds.mapIndexed { index, sound ->
+                DramaResourcePreviewItem(
+                    key = "${resource.id}-sound-$index",
+                    label = buildLabel(index, sounds.size),
+                    title = resource.title,
+                    type = ResourceType.SOUND,
+                    path = sound.path
+                )
+            }
+        }
+        else -> emptyList()
+    }
 }
 
 private fun buildDramaEditorScript(blocks: List<DramaEditorBlock>): String {


### PR DESCRIPTION
### Motivation
- Make the script-editor dialogs more compact and clearer so shortcut buttons/dialogs are tighter and more purpose-specific. 
- Split combined `跳转/条件/计时` into separate actions to reduce confusion and simplify each dialog. 
- Fix resource/background selection UX so typing multiple IDs still lets users preview selected files and browse all file entries. 

### Description
- Reduce dialog max width by changing `dramaDialogModifier` to `.widthIn(max = 360.dp)` and tighten role-chip spacing in `DramaRoleLineDialog` (`Arrangement.spacedBy(3.dp)` and chip height `28.dp`). (file: `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt`)
- Split the combined jump dialog into three dialog types by adding `DramaDialogType.CONDITION` and `DramaDialogType.COUNTDOWN` and updating `commandGroups` and dialog dispatch to open separate `DramaJumpDialog` instances with appropriate `initialMode`/titles. (file: `ResourceScreen.kt`)
- Overhaul `DramaResourceDialog`/background flow: make `initialSource` empty, add two inputs (`命令值（可填多个ID）` for real command value and `搜索预览（不写入命令）` for preview-only search), parse comma-separated tokens, and maintain selected tokens separately from the search query. (file: `ResourceScreen.kt`)
- Add multi-file preview support: expand a single resource into multiple `DramaResourcePreviewItem` entries (labels like `ID` or `ID.1`, `ID.2`), decode bitmaps for each preview item and present them with a `HorizontalPager` for horizontal swipe, showing current page and label. (file: `ResourceScreen.kt`)
- Add helper functions `parseDramaResourceTokens`, `appendDramaResourceToken`, and `buildDramaResourcePreviewItems` to parse input tokens, append new tokens without duplicates, and expand resources into preview items. (file: `ResourceScreen.kt`)
- Adjust `DramaJumpDialog` field labels and defaults to be single-line and clearer (e.g. `跳转目标分段`, `条件成立后跳转`, `计时秒数`). (file: `ResourceScreen.kt`)
- Make `DramaButtonsDialog` stop pre-filling button target with block name by default (use empty string). (file: `ResourceScreen.kt`)

### Testing
- Attempted `./gradlew :app:compileDebugKotlin`, which failed because the Gradle wrapper download was blocked by the environment proxy (`HTTP/1.1 403 Forbidden`).
- Attempted `JAVA_HOME=/root/.local/share/mise/installs/java/17.0.2 PATH=/root/... gradle :app:compileDebugKotlin`, which failed due to missing Android SDK (`SDK location not found`).
- All code edits were compiled locally by static tools (search/replace/format) and changes were committed to Git; no successful APK/build could be produced in the current environment due to the above external constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bbbe04fbf4832bbc2435104799d34f)