### PR TITLE
Support multi-value background sources and update background dialog labels

### DIFF
--- a/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/ResourceScreen.kt
@@ -3813,9 +3813,8 @@ private fun MagicDramaScriptEditorScreen(
                 resourceOptions = mediaResources.filter { it.resource.type == ResourceType.VIDEO || it.resource.type == ResourceType.SOUND },
                 vm = vm,
                 title = "添加背景",
-                valueLabel = "背景名（按名字填写）",
-                valueHint = "按背景名称填写，多个背景请用逗号分隔。",
-                insertTitleInsteadOfCode = true,
+                valueLabel = "命令值（可填组ID/单个ID）",
+                valueHint = "与资源设定一致：填写组ID或单个ID；可填多个值并用逗号分隔，按顺序取第一个可用项播放。",
                 onConfirm = {
                     addCommand(DramaEditorCommand.Background(it.trim()))
                     activeDialog = null
@@ -4360,9 +4359,8 @@ private fun DramaCommandEditDialog(
             vm = vm,
             initialSource = command.source,
             title = "编辑背景",
-            valueLabel = "背景名（按名字填写）",
-            valueHint = "按背景名称填写，多个背景请用逗号分隔。",
-            insertTitleInsteadOfCode = true,
+            valueLabel = "命令值（可填组ID/单个ID）",
+            valueHint = "与资源设定一致：填写组ID或单个ID；可填多个值并用逗号分隔，按顺序取第一个可用项播放。",
             onConfirm = { onConfirm(DramaEditorCommand.Background(it.trim())) },
             onDismiss = onDismiss
         )

--- a/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
+++ b/app/src/main/java/com/example/quotepicker/ui/components/MagicDramaScreen.kt
@@ -849,8 +849,15 @@ private fun isScriptCommandLine(line: String): Boolean {
 }
 
 private fun resolveMediaPlaybackUri(source: String, vm: ResourceViewModel): Uri? {
-    return vm.resolveMediaUriByCodeOrPath(source)
-        ?: runCatching { Uri.parse(source) }.getOrNull()?.takeIf { it.scheme != null }
+    val candidates = source
+        .split(',', '&', '，')
+        .map { it.trim() }
+        .filter { it.isNotBlank() }
+        .ifEmpty { listOf(source.trim()) }
+    return candidates.firstNotNullOfOrNull { token ->
+        vm.resolveMediaUriByCodeOrPath(token)
+            ?: runCatching { Uri.parse(token) }.getOrNull()?.takeIf { it.scheme != null }
+    }
 }
 
 private fun createRepeatedMediaPlayer(source: String, vm: ResourceViewModel, repeatCount: Int): MediaPlayer? {


### PR DESCRIPTION
### Motivation

- Make background resource handling more flexible by allowing group IDs or multiple candidate IDs/paths to be specified in a single command.
- Clarify the background dialogs so users know to enter command values (group ID or single ID) rather than resource titles.

### Description

- Updated `DramaResourceDialog` usage for the Background command in `ResourceScreen.kt` to change `valueLabel` and `valueHint` to explain that command values may be group IDs or single IDs and that multiple values can be provided comma-separated, and removed the `insertTitleInsteadOfCode` behavior.
- Applied the same `valueLabel` and `valueHint` change to the Background editor dialog when editing an existing `DramaEditorCommand.Background` instance.
- Reworked `resolveMediaPlaybackUri` in `MagicDramaScreen.kt` to accept multiple tokens in a source string by splitting on `,`, `&`, and the Chinese comma `，`, trimming entries, and returning the first token that resolves to a media URI (either via `vm.resolveMediaUriByCodeOrPath` or a parsable URI with a scheme).
- Kept media player creation logic but wired it to the enhanced resolver so repeated playback uses the first available candidate URI.

### Testing

- Ran the existing unit test suite against the modified codebase and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca271fe2d8832b9ba8f3ccb24c5a9a)