### PR TITLE
在视频预览页显示文件大小

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt
@@ -649,11 +649,12 @@ private fun MediaPreviewPager(uris: List<Uri>, resourceCode: String?) {
             Box(modifier = Modifier.weight(1f)) {
                 val currentIndex = pagerState.currentPage + 1
                 val currentCode = indexedResourceFileId(resourceCode, pagerState.currentPage)
+                val currentSize = formatSizeMb(uris[pagerState.currentPage].toString())
                 Text(
                     text = if (currentCode.isNullOrBlank()) {
-                        "视频 $currentIndex/${uris.size}"
+                        "视频 $currentIndex/${uris.size} ($currentSize)"
                     } else {
-                        "视频 $currentIndex/${uris.size} $currentCode"
+                        "视频 $currentIndex/${uris.size} $currentCode ($currentSize)"
                     },
                     style = MaterialTheme.typography.labelSmall
                 )


### PR DESCRIPTION
### Motivation
- 在视频组预览的分页底部补上每个视频的文件大小，使视频与图片/音频在 UI 上保持一致的 `(...M)` 显示风格，便于快速识别大文件。

### Description
- 在 `MediaPreviewPager` 中新增 `val currentSize = formatSizeMb(uris[pagerState.currentPage].toString())` 并将 `(...M)` 追加到原有的 `视频 x/y` 或 `视频 x/y resourceCode` 文本中，复用现有 `formatSizeMb` 逻辑，变更文件为 `app/src/main/java/com/example/quotepicker/ui/components/ResourcePreviewScreen.kt`。 

### Testing
- 尝试运行 `./gradlew :app:compileDebugKotlin` 进行编译验证，但因环境下载 Gradle 分发包被代理拦截（返回 `HTTP/1.1 403 Forbidden`），编译未能完成且验证失败.
- 运行 `git status --short` 并提交变更后工作区显示为干净，提交操作已成功。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c61574a748832b88461ce3973fcc90)