### PR TITLE
MagicDrama: per-line `cc` mute and `背景N:` repeat-count background playback

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -3569,7 +3569,7 @@ private sealed interface DramaEditorCommand {
     data object ClearResourceArea : DramaEditorCommand
     data object ClearAllVariables : DramaEditorCommand
     data object ClearDialogue : DramaEditorCommand
-    data class Background(val source: String) : DramaEditorCommand
+    data class Background(val source: String, val repeatCount: Int = 1) : DramaEditorCommand
     data object StopBackgroundMusic : DramaEditorCommand
     data object StopCountdown : DramaEditorCommand
     data class Buttons(val options: List<Pair<String, String>>) : DramaEditorCommand
@@ -4925,6 +4925,7 @@ private fun parseDramaEditorCommands(lines: List<String>): List<DramaEditorComma
     var index = 0
     while (index < lines.size) {
         val line = lines[index]
+        val backgroundSpec = parseDramaBackgroundLine(line)
         when {
             line.matches(Regex("^w\\d+$", RegexOption.IGNORE_CASE)) -> commands += DramaEditorCommand.Wait(line.drop(1).toIntOrNull() ?: 0)
             line.startsWith("资源:") -> commands += DramaEditorCommand.Resource(line.substringAfter(':').trim())
@@ -4947,7 +4948,10 @@ private fun parseDramaEditorCommands(lines: List<String>): List<DramaEditorComma
             line.equals("c1", ignoreCase = true) -> commands += DramaEditorCommand.ClearResourceArea
             line.equals("c2", ignoreCase = true) -> commands += DramaEditorCommand.ClearAllVariables
             line.equals("c3", ignoreCase = true) -> commands += DramaEditorCommand.ClearDialogue
-            line.startsWith("背景:") -> commands += DramaEditorCommand.Background(line.substringAfter(':').trim())
+            backgroundSpec != null -> {
+                val (repeatCount, source) = backgroundSpec
+                commands += DramaEditorCommand.Background(source = source, repeatCount = repeatCount)
+            }
             line.equals("停:背景", ignoreCase = true) -> commands += DramaEditorCommand.StopBackgroundMusic
             line.equals("停:计时", ignoreCase = true) -> commands += DramaEditorCommand.StopCountdown
             line.startsWith("按钮:") -> {
@@ -4998,7 +5002,15 @@ private fun isDramaStructuredCommandLine(line: String): Boolean {
         line.startsWith("氛围:") ||
         line.startsWith("计时:") ||
         line.startsWith("按钮:") ||
-        line.startsWith("背景:")
+        parseDramaBackgroundLine(line) != null
+}
+
+private fun parseDramaBackgroundLine(line: String): Pair<Int, String>? {
+    val match = Regex("^背景(\\d*):(.*)$", RegexOption.IGNORE_CASE).matchEntire(line) ?: return null
+    val repeatCount = match.groupValues[1].toIntOrNull()?.coerceAtLeast(1) ?: 1
+    val source = match.groupValues[2].trim()
+    if (source.isBlank()) return null
+    return repeatCount to source
 }
 
 private fun parseDramaResourceTokens(raw: String): List<String> {
@@ -5080,7 +5092,10 @@ private fun buildDramaEditorScript(blocks: List<DramaEditorBlock>): String {
                     DramaEditorCommand.ClearResourceArea -> add("c1")
                     DramaEditorCommand.ClearAllVariables -> add("c2")
                     DramaEditorCommand.ClearDialogue -> add("c3")
-                    is DramaEditorCommand.Background -> add("背景:${command.source}")
+                    is DramaEditorCommand.Background -> {
+                        val prefix = if (command.repeatCount <= 1) "背景" else "背景${command.repeatCount}"
+                        add("$prefix:${command.source}")
+                    }
                     DramaEditorCommand.StopBackgroundMusic -> add("停:背景")
                     DramaEditorCommand.StopCountdown -> add("停:计时")
                     is DramaEditorCommand.Buttons -> {
@@ -5109,7 +5124,9 @@ private fun summarizeDramaEditorCommand(command: DramaEditorCommand): String {
         DramaEditorCommand.ClearResourceArea -> "清资源：c1"
         DramaEditorCommand.ClearAllVariables -> "清变量：c2"
         DramaEditorCommand.ClearDialogue -> "清对白：c3"
-        is DramaEditorCommand.Background -> "背景：${command.source}"
+        is DramaEditorCommand.Background -> {
+            if (command.repeatCount <= 1) "背景：${command.source}" else "背景${command.repeatCount}次：${command.source}"
+        }
         DramaEditorCommand.StopBackgroundMusic -> "停止背景：停:背景"
         DramaEditorCommand.StopCountdown -> "停止计时：停:计时"
         is DramaEditorCommand.Buttons -> "按钮：${command.options.joinToString { "${it.first}→${it.second}" }}"

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -99,7 +99,7 @@ private sealed interface DramaCommand {
     data object ClearResourceArea : DramaCommand
     data object ClearAllVariables : DramaCommand
     data object ClearDialogue : DramaCommand
-    data class SetBackgroundMusic(val source: String) : DramaCommand
+    data class SetBackgroundMusic(val source: String, val repeatCount: Int = 1) : DramaCommand
     data object StopBackgroundMusic : DramaCommand
     data object StopCountdown : DramaCommand
 }
@@ -213,33 +213,35 @@ fun MagicDramaScreen(
             when (val cmd = queue.removeFirst()) {
                 is DramaCommand.Narration -> {
                     val text = resolveVariablePlaceholders(renderRandomToken(cmd.text), variables)
-                    if (playbackOptions.voicePlaybackMode == MagicDramaVoicePlaybackMode.ALL) {
+                    val (displayText, suppressSpeech) = extractSpeechControl(text)
+                    if (!suppressSpeech && playbackOptions.voicePlaybackMode == MagicDramaVoicePlaybackMode.ALL) {
                         val narrationRoleName = if (cmd.important) "注意" else "旁白"
                         speakByRole(
-                            text = text,
+                            text = displayText,
                             roleName = narrationRoleName,
                             voiceSettings = voiceSettings,
                             piperSpeechEngine = piperSpeechEngine,
                             vm = vm
                         )
                     }
-                    messages += DramaMessage.Narration(text = text, important = cmd.important)
+                    messages += DramaMessage.Narration(text = displayText, important = cmd.important)
                     delay(settings.defaultDelayMs)
                 }
 
                 is DramaCommand.RoleLine -> {
                     val role = resolveRoleName(cmd.roleKey, boundCharacters)
                     val text = resolveVariablePlaceholders(cmd.text, variables).replace("nn", "\n")
-                    if (playbackOptions.voicePlaybackMode != MagicDramaVoicePlaybackMode.SILENT) {
+                    val (displayText, suppressSpeech) = extractSpeechControl(text)
+                    if (!suppressSpeech && playbackOptions.voicePlaybackMode != MagicDramaVoicePlaybackMode.SILENT) {
                         speakByRole(
-                            text = text,
+                            text = displayText,
                             roleName = role,
                             voiceSettings = voiceSettings,
                             piperSpeechEngine = piperSpeechEngine,
                             vm = vm
                         )
                     }
-                    messages += DramaMessage.Role(role = role, text = text)
+                    messages += DramaMessage.Role(role = role, text = displayText)
                     delay(settings.defaultDelayMs)
                 }
 
@@ -266,10 +268,10 @@ fun MagicDramaScreen(
                     val backgroundSource = resolveVariablePlaceholders(cmd.source, variables)
                     val resolvedUri = resolveMediaPlaybackUri(backgroundSource, vm)
                     if (resolvedUri != null && vm.isVideoUri(resolvedUri)) {
-                        backgroundVideoUri = resolvedUri
+                        backgroundVideoUri = resolvedUri.withRepeatCount(cmd.repeatCount)
                     } else {
                         backgroundVideoUri = null
-                        backgroundPlayer = createLoopMediaPlayer(backgroundSource, vm)
+                        backgroundPlayer = createRepeatedMediaPlayer(backgroundSource, vm, cmd.repeatCount)
                     }
                 }
                 is DramaCommand.StopBackgroundMusic -> {
@@ -324,7 +326,12 @@ fun MagicDramaScreen(
                 .fillMaxSize()
                 .background(currentTheme.dialogBackground)
         ) {
-            backgroundVideoUri?.let { HiddenBackgroundVideoPlayer(uri = it) }
+            backgroundVideoUri?.let { uri ->
+                HiddenBackgroundVideoPlayer(
+                    uri = uri.withoutRepeatCount(),
+                    repeatCount = uri.repeatCountFromFragment()
+                )
+            }
             Column(modifier = Modifier.fillMaxSize()) {
                 Box(
                     modifier = Modifier
@@ -582,9 +589,9 @@ private fun resolveTokenValue(token: String, variables: Map<String, String>): St
 
 
 @Composable
-private fun HiddenBackgroundVideoPlayer(uri: Uri) {
+private fun HiddenBackgroundVideoPlayer(uri: Uri, repeatCount: Int) {
     val holder = remember { mutableStateOf<VideoView?>(null) }
-    DisposableEffect(uri) {
+    DisposableEffect(uri, repeatCount) {
         onDispose {
             holder.value?.stopPlayback()
             holder.value = null
@@ -595,16 +602,21 @@ private fun HiddenBackgroundVideoPlayer(uri: Uri) {
             VideoView(context).apply {
                 alpha = 0f
                 setVideoURI(uri)
-                setOnPreparedListener { player ->
-                    player.isLooping = true
+                var remaining = repeatCount.coerceAtLeast(1)
+                setOnPreparedListener {
                     start()
+                }
+                setOnCompletionListener {
+                    remaining -= 1
+                    if (remaining > 0) start()
                 }
                 holder.value = this
             }
         },
         update = { view ->
-            if (view.tag != uri) {
-                view.tag = uri
+            val tag = "${uri}#${repeatCount.coerceAtLeast(1)}"
+            if (view.tag != tag) {
+                view.tag = tag
                 view.setVideoURI(uri)
                 view.start()
             }
@@ -740,6 +752,7 @@ private fun parseBlockCommands(lines: List<String>): List<DramaCommand> {
     var i = 0
     while (i < lines.size) {
         val line = lines[i]
+        val backgroundSpec = parseBackgroundLine(line)
         when {
             line.matches(Regex("^w\\d+$", RegexOption.IGNORE_CASE)) -> {
                 commands += DramaCommand.WaitSeconds(line.drop(1).toIntOrNull() ?: 0)
@@ -780,10 +793,9 @@ private fun parseBlockCommands(lines: List<String>): List<DramaCommand> {
             line.equals("c1", ignoreCase = true) -> commands += DramaCommand.ClearResourceArea
             line.equals("c2", ignoreCase = true) -> commands += DramaCommand.ClearAllVariables
             line.equals("c3", ignoreCase = true) -> commands += DramaCommand.ClearDialogue
-            line.startsWith("背景:") -> {
-                val source = line.substringAfter(':').trim()
-                if (source.isNotBlank()) commands += DramaCommand.SetBackgroundMusic(source)
-            }
+            backgroundSpec?.let { (repeatCount, source) ->
+                commands += DramaCommand.SetBackgroundMusic(source = source, repeatCount = repeatCount)
+            } != null -> Unit
             line.equals("停:背景", ignoreCase = true) -> commands += DramaCommand.StopBackgroundMusic
             line.equals("停:计时", ignoreCase = true) -> commands += DramaCommand.StopCountdown
             line.startsWith("按钮:") -> {
@@ -833,7 +845,7 @@ private fun isScriptCommandLine(line: String): Boolean {
         line.startsWith("氛围:") ||
         line.startsWith("计时:") ||
         line.startsWith("按钮:") ||
-        line.startsWith("背景:")
+        parseBackgroundLine(line) != null
 }
 
 private fun resolveMediaPlaybackUri(source: String, vm: ResourceViewModel): Uri? {
@@ -841,15 +853,52 @@ private fun resolveMediaPlaybackUri(source: String, vm: ResourceViewModel): Uri?
         ?: runCatching { Uri.parse(source) }.getOrNull()?.takeIf { it.scheme != null }
 }
 
-private fun createLoopMediaPlayer(source: String, vm: ResourceViewModel): MediaPlayer? {
+private fun createRepeatedMediaPlayer(source: String, vm: ResourceViewModel, repeatCount: Int): MediaPlayer? {
     val uri = resolveMediaPlaybackUri(source, vm) ?: return null
     return runCatching {
         MediaPlayer.create(vm.getApplication(), uri)?.apply {
-            isLooping = true
+            var remaining = repeatCount.coerceAtLeast(1)
+            setOnCompletionListener { player ->
+                remaining -= 1
+                if (remaining > 0) {
+                    player.seekTo(0)
+                    player.start()
+                } else {
+                    player.setOnCompletionListener(null)
+                }
+            }
             start()
         }
     }.getOrNull()
 }
+
+private fun extractSpeechControl(text: String): Pair<String, Boolean> {
+    val match = Regex("^(.*?)(?:\\s+)?cc\\s*$", RegexOption.IGNORE_CASE).matchEntire(text)
+    if (match != null) {
+        return match.groupValues[1].trimEnd() to true
+    }
+    return text to false
+}
+
+private fun parseBackgroundLine(line: String): Pair<Int, String>? {
+    val match = Regex("^背景(\\d*):(.*)$", RegexOption.IGNORE_CASE).matchEntire(line) ?: return null
+    val count = match.groupValues[1].toIntOrNull()?.coerceAtLeast(1) ?: 1
+    val source = match.groupValues[2].trim()
+    if (source.isBlank()) return null
+    return count to source
+}
+
+private fun Uri.withRepeatCount(repeatCount: Int): Uri {
+    return buildUpon().encodedFragment("repeat=${repeatCount.coerceAtLeast(1)}").build()
+}
+
+private fun Uri.repeatCountFromFragment(): Int {
+    val raw = fragment ?: return 1
+    val match = Regex("repeat=(\\d+)", RegexOption.IGNORE_CASE).find(raw) ?: return 1
+    return match.groupValues[1].toIntOrNull()?.coerceAtLeast(1) ?: 1
+}
+
+private fun Uri.withoutRepeatCount(): Uri = buildUpon().fragment(null).build()
 
 private fun resolveRoleName(input: String, boundCharacters: List<CharacterEntity>): String {
     val exact = boundCharacters.firstOrNull { it.name.equals(input, ignoreCase = true) }


### PR DESCRIPTION
### Motivation
- Enable authors to suppress TTS for a single line while still showing it in the UI by using a per-line suffix, and let `背景` playback be finite instead of always looping.
- Keep the editor and runtime parsers in sync so `背景N:...` commands survive edit/save and are represented consistently in the UI.

### Description
- Added per-line speech control: lines whose text ends with `cc` (case-insensitive, allowed trailing spaces) are displayed but will not trigger speech playback; implemented by `extractSpeechControl` and integrated into narration and role-line handling in `MagicDramaScreen.kt` using the returned `(displayText, suppressSpeech)` pair.
- Extended background command syntax to accept `背景N:source` (e.g. `背景3:...`) to play the source exactly N times, with `背景:...` treated as `N=1`; added `parseBackgroundLine` and plumbing to propagate `repeatCount` into runtime players and editor representation.
- Implemented finite-repeat playback: replaced infinite looping for audio and video with repeat-count-aware players via `createRepeatedMediaPlayer`, video handling in `HiddenBackgroundVideoPlayer` (accepts `repeatCount`), and encoded repeat count in `Uri` fragment helpers `withRepeatCount`, `repeatCountFromFragment`, and `withoutRepeatCount` for passing count through video URIs.
- Synchronized editor parsing/serialization in `ResourceScreen.kt` by adding `DramaEditorCommand.Background(source, repeatCount)`, parsing `背景N:` lines, and writing them back so `背景N:` is preserved when editing scripts.

### Testing
- Ran the Kotlin compile step with `./gradlew :app:compileDebugKotlin` in CI-like environment and it failed due to an external Gradle distribution download error (`HTTP/1.1 403 Forbidden`), so no compiled build was produced.
- Performed code-level inspection and cross-checked parser + renderer paths to ensure the new `cc` handling and `背景N:` parsing/serialization are consistently wired across `MagicDramaScreen.kt` and `ResourceScreen.kt` (no automated test failures reported locally).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c9d897dc80832badaf5109a9bb5b96)