### PR TITLE
Fix magic drama preview script parsing for button sections

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -4953,7 +4953,7 @@ private fun parseDramaEditorCommands(lines: List<String>): List<DramaEditorComma
             line.startsWith("按钮:") -> {
                 val options = mutableListOf<Pair<String, String>>()
                 var buttonIndex = index + 1
-                while (buttonIndex < lines.size && lines[buttonIndex].contains("--")) {
+                while (buttonIndex < lines.size && isDramaButtonOptionLine(lines[buttonIndex])) {
                     val parts = lines[buttonIndex].split("--", limit = 2)
                     val label = parts.firstOrNull()?.trim().orEmpty()
                     val target = parts.getOrNull(1)?.trim().orEmpty()
@@ -4973,6 +4973,32 @@ private fun parseDramaEditorCommands(lines: List<String>): List<DramaEditorComma
         index++
     }
     return commands
+}
+
+private fun isDramaButtonOptionLine(line: String): Boolean {
+    if (!line.contains("--")) return false
+    if (line.startsWith("@")) return false
+    return !isDramaStructuredCommandLine(line)
+}
+
+private fun isDramaStructuredCommandLine(line: String): Boolean {
+    return line.matches(Regex("^w\\d+$", RegexOption.IGNORE_CASE)) ||
+        line.equals("c1", ignoreCase = true) ||
+        line.equals("c2", ignoreCase = true) ||
+        line.equals("c3", ignoreCase = true) ||
+        line.equals("停:背景", ignoreCase = true) ||
+        line.equals("停:计时", ignoreCase = true) ||
+        line.startsWith("资源:") ||
+        line.startsWith("旁白:") ||
+        line.startsWith("注意:") ||
+        line.startsWith("设:") ||
+        line.startsWith("删:") ||
+        line.startsWith("跳:") ||
+        line.startsWith("判:") ||
+        line.startsWith("氛围:") ||
+        line.startsWith("计时:") ||
+        line.startsWith("按钮:") ||
+        line.startsWith("背景:")
 }
 
 private fun parseDramaResourceTokens(raw: String): List<String> {

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -793,7 +793,7 @@ private fun parseBlockCommands(lines: List<String>): List<DramaCommand> {
             line.startsWith("按钮:") -> {
                 val options = mutableListOf<DramaButtonOption>()
                 var j = i + 1
-                while (j < lines.size && lines[j].contains("--")) {
+                while (j < lines.size && isButtonOptionLine(lines[j])) {
                     val p = lines[j].split("--", limit = 2)
                     val text = p.firstOrNull()?.trim().orEmpty()
                     val target = p.getOrNull(1)?.let(::normalizeBlockRef).orEmpty()
@@ -812,6 +812,32 @@ private fun parseBlockCommands(lines: List<String>): List<DramaCommand> {
         i++
     }
     return commands
+}
+
+private fun isButtonOptionLine(line: String): Boolean {
+    if (!line.contains("--")) return false
+    if (line.startsWith("@")) return false
+    return !isScriptCommandLine(line)
+}
+
+private fun isScriptCommandLine(line: String): Boolean {
+    return line.matches(Regex("^w\\d+$", RegexOption.IGNORE_CASE)) ||
+        line.equals("c1", ignoreCase = true) ||
+        line.equals("c2", ignoreCase = true) ||
+        line.equals("c3", ignoreCase = true) ||
+        line.equals("停:背景", ignoreCase = true) ||
+        line.equals("停:计时", ignoreCase = true) ||
+        line.startsWith("资源:") ||
+        line.startsWith("旁白:") ||
+        line.startsWith("注意:") ||
+        line.startsWith("设:") ||
+        line.startsWith("删:") ||
+        line.startsWith("跳:") ||
+        line.startsWith("判:") ||
+        line.startsWith("氛围:") ||
+        line.startsWith("计时:") ||
+        line.startsWith("按钮:") ||
+        line.startsWith("背景:")
 }
 
 private fun resolveMediaPlaybackUri(source: String, vm: ResourceViewModel): Uri? {


### PR DESCRIPTION
### Motivation

- Scripts with a `按钮:` section could accidentally consume the next structured command lines that also contain `--` (for example `判:` or `计时:`), causing preview parsing and playback to behave incorrectly.
- The editor and runtime parsers were not fully aligned in how they decide which following lines belong to a button section, causing inconsistent visible script vs preview execution.

### Description

- Tighten runtime parsing in `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt` so `按钮:` only consumes true button-option rows by replacing the previous `lines[j].contains("--")` check with `isButtonOptionLine(lines[j])`.
- Add helper detection functions `isButtonOptionLine` and `isScriptCommandLine` to identify genuine button option rows and to exclude structured command lines (waiting, countdown, jump/condition, background, clear commands, narration/resource/氛围/etc.).
- Apply the same button-option boundary logic to the script editor parser in `app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt` so the editor-generated script and the preview runtime behave consistently.

### Testing

- Ran `git diff --check` which reported no whitespace or diff-check issues.
- Attempted to run a Kotlin compile with `./gradlew :app:compileDebugKotlin` but the build was blocked by an environment proxy error (`HTTP/1.1 403 Forbidden`) when downloading the Gradle distribution, so a full compile could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c25bfd6290832b8dd227d2dee1fb48)