### PR TITLE
让魔剧计时异步执行，避免阻塞后续剧情

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -200,10 +200,14 @@ fun MagicDramaScreen(
         }
 
         val queue = ArrayDeque(parsed.blocks[parsed.startBlock].orEmpty())
-        while (queue.isNotEmpty()) {
+        while (queue.isNotEmpty() || countdownJob?.isActive == true) {
             timeoutBlockToJump?.let { blockId ->
                 timeoutBlockToJump = null
                 jumpTo(blockId, queue)
+            }
+            if (queue.isEmpty()) {
+                delay(50)
+                continue
             }
 
             when (val cmd = queue.removeFirst()) {
@@ -280,18 +284,10 @@ fun MagicDramaScreen(
 
                 is DramaCommand.Countdown -> {
                     countdownJob?.cancel()
-                    val awaitingButtonSelection = queue.firstOrNull() is DramaCommand.ShowButtons
-                    if (awaitingButtonSelection) {
-                        countdownJob = coroutineScope.launch {
-                            launchCountdown(cmd.seconds) { left -> countdownSeconds = left }
-                            timeoutBlockToJump = cmd.timeoutBlock
-                            pendingBranch?.complete(cmd.timeoutBlock)
-                        }
-                    } else {
+                    countdownJob = coroutineScope.launch {
                         launchCountdown(cmd.seconds) { left -> countdownSeconds = left }
-                        countdownJob = null
-                        countdownSeconds = null
-                        jumpTo(cmd.timeoutBlock, queue)
+                        timeoutBlockToJump = cmd.timeoutBlock
+                        pendingBranch?.complete(cmd.timeoutBlock)
                     }
                 }
 


### PR DESCRIPTION
### Motivation
- 让脚本中的 `计时:`（`DramaCommand.Countdown`）在启动后异步运行，以便后续台词/指令不被阻塞。
- 保证计时结束后的超时跳转仍能触发，即使主脚本队列在计时期间短暂耗尽也不丢失计时结果。
- 简化计时分支逻辑，使行为在有无按钮分支时一致。

### Description
- 在 `app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt` 中将主执行循环改为 `while (queue.isNotEmpty() || countdownJob?.isActive == true)`，并在队列空但计时仍在运行时用短 `delay(50)` 轮询。 
- 将 `DramaCommand.Countdown` 处理改为统一启动后台协程（`coroutineScope.launch` + `launchCountdown`），计时不再阻塞脚本队列。 
- 在计时协程结束后设置 `timeoutBlockToJump` 并调用 `pendingBranch?.complete` 以触发超时跳转与完成待选分支。 
- 保留 `StopCountdown` 的取消/清理逻辑以正确停止正在运行的计时。 

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 作为编译验证，但在当前环境中下载 Gradle 分发包被代理拦截返回 `HTTP/1.1 403 Forbidden`，因此编译验证未能完成。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4d754fa88832ba98d14b866886d6c)