### PR TITLE
Handle countdown timeouts and empty-queue waits in MagicDramaScreen

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -200,10 +200,14 @@ fun MagicDramaScreen(
         }
 
         val queue = ArrayDeque(parsed.blocks[parsed.startBlock].orEmpty())
-        while (queue.isNotEmpty()) {
+        while (queue.isNotEmpty() || countdownJob?.isActive == true || timeoutBlockToJump != null) {
             timeoutBlockToJump?.let { blockId ->
                 timeoutBlockToJump = null
                 jumpTo(blockId, queue)
+            }
+            if (queue.isEmpty()) {
+                delay(50)
+                continue
             }
 
             when (val cmd = queue.removeFirst()) {
@@ -280,18 +284,10 @@ fun MagicDramaScreen(
 
                 is DramaCommand.Countdown -> {
                     countdownJob?.cancel()
-                    val awaitingButtonSelection = queue.firstOrNull() is DramaCommand.ShowButtons
-                    if (awaitingButtonSelection) {
-                        countdownJob = coroutineScope.launch {
-                            launchCountdown(cmd.seconds) { left -> countdownSeconds = left }
-                            timeoutBlockToJump = cmd.timeoutBlock
-                            pendingBranch?.complete(cmd.timeoutBlock)
-                        }
-                    } else {
+                    countdownJob = coroutineScope.launch {
                         launchCountdown(cmd.seconds) { left -> countdownSeconds = left }
-                        countdownJob = null
-                        countdownSeconds = null
-                        jumpTo(cmd.timeoutBlock, queue)
+                        timeoutBlockToJump = cmd.timeoutBlock
+                        pendingBranch?.complete(cmd.timeoutBlock)
                     }
                 }
 


### PR DESCRIPTION
### Motivation
- Ensure countdown-based timeouts and branch jumps behave correctly when the command `queue` is empty or when a countdown is active, avoiding race conditions where timeouts could be missed.

### Description
- Extend the main processing loop condition to `while (queue.isNotEmpty() || countdownJob?.isActive == true || timeoutBlockToJump != null)` so the runner keeps checking for timeouts and pending jumps.
- When the `queue` is empty the loop now delays `50`ms and continues to allow countdown coroutines to complete and trigger branch jumps.
- Simplify `Countdown` handling by always launching a `countdownJob` that sets `timeoutBlockToJump` and completes `pendingBranch` on timeout instead of immediately performing a `jumpTo` inside the countdown coroutine.
- Add a trailing newline at EOF.

### Testing
- Built the app with `./gradlew assembleDebug` and the build completed successfully.
- No automated unit tests were added or modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4d754fa88832ba98d14b866886d6c)