### PR TITLE
Add webview-based gate screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />

--- a/app/src/main/java/com/example/quotepicker/ui/GateScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/GateScreen.kt
@@ -1,51 +1,73 @@
 package com.example.quotepicker.ui
 
-import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.tween
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
+import android.annotation.SuppressLint
+import android.graphics.Bitmap
+import android.view.ViewGroup
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.compose.foundation.background
-import androidx.compose.foundation.gestures.awaitEachGesture
-import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.runtime.*
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Language
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Divider
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.drawscope.Stroke
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
-import kotlin.math.roundToInt
 
 enum class Corner { LEFT_TOP, RIGHT_TOP, LEFT_BOTTOM, RIGHT_BOTTOM, NONE }
 
-private fun classifyCorner(p: Offset, size: IntSize): Corner {
-    val quarterW = size.width * 0.25f
-    val quarterH = size.height * 0.25f
+data class GateWebItem(
+    val name: String,
+    val url: String
+)
 
-    return when {
-        p.x <= quarterW && p.y <= quarterH -> Corner.LEFT_TOP
-        p.x >= size.width - quarterW && p.y <= quarterH -> Corner.RIGHT_TOP
-        p.x <= quarterW && p.y >= size.height - quarterH -> Corner.LEFT_BOTTOM
-        p.x >= size.width - quarterW && p.y >= size.height - quarterH -> Corner.RIGHT_BOTTOM
-        else -> Corner.NONE
+private fun normalizeUrl(rawUrl: String): String {
+    val trimmed = rawUrl.trim()
+    if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) {
+        return trimmed
     }
+    return "https://$trimmed"
 }
 
 @Composable
@@ -53,61 +75,20 @@ fun GateScreen(onPassed: () -> Unit) {
     var step by remember { mutableStateOf(0) }
     var count by remember { mutableStateOf(0) }
     var startTime by remember { mutableStateOf<Long?>(null) }
-    var touchPosition by remember { mutableStateOf<Offset?>(null) }
-    val opacity = remember { Animatable(0f) }
-    val scope = rememberCoroutineScope()
-    val infiniteTransition = rememberInfiniteTransition(label = "magicCircle")
-    val rotation by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = 360f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(6000),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "magicCircleRotation"
-    )
-    val counterRotation by infiniteTransition.animateFloat(
-        initialValue = 0f,
-        targetValue = -360f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(4200),
-            repeatMode = RepeatMode.Restart
-        ),
-        label = "magicCircleCounterRotation"
-    )
-    val pulse by infiniteTransition.animateFloat(
-        initialValue = 0.92f,
-        targetValue = 1.08f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1400),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "magicCirclePulse"
-    )
-    val glowAlpha by infiniteTransition.animateFloat(
-        initialValue = 0.15f,
-        targetValue = 0.45f,
-        animationSpec = infiniteRepeatable(
-            animation = tween(1600),
-            repeatMode = RepeatMode.Reverse
-        ),
-        label = "magicCircleGlow"
-    )
-    val density = LocalDensity.current
-    val circleSize = 156.dp
-    val innerSize = 110.dp
-    val outerSize = 230.dp
-    val circleSizePx = with(density) { circleSize.toPx() }
-    val outerSizePx = with(density) { outerSize.toPx() }
+    var showAddDialog by remember { mutableStateOf(false) }
+    val webItems = remember {
+        mutableStateListOf(
+            GateWebItem(name = "Notion 表单", url = "https://www.notion.so")
+        )
+    }
+    var selectedIndex by remember { mutableStateOf(0) }
 
-    // 解锁目标顺序：右上3次 → 左上1次 → 左下2次
     val targets = listOf(
         Corner.RIGHT_TOP to 3,
         Corner.LEFT_TOP to 1,
         Corner.LEFT_BOTTOM to 2
     )
 
-    // 超时10秒自动重置
     LaunchedEffect(startTime) {
         while (true) {
             delay(500)
@@ -120,111 +101,293 @@ fun GateScreen(onPassed: () -> Unit) {
         }
     }
 
+    fun handleCornerTap(corner: Corner) {
+        if (corner == Corner.NONE || step >= targets.size) return
+        if (startTime == null) startTime = System.currentTimeMillis()
+        val (expectCorner, expectTimes) = targets[step]
+        if (corner == expectCorner) {
+            count += 1
+            if (count >= expectTimes) {
+                step += 1
+                count = 0
+                if (step >= targets.size) {
+                    onPassed()
+                }
+            }
+        } else {
+            step = 0
+            count = 0
+            startTime = null
+        }
+    }
+
+    Scaffold(
+        floatingActionButton = {
+            FloatingActionButton(onClick = { showAddDialog = true }) {
+                Icon(Icons.Default.Add, contentDescription = "添加网页")
+            }
+        }
+    ) { innerPadding ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background)
+                .padding(innerPadding)
+        ) {
+            Row(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(12.dp),
+                horizontalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                Card(
+                    modifier = Modifier
+                        .width(220.dp)
+                        .fillMaxSize(),
+                    colors = CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.45f)
+                    )
+                ) {
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        Text(
+                            text = "网页列表",
+                            style = MaterialTheme.typography.titleMedium,
+                            fontWeight = FontWeight.SemiBold,
+                            modifier = Modifier.padding(16.dp)
+                        )
+                        Divider()
+                        LazyColumn(modifier = Modifier.fillMaxSize()) {
+                            itemsIndexed(webItems) { index, item ->
+                                val selected = index == selectedIndex
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .clickable { selectedIndex = index }
+                                        .background(
+                                            if (selected) MaterialTheme.colorScheme.primary.copy(alpha = 0.12f)
+                                            else Color.Transparent
+                                        )
+                                        .padding(horizontal = 16.dp, vertical = 14.dp)
+                                ) {
+                                    Text(
+                                        text = item.name,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                        fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Normal,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                    Spacer(modifier = Modifier.height(4.dp))
+                                    Text(
+                                        text = item.url,
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        maxLines = 2,
+                                        overflow = TextOverflow.Ellipsis
+                                    )
+                                }
+                                Divider()
+                            }
+                        }
+                    }
+                }
+
+                Card(
+                    modifier = Modifier.fillMaxSize(),
+                    shape = RoundedCornerShape(20.dp)
+                ) {
+                    Column(modifier = Modifier.fillMaxSize()) {
+                        val selectedItem = webItems.getOrNull(selectedIndex)
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 14.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            Icon(Icons.Default.Language, contentDescription = null)
+                            Column(modifier = Modifier.weight(1f)) {
+                                Text(
+                                    text = selectedItem?.name ?: "未选择网页",
+                                    style = MaterialTheme.typography.titleMedium,
+                                    fontWeight = FontWeight.SemiBold,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                                Text(
+                                    text = selectedItem?.url ?: "点击右下角 + 添加网页",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis
+                                )
+                            }
+                        }
+                        Divider()
+                        Box(modifier = Modifier.fillMaxSize()) {
+                            if (selectedItem == null) {
+                                EmptyPreview()
+                            } else {
+                                GateWebPreview(url = selectedItem.url)
+                            }
+                        }
+                    }
+                }
+            }
+
+            CornerHotspot(
+                modifier = Modifier.align(Alignment.TopStart),
+                onTap = { handleCornerTap(Corner.LEFT_TOP) }
+            )
+            CornerHotspot(
+                modifier = Modifier.align(Alignment.TopEnd),
+                onTap = { handleCornerTap(Corner.RIGHT_TOP) }
+            )
+            CornerHotspot(
+                modifier = Modifier.align(Alignment.BottomStart),
+                onTap = { handleCornerTap(Corner.LEFT_BOTTOM) }
+            )
+            CornerHotspot(
+                modifier = Modifier.align(Alignment.BottomEnd),
+                onTap = { handleCornerTap(Corner.RIGHT_BOTTOM) }
+            )
+        }
+    }
+
+    if (showAddDialog) {
+        var name by remember { mutableStateOf("") }
+        var url by remember { mutableStateOf("") }
+        AlertDialog(
+            onDismissRequest = { showAddDialog = false },
+            title = { Text("添加网页") },
+            text = {
+                Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = { name = it },
+                        label = { Text("名称") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                    OutlinedTextField(
+                        value = url,
+                        onValueChange = { url = it },
+                        label = { Text("URL") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val normalizedUrl = normalizeUrl(url)
+                        webItems.add(
+                            GateWebItem(
+                                name = name.trim().ifBlank { normalizedUrl },
+                                url = normalizedUrl
+                            )
+                        )
+                        selectedIndex = webItems.lastIndex
+                        showAddDialog = false
+                    },
+                    enabled = url.trim().isNotBlank()
+                ) {
+                    Text("追加")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAddDialog = false }) {
+                    Text("取消")
+                }
+            }
+        )
+    }
+}
+
+@Composable
+private fun EmptyPreview() {
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(Color.White)
-            .pointerInput(Unit) {
-                awaitEachGesture {
-                    val down = awaitFirstDown()
-                    touchPosition = down.position
-                    scope.launch {
-                        opacity.snapTo(1f)
-                    }
-                    var pointerId = down.id
-                    var upPosition = down.position
-                    while (true) {
-                        val event = awaitPointerEvent()
-                        val change = event.changes.firstOrNull { it.id == pointerId }
-                        if (change == null) break
-                        if (change.pressed) {
-                            touchPosition = change.position
-                            upPosition = change.position
-                        } else {
-                            upPosition = change.position
-                            break
-                        }
-                    }
-                    val corner = classifyCorner(upPosition, this.size)
-                    if (corner != Corner.NONE) {
-                        if (startTime == null) startTime = System.currentTimeMillis()
-                        val (expectCorner, expectTimes) = targets[step]
-                        if (corner == expectCorner) {
-                            count += 1
-                            if (count >= expectTimes) {
-                                step += 1
-                                count = 0
-                                if (step >= targets.size) {
-                                    onPassed()
-                                }
-                            }
-                        } else {
-                            step = 0
-                            count = 0
-                            startTime = null
-                        }
-                    }
-                    scope.launch {
-                        opacity.animateTo(0f, tween(200))
-                    }
-                    touchPosition = null
-                }
-            }
+            .background(MaterialTheme.colorScheme.surface),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "点击右下角 + 添加网页，\n再从左侧列表选择后即可预览。",
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun CornerHotspot(
+    modifier: Modifier = Modifier,
+    onTap: () -> Unit
+) {
+    Box(
+        modifier = modifier
+            .size(72.dp)
+            .clickable(onClick = onTap)
     )
-    touchPosition?.let { pos ->
-        Box(
-            modifier = Modifier
-                .offset {
-                    IntOffset(
-                        (pos.x - outerSizePx / 2f).roundToInt(),
-                        (pos.y - outerSizePx / 2f).roundToInt()
+}
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+private fun GateWebPreview(url: String) {
+    val context = LocalContext.current
+    var loading by remember(url) { mutableStateOf(true) }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        AndroidView(
+            factory = {
+                WebView(context).apply {
+                    layoutParams = ViewGroup.LayoutParams(
+                        ViewGroup.LayoutParams.MATCH_PARENT,
+                        ViewGroup.LayoutParams.MATCH_PARENT
                     )
+                    settings.javaScriptEnabled = true
+                    settings.domStorageEnabled = true
+                    settings.loadsImagesAutomatically = true
+                    settings.allowFileAccess = true
+                    settings.useWideViewPort = true
+                    settings.loadWithOverviewMode = true
+                    settings.mediaPlaybackRequiresUserGesture = false
+                    webChromeClient = WebChromeClient()
+                    webViewClient = object : WebViewClient() {
+                        override fun onPageStarted(view: WebView?, url: String?, favicon: Bitmap?) {
+                            loading = true
+                        }
+
+                        override fun onPageFinished(view: WebView?, url: String?) {
+                            loading = false
+                        }
+
+                        override fun shouldOverrideUrlLoading(
+                            view: WebView?,
+                            request: WebResourceRequest?
+                        ): Boolean = false
+                    }
+                    loadUrl(url)
                 }
-                .size(outerSize)
-                .graphicsLayer(alpha = opacity.value)
-        ) {
-            Canvas(
+            },
+            update = { webView ->
+                if (webView.url != url) {
+                    webView.loadUrl(url)
+                }
+            },
+            modifier = Modifier.fillMaxSize()
+        )
+
+        if (loading) {
+            Box(
                 modifier = Modifier
                     .fillMaxSize()
-                    .graphicsLayer(scaleX = pulse, scaleY = pulse, alpha = glowAlpha)
+                    .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.75f)),
+                contentAlignment = Alignment.Center
             ) {
-                val radius = size.minDimension / 2f
-                drawCircle(
-                    brush = Brush.radialGradient(
-                        colors = listOf(Color(0xFF7B4DFF), Color.Transparent)
-                    ),
-                    radius = radius
-                )
-                drawCircle(
-                    color = Color(0xFFB388FF).copy(alpha = 0.5f),
-                    radius = radius * 0.88f,
-                    style = Stroke(width = radius * 0.08f)
-                )
+                CircularProgressIndicator()
             }
-            Image(
-                painter = painterResource(id = com.example.quotepicker.R.drawable.magic_circle),
-                contentDescription = null,
-                modifier = Modifier
-                    .size(circleSize)
-                    .align(Alignment.Center)
-                    .graphicsLayer(
-                        rotationZ = rotation,
-                        shadowElevation = with(density) { 14.dp.toPx() },
-                        scaleX = 1.08f,
-                        scaleY = 1.08f
-                    )
-            )
-            Image(
-                painter = painterResource(id = com.example.quotepicker.R.drawable.magic_circle),
-                contentDescription = null,
-                modifier = Modifier
-                    .size(innerSize)
-                    .align(Alignment.Center)
-                    .graphicsLayer(
-                        rotationZ = counterRotation,
-                        alpha = 0.85f
-                    )
-            )
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the blank entry/gate page with a webpage previewer so users can add and preview Notion forms directly in the app. 
- Keep the existing corner-tap unlock sequence but remove the full-screen touch magic-circle effect that interfered with web interactions.

### Description
- Replace `GateScreen` implementation with a web-list + preview layout that stores `GateWebItem` entries, supports adding a named URL via a `+` dialog and selecting entries from a left-hand list to preview on the right. 
- Implement `GateWebPreview` using `AndroidView` + `WebView` with JavaScript and DOM storage enabled and a `normalizeUrl` helper to canonicalize input URLs. 
- Preserve the corner unlock logic by adding invisible `CornerHotspot` clickable areas and `handleCornerTap` to maintain the original `RIGHT_TOP x3 → LEFT_TOP x1 → LEFT_BOTTOM x2` sequence and call `onPassed()` when completed. 
- Remove the old touch visual/magic-circle code and related animation imports, and add the `INTERNET` permission to `app/src/main/AndroidManifest.xml`.

### Testing
- Attempted `./gradlew :app:assembleDebug` which could not complete because Gradle could not find a Java 17 toolchain in the environment, so the APK build was blocked. 
- Verified repository changes with `git status --short` and committed the changes successfully as `Add webview-based gate screen`.
- No UI runtime screenshot tests were run due to the blocked build in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0efaf7f10832bb4b5751fe14a355c)